### PR TITLE
More 'labels' usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `Atom::{label,element}` method and remove the `Atom::name` method. This also
   remove `chfl_atom_{name,set_name}` and add `chfl_atom_{element,set_element}`
   and `chfl_atom_{label,set_label}`.
+* The `name` selector now select atoms based on the atomic label. To select on
+  the element, use the new `element` selector.
 
 ## 0.6 (1 July 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (and velocity) data to a frame, and the C API `chfl_frame_add_atom` function.
 * Rename `UnitCell::type` to `UnitCell::shape`. This also affect
   `chfl_cell_shape_t`, `chfl_cell_shape`, and `chfl_cell_set_shape`.
+* Add the atomic label in addition to the atomic element. This introduces the
+  `Atom::{label,element}` method and remove the `Atom::name` method. This also
+  remove `chfl_atom_{name,set_name}` and add `chfl_atom_{element,set_element}`
+  and `chfl_atom_{label,set_label}`.
 
 ## 0.6 (1 July 2016)
 

--- a/doc/selections.rst
+++ b/doc/selections.rst
@@ -55,7 +55,10 @@ The following selectors are implemented in chemfiles:
 
 - ``all``: select all the atoms;
 - ``none``: select none of the atoms;
-- ``name``: select atoms based on their name;
+- ``element``: select atoms based on their element;
+- ``name``: select atoms based on their name. Some formats store both an atomic
+  name (H3) and an atom element (H), this is why you can use two different
+  selectors depending on the actual data;
 - ``index``: select atoms based on their index in the frame;
 - ``mass``: select atoms based on their mass;
 - ``x``, ``y`` and ``z``: select atoms based on their position cartesian components;

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -38,11 +38,11 @@ public:
     };
 
     //! Create an atom from its 'element' with 'label'='element'
-    Atom(std::string element);
+    explicit Atom(std::string element);
     //! Create an atom from its 'element' and its label
     Atom(std::string element, std::string label);
     //! Create an atom from its 'element' and its type
-    Atom(AtomType type, std::string element = "", std::string label = "");
+    Atom(AtomType type, std::string element, std::string label = "");
     //! Default is to create an UNDEFINED atom type with no element or label
     Atom();
 
@@ -89,8 +89,8 @@ public:
 private:
     std::string element_;
     std::string label_;
-    float mass_;
-    float charge_;
+    float mass_ = 0;
+    float charge_ = 0;
     AtomType type_;
 };
 

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -37,7 +37,7 @@ public:
         UNDEFINED = 3,
     };
 
-	//! Create an atom from its 'element' with 'label'='element'
+    //! Create an atom from its 'element' with 'label'='element'
     Atom(std::string element);
     //! Create an atom from its 'element' and its label
     Atom(std::string element, std::string label);

--- a/include/chemfiles/Frame.hpp
+++ b/include/chemfiles/Frame.hpp
@@ -26,11 +26,12 @@ namespace chemfiles {
  * topology, the positions, and the velocities of the particles in the system.
  * If some information is missing (topology or velocity or unit cell), the
  * corresponding data is filled with a default value. Specifically:
- * 	- `velocities` is the `nullopt` version of `optional<Array3D>`. Here,
+ * 
+ * - `velocities` is the `nullopt` version of `optional<Array3D>`. Here,
  *    `optional<T>` refers to the optional template as defined in
  *    [std::experimental::optional][optional]
- * 	- `cell` is an infinite unit cell;
- * 	- `topology` is empty, and contains no data.
+ * - `cell` is an infinite unit cell;
+ * - `topology` is empty, and contains no data.
  *
  * [optional]: http://en.cppreference.com/w/cpp/experimental/optional
  */

--- a/include/chemfiles/UnitCell.hpp
+++ b/include/chemfiles/UnitCell.hpp
@@ -31,9 +31,9 @@ namespace chemfiles {
  * vector into an orthonormal base. We choose to represent such matrix as an
  * upper triangular matrix:
  *
- * 				| a_x   b_x   c_x |
- * 				|  0    b_y   c_y |
- * 				|  0     0    c_z |
+ *                 | a_x   b_x   c_x |
+ *                 |  0    b_y   c_y |
+ *                 |  0     0    c_z |
  */
 class CHFL_EXPORT UnitCell {
 public:

--- a/include/chemfiles/optional.hpp
+++ b/include/chemfiles/optional.hpp
@@ -116,8 +116,8 @@ namespace experimental{
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
     // leave it: the user doesn't want it
 # else
-	template <typename T>
-	using is_trivially_destructible = std::has_trivial_destructor<T>;
+    template <typename T>
+    using is_trivially_destructible = std::has_trivial_destructor<T>;
 # endif
 // END workaround for missing is_trivially_destructible
 
@@ -537,7 +537,7 @@ public:
 
   OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
     if (!initialized()) throw bad_optional_access("bad optional access");
-	return std::move(contained_val());
+    return std::move(contained_val());
   }
 
 # else
@@ -1045,11 +1045,11 @@ namespace std
 # undef TR2_OPTIONAL_ASSERTED_EXPRESSION
 
 namespace chemfiles {
-	using std::experimental::optional;
-	using std::experimental::make_optional;
+    using std::experimental::optional;
+    using std::experimental::make_optional;
 
-	using nullopt_t = std::experimental::nullopt_t;
-	constexpr nullopt_t nullopt{nullopt_t::init()};
+    using nullopt_t = std::experimental::nullopt_t;
+    constexpr nullopt_t nullopt{nullopt_t::init()};
 }
 
 # endif //CHEMFILES_OPTIONAL_HPP

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -120,7 +120,7 @@ protected:
 };
 
 //! @class ElementExpr selections/expr.hpp selections/expr.cpp
-//! @brief Select atoms using their element.
+//! @brief Select atoms using their element name.
 //!
 //! Only `==` and `!=` operators are allowed. The short form `element <value>` is
 //! equivalent to `element == <value>`
@@ -132,6 +132,22 @@ public:
     std::vector<bool> evaluate(const Frame& frame, const std::vector<Match>& matches) const override;
 private:
     std::string element_;
+    bool equals_;
+};
+
+//! @class ElementExpr selections/expr.hpp selections/expr.cpp
+//! @brief Select atoms using their label.
+//!
+//! Only `==` and `!=` operators are allowed. The short form `element <value>` is
+//! equivalent to `element == <value>`
+class NameExpr final: public SingleSelector {
+public:
+    NameExpr(unsigned argument, std::string name, bool equals)
+        : SingleSelector(argument), name_(name), equals_(equals) {}
+    std::string print(unsigned delta) const override;
+    std::vector<bool> evaluate(const Frame& frame, const std::vector<Match>& matches) const override;
+private:
+    std::string name_;
     bool equals_;
 };
 

--- a/include/chemfiles/selections/lexer.hpp
+++ b/include/chemfiles/selections/lexer.hpp
@@ -21,10 +21,10 @@ namespace selections {
  *
  * Various tokens are alowed here:
  *
- * 	- binary comparison operators (== != < <= > >=);
- * 	- boolean operators (and not or);
- * 	- numbers, the scientific notation is alowed;
- * 	- identifiers, obeing to the ([a-Z][a-Z_1-9]+) regular expression
+ * - binary comparison operators (== != < <= > >=);
+ * - boolean operators (and not or);
+ * - numbers, the scientific notation is alowed;
+ * - identifiers, obeing to the ([a-Z][a-Z_1-9]+) regular expression
  */
 class CHFL_EXPORT Token {
 public:

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -1,4 +1,4 @@
-	/* Chemfiles, an efficient IO library for chemistry file formats
+/* Chemfiles, an efficient IO library for chemistry file formats
  * Copyright (C) 2015 Guillaume Fraux
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -37,8 +37,7 @@ static bool is_element(const std::string& element) {
 }
 
 Atom::Atom(std::string element)
-	: element_(element), label_(std::move(element)), mass_(0),
-	charge_(0) {
+: element_(element), label_(std::move(element)), mass_(0), charge_(0) {
     if (is_element(element_)) {
         type_ = ELEMENT;
     } else {
@@ -51,8 +50,7 @@ Atom::Atom(std::string element)
 }
 
 Atom::Atom(std::string element, std::string label)
-	: element_(std::move(element)), label_(std::move(label)), mass_(0),
-	charge_(0) {
+    : element_(std::move(element)), label_(std::move(label)), mass_(0), charge_(0) {
     if (is_element(element_)) {
         type_ = ELEMENT;
     } else {
@@ -64,9 +62,12 @@ Atom::Atom(std::string element, std::string label)
     }
 }
 
-Atom::Atom(AtomType type, std::string element, std::string label)
-    : element_(std::move(element)), label_(std::move(label)), mass_(0),
-	charge_(0), type_(type) {}
+Atom::Atom(AtomType type, std::string element, std::string label):
+    element_(std::move(element)),
+    label_(std::move(label)),
+    mass_(0),
+    charge_(0),
+    type_(type) {}
 
 Atom::Atom() : Atom(UNDEFINED) {}
 

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -37,24 +37,27 @@ static bool is_element(const std::string& element) {
 }
 
 Atom::Atom(std::string element)
-: element_(element), label_(std::move(element)), mass_(0), charge_(0) {
-    if (is_element(element_)) {
-        type_ = ELEMENT;
-    } else {
-        type_ = COARSE_GRAINED;
-    }
-
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        mass_ = PERIODIC_INFORMATION.at(element_).mass;
-    }
-}
+    : Atom(UNDEFINED, element, std::move(element)) {}
 
 Atom::Atom(std::string element, std::string label)
-    : element_(std::move(element)), label_(std::move(label)), mass_(0), charge_(0) {
-    if (is_element(element_)) {
-        type_ = ELEMENT;
-    } else {
-        type_ = COARSE_GRAINED;
+    : Atom(UNDEFINED, std::move(element), std::move(label)) {}
+
+Atom::Atom(AtomType type, std::string element, std::string label):
+    element_(std::move(element)), label_(std::move(label)), type_(type) {
+    // Use the same value for label and element if one is empty and the other
+    // is not.
+    if (element_ == "" && label_ != "") {
+        element_ = label_;
+    } else if (label_ == "" && element_ != "") {
+        label_ = element_;
+    }
+
+    if (type_ == UNDEFINED && element_ != "") {
+        if (is_element(element_)) {
+            type_ = ELEMENT;
+        } else {
+            type_ = COARSE_GRAINED;
+        }
     }
 
     if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
@@ -62,14 +65,7 @@ Atom::Atom(std::string element, std::string label)
     }
 }
 
-Atom::Atom(AtomType type, std::string element, std::string label):
-    element_(std::move(element)),
-    label_(std::move(label)),
-    mass_(0),
-    charge_(0),
-    type_(type) {}
-
-Atom::Atom() : Atom(UNDEFINED) {}
+Atom::Atom(): Atom(UNDEFINED, "", "") {}
 
 std::string Atom::full_name() const {
     if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -20,7 +20,7 @@ void Topology::resize(size_t natoms) {
                 "-" + std::to_string(bond[1]) + ".");
         }
     }
-    atoms_.resize(natoms, Atom(Atom::UNDEFINED));
+    atoms_.resize(natoms, Atom());
 }
 
 void Topology::append(Atom atom) {

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -280,7 +280,7 @@ void PDBFormat::write(const Frame& frame) {
 
     for (size_t i = 0; i < frame.natoms(); i++) {
         auto& element = frame.topology()[i].element();
-		auto& label = frame.topology()[i].label();
+        auto& label = frame.topology()[i].label();
         auto& pos = frame.positions()[i];
         // Print all atoms as HETATM, because there is no way we can know if we
         // are handling a biomolecule or not.

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -25,6 +25,7 @@ struct function_info_t {
 
 static std::map<std::string, function_info_t> FUNCTIONS = {
     {"element", {1, true}},
+    {"name", {1, true}},
     {"mass", {1, true}},
     {"index", {1, true}},
     {"x", {1, false}},
@@ -185,6 +186,8 @@ Ast selections::dispatch_parsing(token_iterator_t& begin, const token_iterator_t
         auto ident = begin[2].ident();
         if (ident == "element") {
             return parse<ElementExpr>(begin, end);
+        } else if (ident == "name") {
+            return parse<NameExpr>(begin, end);
         } else if (ident == "index") {
             return parse<IndexExpr>(begin, end);
         } else if (ident == "mass") {

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -11,20 +11,25 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
     Atom a3(Atom::COARSE_GRAINED, "CH4");
     Atom a4("W");
     Atom a5("C", "CB");
+    Atom a6("", "Label only");
+    Atom a7("", "Na");
 
     SECTION("Check constructors"){
         CHECK(a1.element() == "H");
+        CHECK(a1.label() == "H");
         CHECK(a1.mass() == 1.008f);
         CHECK(a1.type() == Atom::ELEMENT);
         CHECK(a1.charge() == 0);
 
         CHECK(a2.type() == Atom::UNDEFINED);
         CHECK(a2.element() == "");
+        CHECK(a2.label() == "");
         CHECK(a2.mass() == 0);
         CHECK(a2.charge() == 0);
 
         CHECK(a3.type() == Atom::COARSE_GRAINED);
         CHECK(a3.element() == "CH4");
+        CHECK(a3.label() == "CH4");
         CHECK(a3.mass() == 0);
         CHECK(a3.charge() == 0);
 
@@ -33,6 +38,18 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
         CHECK(a5.label() == "CB");
         CHECK(a5.mass() == 12.011f);
         CHECK(a5.charge() == 0);
+
+        CHECK(a6.type() == Atom::COARSE_GRAINED);
+        CHECK(a6.element() == "Label only");
+        CHECK(a6.label() == "Label only");
+        CHECK(a6.mass() == 0);
+        CHECK(a6.charge() == 0);
+
+        CHECK(a7.type() == Atom::ELEMENT);
+        CHECK(a7.element() == "Na");
+        CHECK(a7.label() == "Na");
+        CHECK(a7.mass() == 22.98976928f);
+        CHECK(a7.charge() == 0);
     }
 
     SECTION("Set and get properties"){

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
     Atom a2 = Atom();
     Atom a3(Atom::COARSE_GRAINED, "CH4");
     Atom a4("W");
-	Atom a5("C", "CB");
+    Atom a5("C", "CB");
 
     SECTION("Check constructors"){
         CHECK(a1.element() == "H");
@@ -28,9 +28,9 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
         CHECK(a3.mass() == 0);
         CHECK(a3.charge() == 0);
 
-		CHECK(a5.type() == Atom::ELEMENT);
+        CHECK(a5.type() == Atom::ELEMENT);
         CHECK(a5.element() == "C");
-		CHECK(a5.label() == "CB");
+        CHECK(a5.label() == "CB");
         CHECK(a5.mass() == 12.011f);
         CHECK(a5.charge() == 0);
     }
@@ -48,16 +48,16 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
         a1.set_element("foo");
         CHECK(a1.element() == "foo");
 
-		a5.set_type(Atom::DUMMY);
-		CHECK(a5.type() == Atom::DUMMY);
-		a5.set_mass(14.789f);
-		CHECK(a5.mass() == 14.789f);
-		a5.set_charge(-2);
-		CHECK(a5.charge() == -2);
-		a5.set_element("foo");
-		CHECK(a5.element() == "foo");
-		a5.set_label("HE22");
-		CHECK(a5.label() == "HE22");
+        a5.set_type(Atom::DUMMY);
+        CHECK(a5.type() == Atom::DUMMY);
+        a5.set_mass(14.789f);
+        CHECK(a5.mass() == 14.789f);
+        a5.set_charge(-2);
+        CHECK(a5.charge() == -2);
+        a5.set_element("foo");
+        CHECK(a5.element() == "foo");
+        a5.set_label("HE22");
+        CHECK(a5.label() == "HE22");
 
         CHECK(a4.mass() == 183.84f);
         CHECK(a4.atomic_number() == 74);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -282,6 +282,18 @@ TEST_CASE("Parsing", "[selection]") {
         CHECK_THROWS_AS(parse(tokenize("element == 45")), SelectionError);
     }
 
+    SECTION("name") {
+        CHECK(parse(tokenize("name == goo"))->print() == "name($1) == goo");
+        CHECK(parse(tokenize("name($1) == goo"))->print() == "name($1) == goo");
+        CHECK(parse(tokenize("name goo"))->print() == "name($1) == goo");
+        CHECK(parse(tokenize("name($3) goo"))->print() == "name($3) == goo");
+        CHECK(parse(tokenize("name != goo"))->print() == "name($1) != goo");
+
+        CHECK_THROWS_AS(parse(tokenize("name < bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("name >= bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("name == 45")), SelectionError);
+    }
+
     SECTION("Index") {
         CHECK(parse(tokenize("index == 4"))->print() == "index($1) == 4");
         CHECK(parse(tokenize("index($1) == 4"))->print() == "index($1) == 4");

--- a/tests/selections.cpp
+++ b/tests/selections.cpp
@@ -48,6 +48,20 @@ TEST_CASE("Atoms selections", "[selection]") {
         CHECK(sel.list(frame) == res);
     }
 
+    SECTION("element") {
+        auto sel = Selection("name O");
+        auto res = std::vector<size_t>{1, 2};
+        CHECK(sel.list(frame) == res);
+
+        sel = Selection("name != O");
+        res = std::vector<size_t>{0, 3};
+        CHECK(sel.list(frame) == res);
+
+        sel = Selection("name H1");
+        res = std::vector<size_t>{0};
+        CHECK(sel.list(frame) == res);
+    }
+
     SECTION("positions") {
         auto sel = Selection("x < 2");
         auto res = std::vector<size_t>{0, 1};
@@ -170,7 +184,7 @@ TEST_CASE("Multiple selections", "[selection]") {
 
 Frame testing_frame() {
     auto topology = Topology();
-    topology.append(Atom("H"));
+    topology.append(Atom("H", "H1"));
     topology.append(Atom("O"));
     topology.append(Atom("O"));
     topology.append(Atom("H"));


### PR DESCRIPTION
This use the new label field in more places:

- For atoms without an element name (f080248d55e64531d7a53528352183a4f1cd08b7);
- In molfiles-based formats (ae4b117c513b0b90cc7c4eae43a0ce1b441785de);
- In selections (a8e1e79c3079d97a0c570522f08af45d887910c3).

@pgbarletta I commited the CHANGELOG update (07b96d00aa70b74d99e3143ca2d73abf0fcd4f97) using your username, are you OK with it? Do the other changes seems fine to you?

Follow #41.