### PR TITLE
Residues, part n+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   used by Gromacs.
 * All the integers at C boundary have a fixed size, most of the time using
   `uint64_t`.
+* Remove the `Atom::type` value from C and C++ API.
 
 ## 0.6 (1 July 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Add a public `Residue` class to C++ and C API to represent residue data.
   Residues are groups of atoms bonded together, which may or may not correspond
   to molecules; and are often used for bio-molecules.
+* Add the `resname` and `resid` selector, to select atoms based on their
+  residue.
 * Remove the `Trajectory::sync` and the `chfl_trajectory_sync` functions.
   To ensure that all content of a file is written to the disk, the user need to
   close it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (and velocity) data to a frame, and the C API `chfl_frame_add_atom` function.
 * Rename `UnitCell::type` to `UnitCell::shape`. This also affect
   `chfl_cell_shape_t`, `chfl_cell_shape`, and `chfl_cell_set_shape`.
-* Add the atomic label in addition to the atomic element. This introduces the
-  `Atom::{label,element}` method and remove the `Atom::name` method. This also
-  remove `chfl_atom_{name,set_name}` and add `chfl_atom_{element,set_element}`
-  and `chfl_atom_{label,set_label}`.
-* The `name` selector now select atoms based on the atomic label. To select on
-  the element, use the new `element` selector.
+* Account for the difference between the atom name and atom type in some
+  formats (PDB, TNG, ...). This introduces the `Atom::type` member function
+  and the `chfl_atom_type` C API function.
+* Add the `type` selector, to select atoms based on their type.
 * All the floating point data uses doubles instead of floats. This concerns
   atomic data, positions and velocities.
 * C API functions taking three lengths/angles now take a `double[3]` parameter

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -31,11 +31,7 @@ amino-acids in the protein.
 
 The ``Atom`` class contains basic information about the atoms in the system: the
 name (if it is disponible), mass, kind of atom and so on. Atoms are not limited
-to plain chemical elements. Four types of atoms are defined: *Element* are Atoms
-from the periodic classification; *coarse grained* atoms are particles taking
-together more than one element (*CH4* or *H2O* are examples); *Dummy* atoms are
-fictitous points associated with some data, like the fourth site in the TIP4P
-model of water; and *Undefined* atoms are all the other atoms types.
+to plain chemical elements.
 
 The ``UnitCell`` class describe the boundary conditions of the system: where are
 the boundaries, and what is the periodicity of theses boundaries. An unit cell

--- a/doc/selections.rst
+++ b/doc/selections.rst
@@ -55,9 +55,9 @@ The following selectors are implemented in chemfiles:
 
 - ``all``: select all the atoms;
 - ``none``: select none of the atoms;
-- ``element``: select atoms based on their element;
+- ``type``: select atoms based on their type;
 - ``name``: select atoms based on their name. Some formats store both an atomic
-  name (H3) and an atom element (H), this is why you can use two different
+  name (H3) and an atom type (H), this is why you can use two different
   selectors depending on the actual data;
 - ``index``: select atoms based on their index in the frame;
 - ``mass``: select atoms based on their mass;

--- a/doc/selections.rst
+++ b/doc/selections.rst
@@ -60,6 +60,10 @@ The following selectors are implemented in chemfiles:
   name (H3) and an atom type (H), this is why you can use two different
   selectors depending on the actual data;
 - ``index``: select atoms based on their index in the frame;
+- ``resname``: select atoms based on their residue name. An atom without residue
+  information will never be selected.
+- ``resid``: select atoms based on their residue name. An atom without residue
+  information will never be selected.
 - ``mass``: select atoms based on their mass;
 - ``x``, ``y`` and ``z``: select atoms based on their position cartesian components;
 - ``vx``, ``vy`` and ``vz``: select atoms based on their velocity cartesian components;

--- a/include/chemfiles.h
+++ b/include/chemfiles.h
@@ -539,7 +539,7 @@ typedef enum CHFL_CELL_SHAPE {
     CHFL_CELL_ORTHORHOMBIC = 0,
     //! The three angles may not be 90°
     CHFL_CELL_TRICLINIC = 1,
-    //! Cell type when there is no periodic boundary conditions
+    //! Cell shape when there is no periodic boundary conditions
     CHFL_CELL_INFINITE = 2,
 } chfl_cell_shape_t;
 
@@ -1017,37 +1017,6 @@ CHFL_EXPORT chfl_status chfl_atom_covalent_radius(const CHFL_ATOM* const atom,
 */
 CHFL_EXPORT chfl_status chfl_atom_atomic_number(const CHFL_ATOM* const atom,
                                                 int64_t* number);
-
-//! Available types of atoms
-typedef enum CHFL_ATOM_TYPES {
-    //! Element from the periodic table of elements
-    CHFL_ATOM_ELEMENT = 0,
-    //! Coarse-grained atom are composed of more than one element: CH3 groups,
-    //! amino-acids are coarse-grained atoms.
-    CHFL_ATOM_COARSE_GRAINED = 1,
-    //! Dummy site, with no physical reality
-    CHFL_ATOM_DUMMY = 2,
-    //! Undefined atom type
-    CHFL_ATOM_UNDEFINED = 3,
-} chfl_atom_type_t;
-
-/*!
-* @brief Get the atom type
-* @param atom the atom to read
-* @param type the type of the atom
-* @return The status code
-*/
-CHFL_EXPORT chfl_status chfl_atom_type(const CHFL_ATOM* const atom,
-                                       chfl_atom_type_t* const type);
-
-/*!
-* @brief Set the atom type
-* @param atom the atom to modify
-* @param type the new type of the atom
-* @return The status code
-*/
-CHFL_EXPORT chfl_status chfl_atom_set_type(CHFL_ATOM* const atom,
-                                           chfl_atom_type_t type);
 
 /*!
 * @brief Destroy an atom, and free the associated memory

--- a/include/chemfiles.h
+++ b/include/chemfiles.h
@@ -593,8 +593,7 @@ CHFL_EXPORT chfl_status chfl_topology_atoms_count(const CHFL_TOPOLOGY* const top
                                                   uint64_t* natoms);
 
 /*!
-* @brief Resize the topology to hold `natoms` atoms, adding `CHFL_ATOM_UNDEFINED`
-*        atoms as needed.
+* @brief Resize the topology to hold `natoms` atoms.
 *
 * @param topology The topology
 * @param natoms The new number of atoms.
@@ -882,11 +881,11 @@ CHFL_EXPORT chfl_status chfl_residue_free(CHFL_RESIDUE* residue);
 /******************************************************************************/
 
 /*!
-* @brief Create an atom from an element name
-* @param element The new atom element
+* @brief Create an atom from a name
+* @param name The new atom name
 * @return A pointer to the new atom, or NULL in case of error
 */
-CHFL_EXPORT CHFL_ATOM* chfl_atom(const char* element);
+CHFL_EXPORT CHFL_ATOM* chfl_atom(const char* name);
 
 /*!
 * @brief Get a specific atom from a frame
@@ -941,56 +940,56 @@ CHFL_EXPORT chfl_status chfl_atom_charge(const CHFL_ATOM* const atom, double* ch
 CHFL_EXPORT chfl_status chfl_atom_set_charge(CHFL_ATOM* const atom, double charge);
 
 /*!
-* @brief Get the element name of an atom
+* @brief Get the type of an atom
 * @param atom The atom
-* @param element A string buffer to be filled with the element name
+* @param type A string buffer to be filled with the atom type
 * @param buffsize The size of the string buffer
 * @return The status code
 */
-CHFL_EXPORT chfl_status chfl_atom_element(const CHFL_ATOM* const atom,
-                                       char* const element,
+CHFL_EXPORT chfl_status chfl_atom_type(const CHFL_ATOM* const atom,
+                                       char* const type,
                                        uint64_t buffsize);
 
 /*!
-* @brief Set the element name of an atom
+* @brief Set the type of an atom
 * @param atom The atom
-* @param element A null terminated string containing the new element name
+* @param type A null terminated string containing the new atom type
 * @return The status code
 */
-CHFL_EXPORT chfl_status chfl_atom_set_element(CHFL_ATOM* const atom, const char* element);
+CHFL_EXPORT chfl_status chfl_atom_set_type(CHFL_ATOM* const atom, const char* type);
 
 /*!
-* @brief Get the label name of an atom
+* @brief Get the name of an atom
 * @param atom The atom
-* @param label A string buffer to be filled with the label
+* @param name A string buffer to be filled with the atom name
 * @param buffsize The size of the string buffer
 * @return The status code
 */
-CHFL_EXPORT chfl_status chfl_atom_label(const CHFL_ATOM* const atom,
-                                       char* const label,
+CHFL_EXPORT chfl_status chfl_atom_name(const CHFL_ATOM* const atom,
+                                       char* const name,
                                        uint64_t buffsize);
 
 /*!
-* @brief Set the label of an atom
+* @brief Set the name of an atom
 * @param atom The atom
-* @param label A null terminated string containing the new label
+* @param name A null terminated string containing the new atom name
 * @return The status code
 */
-CHFL_EXPORT chfl_status chfl_atom_set_label(CHFL_ATOM* const atom, const char* label);
+CHFL_EXPORT chfl_status chfl_atom_set_name(CHFL_ATOM* const atom, const char* name);
 
 /*!
-* @brief Try to get the full name of an atom from the element name
+* @brief Try to get the full name of an atom from the atom type
 * @param atom The atom
-* @param element A string buffer to be filled with the element name
+* @param name A string buffer to be filled with the full name
 * @param buffsize The size of the string buffer
 * @return The status code
 */
 CHFL_EXPORT chfl_status chfl_atom_full_name(const CHFL_ATOM* const atom,
-                                            char* const element,
+                                            char* const name,
                                             uint64_t buffsize);
 
 /*!
-* @brief Try to get the Van der Waals radius of an atom from the element name
+* @brief Try to get the Van der Waals radius of an atom from the atom type
 * @param atom The atom
 * @param radius The Van der Waals radius of the atom or -1 if no value could be
 * found.
@@ -1000,7 +999,7 @@ CHFL_EXPORT chfl_status chfl_atom_vdw_radius(const CHFL_ATOM* const atom,
                                              double* radius);
 
 /*!
-* @brief Try to get the covalent radius of an atom from the element name
+* @brief Try to get the covalent radius of an atom from the atom type
 * @param atom The atom
 * @param radius The covalent radius of the atom or -1 if no value could be
 * found.
@@ -1010,7 +1009,7 @@ CHFL_EXPORT chfl_status chfl_atom_covalent_radius(const CHFL_ATOM* const atom,
                                                   double* radius);
 
 /*!
-* @brief Try to get the atomic number of an atom from the element name
+* @brief Try to get the atomic number of an atom from the atom type
 * @param atom The atom
 * @param number The atomic number, or -1 if no value could be found.
 * @return The status code

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -15,45 +15,50 @@
 
 namespace chemfiles {
 
-/*!
- * @class Atom Atom.hpp Atom.cpp
- *
- * An Atom is a particle in the current Frame. It can be used to store and
- * retrieve informations about a particle, such as mass, element name, atomic
- * number, etc.
- */
+//! An `Atom` is a particle in the current `Frame`.
+//!
+//! An atom stores the following atomic properties:
+//!
+//! - atom name;
+//! - atom type;
+//! - atom mass;
+//! - atom charge.
+//!
+//! The atom name is usually an unique identifier ("H1", "C_a") while the atom
+//! type will be shared between all particles of the same type: "H", "Ow",
+//! "CH3".
 class CHFL_EXPORT Atom {
 public:
-    //! Create an atom with the given `label` and set `element` to be the same
-    //! as label.
-    explicit Atom(std::string label = "");
-    //! Create an atom from the given `label` and `element`
-    Atom(std::string element, std::string label);
+    //! Create an atom with the given `name` and set the atom `type` to be the
+    //! same as `name`.
+    explicit Atom(std::string name = "");
+    //! Create an atom from the given `name` and `type`
+    Atom(std::string name, std::string type);
 
     Atom(Atom&&) = default;
     Atom& operator=(Atom&&) = default;
     Atom(const Atom&) = default;
     Atom& operator=(const Atom&) = default;
 
-    //! Get a const (non-modifiable) reference to the atom element name
-    const std::string& element() const { return element_; }
-    //! Get a const (non-modifiable) reference to the atom label
-    const std::string& label() const { return label_; }
+    //! Get a const (non-modifiable) reference to the atom name
+    const std::string& name() const { return name_; }
+    //! Get a const (non-modifiable) reference to the atom type
+    const std::string& type() const { return type_; }
     //! Get the atom mass
     double mass() const { return mass_; }
     //! Get the atom charge
     double charge() const { return charge_; }
 
-    //! Set the atom element name
-    void set_element(const std::string& element) { element_ = element; }
-    //! Set the atom label
-    void set_label(const std::string& label) { label_ = label; }
+    //! Set the atom type
+    void set_type(std::string type) { type_ = std::move(type); }
+    //! Set the atom name
+    void set_name(std::string name) { name_ = std::move(name); }
     //! Set the atom mass
     void set_mass(double mass) { mass_ = mass; }
     //! Set the atom charge
     void set_charge(double charge) { charge_ = charge; }
 
-    //! Try to get the full element name, return and empty string if this is
+    //! Try to get the full atomic name, return and empty string if this is
     //! impossible
     std::string full_name() const;
     //! Try to get the Van der Waals of the atom. Returns -1 if it can not be
@@ -67,14 +72,14 @@ public:
     int atomic_number() const;
 
 private:
-    std::string label_;
-    std::string element_;
+    std::string name_;
+    std::string type_;
     double mass_ = 0;
     double charge_ = 0;
 };
 
 inline bool operator==(const Atom& lhs, const Atom& rhs) {
-    return (lhs.element() == rhs.element() && lhs.label() == rhs.label() &&
+    return (lhs.name() == rhs.name() && lhs.type() == rhs.type() &&
             lhs.mass() == rhs.mass() && lhs.charge() == rhs.charge());
 }
 

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -24,27 +24,11 @@ namespace chemfiles {
  */
 class CHFL_EXPORT Atom {
 public:
-    //! An Atom can be of various kind. This is encoded by a value in this enum.
-    enum AtomType {
-        //! Element from the periodic table of elements
-        ELEMENT = 0,
-        //! Coarse-grained atom are composed of more than one element: CH3
-        //! groups, amino-acids are coarse-grained atoms.
-        COARSE_GRAINED = 1,
-        //! Dummy site, with no physical reality
-        DUMMY = 2,
-        //! Undefined atom-type
-        UNDEFINED = 3,
-    };
-
-    //! Create an atom from its 'element' with 'label'='element'
-    explicit Atom(std::string element);
-    //! Create an atom from its 'element' and its label
+    //! Create an atom with the given `label` and set `element` to be the same
+    //! as label.
+    explicit Atom(std::string label = "");
+    //! Create an atom from the given `label` and `element`
     Atom(std::string element, std::string label);
-    //! Create an atom from its 'element' and its type
-    Atom(AtomType type, std::string element, std::string label = "");
-    //! Default is to create an UNDEFINED atom type with no element or label
-    Atom();
 
     Atom(Atom&&) = default;
     Atom& operator=(Atom&&) = default;
@@ -59,8 +43,6 @@ public:
     double mass() const { return mass_; }
     //! Get the atom charge
     double charge() const { return charge_; }
-    //! Get the atom type
-    AtomType type() const { return type_; }
 
     //! Set the atom element name
     void set_element(const std::string& element) { element_ = element; }
@@ -70,8 +52,6 @@ public:
     void set_mass(double mass) { mass_ = mass; }
     //! Set the atom charge
     void set_charge(double charge) { charge_ = charge; }
-    //! Set the atom type
-    void set_type(AtomType type) { type_ = type; }
 
     //! Try to get the full element name, return and empty string if this is
     //! impossible
@@ -87,17 +67,15 @@ public:
     int atomic_number() const;
 
 private:
-    std::string element_;
     std::string label_;
+    std::string element_;
     double mass_ = 0;
     double charge_ = 0;
-    AtomType type_;
 };
 
 inline bool operator==(const Atom& lhs, const Atom& rhs) {
     return (lhs.element() == rhs.element() && lhs.label() == rhs.label() &&
-            lhs.mass() == rhs.mass() && lhs.charge() == rhs.charge() &&
-            lhs.type() == rhs.type());
+            lhs.mass() == rhs.mass() && lhs.charge() == rhs.charge());
 }
 
 } // namespace chemfiles

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -180,6 +180,21 @@ private:
     bool equals_;
 };
 
+//! @class ResidExpr selections/expr.hpp selections/expr.cpp
+//! @brief Select atoms using their residue name
+//!
+//! Only `==` and `!=` operators are allowed. The short form `resname <value>`
+//! is equivalent to `resname == <value>`
+class ResidExpr final: public SingleSelector {
+public:
+    ResidExpr(unsigned argument, BinOp op, size_t id)
+        : SingleSelector(argument), op_(op), id_(id) {}
+    std::string print(unsigned delta) const override;
+    std::vector<bool> evaluate(const Frame& frame, const std::vector<Match>& matches) const override;
+private:
+    BinOp op_;
+    size_t id_;
+};
 
 //! @class PositionExpr selections/expr.hpp selections/expr.cpp
 //! @brief Select atoms using their position in space. The selection can be

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -164,6 +164,22 @@ private:
     std::size_t val_;
 };
 
+//! @class ResnameExpr selections/expr.hpp selections/expr.cpp
+//! @brief Select atoms using their residue name
+//!
+//! Only `==` and `!=` operators are allowed. The short form `resname <value>`
+//! is equivalent to `resname == <value>`
+class ResnameExpr final: public SingleSelector {
+public:
+    ResnameExpr(unsigned argument, std::string name, bool equals)
+        : SingleSelector(argument), name_(name), equals_(equals) {}
+    std::string print(unsigned delta) const override;
+    std::vector<bool> evaluate(const Frame& frame, const std::vector<Match>& matches) const override;
+private:
+    std::string name_;
+    bool equals_;
+};
+
 
 //! @class PositionExpr selections/expr.hpp selections/expr.cpp
 //! @brief Select atoms using their position in space. The selection can be

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -119,27 +119,27 @@ protected:
     const unsigned argument_;
 };
 
-//! @class ElementExpr selections/expr.hpp selections/expr.cpp
-//! @brief Select atoms using their element name.
+//! @class TypeExpr selections/expr.hpp selections/expr.cpp
+//! @brief Select atoms using their type
 //!
-//! Only `==` and `!=` operators are allowed. The short form `element <value>` is
-//! equivalent to `element == <value>`
-class ElementExpr final: public SingleSelector {
+//! Only `==` and `!=` operators are allowed. The short form `type <value>` is
+//! equivalent to `type == <value>`
+class TypeExpr final: public SingleSelector {
 public:
-    ElementExpr(unsigned argument, std::string element, bool equals)
-        : SingleSelector(argument), element_(element), equals_(equals) {}
+    TypeExpr(unsigned argument, std::string type, bool equals)
+        : SingleSelector(argument), type_(type), equals_(equals) {}
     std::string print(unsigned delta) const override;
     std::vector<bool> evaluate(const Frame& frame, const std::vector<Match>& matches) const override;
 private:
-    std::string element_;
+    std::string type_;
     bool equals_;
 };
 
-//! @class ElementExpr selections/expr.hpp selections/expr.cpp
-//! @brief Select atoms using their label.
+//! @class NameExpr selections/expr.hpp selections/expr.cpp
+//! @brief Select atoms using their name.
 //!
-//! Only `==` and `!=` operators are allowed. The short form `element <value>` is
-//! equivalent to `element == <value>`
+//! Only `==` and `!=` operators are allowed. The short form `name <value>` is
+//! equivalent to `name == <value>`
 class NameExpr final: public SingleSelector {
 public:
     NameExpr(unsigned argument, std::string name, bool equals)

--- a/include/chemfiles/types.hpp
+++ b/include/chemfiles/types.hpp
@@ -9,6 +9,7 @@
 #ifndef CHEMFILES_TYPES_HPP
 #define CHEMFILES_TYPES_HPP
 
+#include <type_traits>
 #include <array>
 #include <cassert>
 #include <cmath>
@@ -80,6 +81,7 @@ inline Vector3D operator/(const Vector3D& lhs, double rhs) {
 // As `std::array<double, 3>` (i.e. Vector3D) is POD, its memory layout is
 // equivalent to a `double[3]` array. So the pointer return by `Array3D::data`
 // is compatible with the C type `(*double)[3] == chfl_vector_t`.
+static_assert(std::is_pod<Vector3D>::value, "Vector3D must be POD");
 
 //! A vector of `Vector3D`, used as a list of positions or velocities in a
 //! system.

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -11,61 +11,14 @@
 
 using namespace chemfiles;
 
-// Check if the string `element` is an element
-static bool is_element(const std::string& element) {
-    // clang-format off
-    const auto ALL_ELEMENTS = {
-    "H" ,                                                                                                 "He",
-    "Li", "Be",                                                             "B" , "C" , "N" , "O" , "F" , "Ne",
-    "Na", "Mg",                                                             "Al", "Si", "P" , "S" , "Cl", "Ar",
-    "K" , "Ca", "Sc", "Ti", "V" , "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr",
-    "Rb", "Sr", "Y" , "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ar", "Cd", "In", "Sn", "Sb", "Te", "I" , "Xe",
-    "Cs", "Ba", "La", "Hf", "Ta", "W" , "Re", "Os", "Ir", "Pt", "Au", "Hg", "Ti", "Pb", "Bi", "Po", "At", "Rn",
-    "Fr", "Ra", "Ac", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg", "Cn",
+Atom::Atom(std::string label): Atom(label, label) {}
 
-    "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
-    "Th", "Pa", "U" , "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"
-    };
-    // clang-format on
-    for (auto& each_element : ALL_ELEMENTS) {
-        if (element == each_element) {
-            return true;
-        }
-    }
-    return false;
-
-}
-
-Atom::Atom(std::string element)
-    : Atom(UNDEFINED, element, std::move(element)) {}
-
-Atom::Atom(std::string element, std::string label)
-    : Atom(UNDEFINED, std::move(element), std::move(label)) {}
-
-Atom::Atom(AtomType type, std::string element, std::string label):
-    element_(std::move(element)), label_(std::move(label)), type_(type) {
-    // Use the same value for label and element if one is empty and the other
-    // is not.
-    if (element_ == "" && label_ != "") {
-        element_ = label_;
-    } else if (label_ == "" && element_ != "") {
-        label_ = element_;
-    }
-
-    if (type_ == UNDEFINED && element_ != "") {
-        if (is_element(element_)) {
-            type_ = ELEMENT;
-        } else {
-            type_ = COARSE_GRAINED;
-        }
-    }
-
+Atom::Atom(std::string element, std::string label):
+    label_(std::move(label)), element_(std::move(element)) {
     if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
         mass_ = PERIODIC_INFORMATION.at(element_).mass;
     }
 }
-
-Atom::Atom(): Atom(UNDEFINED, "", "") {}
 
 std::string Atom::full_name() const {
     if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -11,39 +11,48 @@
 
 using namespace chemfiles;
 
-Atom::Atom(std::string label): Atom(label, label) {}
+Atom::Atom(std::string name): Atom(name, name) {}
 
-Atom::Atom(std::string element, std::string label):
-    label_(std::move(label)), element_(std::move(element)) {
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        mass_ = PERIODIC_INFORMATION.at(element_).mass;
+Atom::Atom(std::string name, std::string type):
+    name_(std::move(name)), type_(std::move(type)) {
+    auto periodic = PERIODIC_INFORMATION.find(type_);
+    if (periodic != PERIODIC_INFORMATION.end()) {
+        mass_ = periodic->second.mass;
     }
 }
 
 std::string Atom::full_name() const {
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        return std::string(PERIODIC_INFORMATION.at(element_).name);
+    auto periodic = PERIODIC_INFORMATION.find(type_);
+    if (periodic != PERIODIC_INFORMATION.end()) {
+        return periodic->second.name;
+    } else {
+        return "";
     }
-    return "";
 }
 
 double Atom::vdw_radius() const {
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        return PERIODIC_INFORMATION.at(element_).vdw_radius;
+    auto periodic = PERIODIC_INFORMATION.find(type_);
+    if (periodic != PERIODIC_INFORMATION.end()) {
+        return periodic->second.vdw_radius;
+    } else {
+        return -1;
     }
-    return -1;
 }
 
 double Atom::covalent_radius() const {
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        return PERIODIC_INFORMATION.at(element_).colvalent_radius;
+    auto periodic = PERIODIC_INFORMATION.find(type_);
+    if (periodic != PERIODIC_INFORMATION.end()) {
+        return periodic->second.colvalent_radius;
+    } else {
+        return -1;
     }
-    return -1;
 }
 
 int Atom::atomic_number() const {
-    if (PERIODIC_INFORMATION.find(element_) != PERIODIC_INFORMATION.end()) {
-        return PERIODIC_INFORMATION.at(element_).number;
+    auto periodic = PERIODIC_INFORMATION.find(type_);
+    if (periodic != PERIODIC_INFORMATION.end()) {
+        return periodic->second.number;
+    } else {
+        return -1;
     }
-    return -1;
 }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -77,14 +77,16 @@ void Frame::guess_topology() {
     for (size_t i = 0; i < natoms(); i++) {
         auto irad = topology_[i].vdw_radius();
         if (irad == -1) {
-            throw Error("Missing Van der Waals radius for the atom " +
-                        topology_[i].element());
+            throw Error(
+                "Missing Van der Waals radius for '" + topology_[i].type() + "'"
+            );
         }
         for (size_t j = i + 1; j < natoms(); j++) {
             auto jrad = topology_[j].vdw_radius();
             if (jrad == -1) {
-                throw Error("Missing Van der Waals radius for the atom " +
-                            topology_[j].element());
+                throw Error(
+                    "Missing Van der Waals radius for '" + topology_[j].type() + "'"
+                );
             }
             auto d = norm(cell_.wrap(positions_[i] - positions_[j]));
             if (0.03 < d && d < 0.6 * (irad + jrad) && d < cutoff) {
@@ -99,10 +101,10 @@ void Frame::guess_topology() {
     // once
     for (auto& bond : bonds) {
         auto i = bond[0], j = bond[1];
-        if (topology_[i].element() != "H") {
+        if (topology_[i].type() != "H") {
             continue;
         }
-        if (topology_[j].element() != "H") {
+        if (topology_[j].type() != "H") {
             continue;
         }
 

--- a/src/capi/atom.cpp
+++ b/src/capi/atom.cpp
@@ -16,10 +16,10 @@
 #include "chemfiles/capi.hpp"
 using namespace chemfiles;
 
-CHFL_ATOM* chfl_atom(const char* element) {
+CHFL_ATOM* chfl_atom(const char* name) {
     CHFL_ATOM* atom = nullptr;
     CHFL_ERROR_GOTO(
-        atom = new Atom(std::string(element));
+        atom = new Atom(name);
     )
     return atom;
 error:
@@ -89,46 +89,46 @@ chfl_status chfl_atom_set_charge(CHFL_ATOM* const atom, double charge) {
     )
 }
 
-chfl_status chfl_atom_element(const CHFL_ATOM* const atom, char* const element, uint64_t buffsize) {
+chfl_status chfl_atom_type(const CHFL_ATOM* const atom, char* const type, uint64_t buffsize) {
     assert(atom != nullptr);
-    assert(element != nullptr);
+    assert(type != nullptr);
     CHFL_ERROR_CATCH(
-        strncpy(element, atom->element().c_str(), buffsize - 1);
-        element[buffsize - 1] = '\0';
+        strncpy(type, atom->type().c_str(), buffsize - 1);
+        type[buffsize - 1] = '\0';
     )
 }
 
-chfl_status chfl_atom_set_element(CHFL_ATOM* const atom, const char* element) {
+chfl_status chfl_atom_set_type(CHFL_ATOM* const atom, const char* type) {
     assert(atom != nullptr);
-    assert(element != nullptr);
+    assert(type != nullptr);
     CHFL_ERROR_CATCH(
-        atom->set_element(std::string(element));
+        atom->set_type(type);
     )
 }
 
-chfl_status chfl_atom_label(const CHFL_ATOM* const atom, char* const label, uint64_t buffsize) {
+chfl_status chfl_atom_name(const CHFL_ATOM* const atom, char* const name, uint64_t buffsize) {
     assert(atom != nullptr);
-    assert(label != nullptr);
+    assert(name != nullptr);
     CHFL_ERROR_CATCH(
-        strncpy(label, atom->label().c_str(), buffsize - 1);
-        label[buffsize - 1] = '\0';
+        strncpy(name, atom->name().c_str(), buffsize - 1);
+        name[buffsize - 1] = '\0';
     )
 }
 
-chfl_status chfl_atom_set_label(CHFL_ATOM* const atom, const char* label) {
+chfl_status chfl_atom_set_name(CHFL_ATOM* const atom, const char* name) {
     assert(atom != nullptr);
-    assert(label != nullptr);
+    assert(name != nullptr);
     CHFL_ERROR_CATCH(
-        atom->set_label(std::string(label));
+        atom->set_name(name);
     )
 }
 
-chfl_status chfl_atom_full_name(const CHFL_ATOM* const atom, char* const element, uint64_t buffsize) {
+chfl_status chfl_atom_full_name(const CHFL_ATOM* const atom, char* const name, uint64_t buffsize) {
     assert(atom != nullptr);
-    assert(element != nullptr);
+    assert(name != nullptr);
     CHFL_ERROR_CATCH(
-        strncpy(element, atom->full_name().c_str(), buffsize - 1);
-        element[buffsize - 1] = '\0';
+        strncpy(name, atom->full_name().c_str(), buffsize - 1);
+        name[buffsize - 1] = '\0';
     )
 }
 

--- a/src/capi/atom.cpp
+++ b/src/capi/atom.cpp
@@ -16,8 +16,6 @@
 #include "chemfiles/capi.hpp"
 using namespace chemfiles;
 
-static_assert(sizeof(chfl_atom_type_t) == sizeof(int), "Wrong size for chfl_atom_type_t enum");
-
 CHFL_ATOM* chfl_atom(const char* element) {
     CHFL_ATOM* atom = nullptr;
     CHFL_ERROR_GOTO(
@@ -155,21 +153,6 @@ chfl_status chfl_atom_atomic_number(const CHFL_ATOM* const atom, int64_t* number
     assert(number != nullptr);
     CHFL_ERROR_CATCH(
         *number = atom->atomic_number();
-    )
-}
-
-chfl_status chfl_atom_type(const CHFL_ATOM* const atom, chfl_atom_type_t* const type) {
-    assert(atom != nullptr);
-    assert(type != nullptr);
-    CHFL_ERROR_CATCH(
-        *type = static_cast<chfl_atom_type_t>(atom->type());
-    )
-}
-
-chfl_status chfl_atom_set_type(CHFL_ATOM* const atom, chfl_atom_type_t type) {
-    assert(atom != nullptr);
-    CHFL_ERROR_CATCH(
-        atom->set_type(static_cast<Atom::AtomType>(type));
     )
 }
 

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -144,7 +144,7 @@ void PDBFormat::read_ATOM(Frame& frame, const std::string& line) {
 
     auto atom = Atom(trim(line.substr(12, 4)));
     if (line.length() >= 78) {
-        atom.set_element(trim(line.substr(76, 2)));
+        atom.set_type(trim(line.substr(76, 2)));
     }
 
     try {
@@ -276,8 +276,8 @@ void PDBFormat::write(const Frame& frame) {
         cell.a(), cell.b(), cell.c(), cell.alpha(), cell.beta(), cell.gamma());
 
     for (size_t i = 0; i < frame.natoms(); i++) {
-        auto& element = frame.topology()[i].element();
-        auto& label = frame.topology()[i].label();
+        auto& name = frame.topology()[i].name();
+        auto& type = frame.topology()[i].type();
         auto& pos = frame.positions()[i];
 
         std::string resname;
@@ -303,7 +303,7 @@ void PDBFormat::write(const Frame& frame) {
         fmt::print(*file_, "HETATM{:5d} {: >4s} {:3} X{:4d}    "
                            "{:8.3f}{:8.3f}{:8.3f}{:6.2f}{:6.2f}"
                            "          {: >2s}\n",
-                   i, label, resname, resid, pos[0], pos[1], pos[2], 0.0, 0.0, element);
+                   i, name, resname, resid, pos[0], pos[1], pos[2], 0.0, 0.0, type);
     }
 
     auto connect = std::vector<std::vector<size_t>>(frame.natoms());

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -282,11 +282,13 @@ void PDBFormat::write(const Frame& frame) {
         auto& element = frame.topology()[i].element();
         auto& label = frame.topology()[i].label();
         auto& pos = frame.positions()[i];
+
         std::string resname;
         size_t resid;
-        if (auto resopt = frame.topology().residue(i)) {
-            resname = resopt->name();
-            resid = resopt->id();
+        auto residue = frame.topology().residue(i);
+        if (residue) {
+            resname = residue->name();
+            resid = residue->id();
         }
         else {
             resname = "RES";

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -142,14 +142,11 @@ void PDBFormat::read_ATOM(Frame& frame, const std::string& line) {
         );
     }
 
-    std::string element;
-    try {
-        element = trim(line.substr(76, 2));
-    } catch(const std::out_of_range&) {
-        element = "";
+    auto atom = Atom(trim(line.substr(12, 4)));
+    if (line.length() >= 78) {
+        atom.set_element(trim(line.substr(76, 2)));
     }
 
-    auto atom = Atom(element, trim(line.substr(12, 4)));
     try {
         auto x = std::stof(line.substr(31, 8));
         auto y = std::stof(line.substr(38, 8));

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -206,7 +206,7 @@ void TNGFormat::read_topology(Frame& frame) {
                     CHECK(tng_atom_type_get(tng_, tng_atom, type, 32));
 
                     residue.add_atom(topology.natoms());
-                    topology.append(Atom(type, name));
+                    topology.append(Atom(name, type));
                 }
                 topology.add_residue(std::move(residue));
             }

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -88,12 +88,12 @@ void XYZFormat::read(Frame& frame) {
     for (size_t i = 0; i < lines.size(); i++) {
         std::istringstream string_stream;
         double x = 0, y = 0, z = 0;
-        std::string element;
+        std::string name;
 
         string_stream.str(lines[i]);
-        string_stream >> element >> x >> y >> z;
+        string_stream >> name >> x >> y >> z;
 
-        frame.add_atom(Atom(element), {{x, y, z}});
+        frame.add_atom(Atom(name), {{x, y, z}});
     }
 }
 
@@ -106,9 +106,9 @@ void XYZFormat::write(const Frame& frame) {
     *file_ << "Written by the chemfiles library\n";
 
     for (size_t i = 0; i < frame.natoms(); i++) {
-        auto element = topology[i].element();
-        if (element == "") {element = "X";}
-        *file_ << element << " "
+        auto type = topology[i].type();
+        if (type == "") {type = "X";}
+        *file_ << type << " "
                << positions[i][0] << " "
                << positions[i][1] << " "
                << positions[i][2] << "\n";

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -24,8 +24,8 @@ struct function_info_t {
 };
 
 static std::map<std::string, function_info_t> FUNCTIONS = {
-    {"element", {1, true}},
     {"name", {1, true}},
+    {"type", {1, true}},
     {"mass", {1, true}},
     {"index", {1, true}},
     {"x", {1, false}},
@@ -47,15 +47,15 @@ static bool is_function(const Token& token) {
  * This convert infix expressions into an AST-like expression, while checking
  * parentheses.
  * The following input:
- *       element == bar and x <= 56
+ *       name == bar and x <= 56
  * is converted to:
- *       and == bar element <= 56 x
+ *       and == bar name <= 56 x
  * which is the AST for
  *             and
  *         /          \
  *        ==          <=
  *       /  \        /  \
- *    element   bar    x    56
+ *    name   bar    x    56
  */
 static std::vector<Token> shunting_yard(token_iterator_t token, token_iterator_t end) {
     std::stack<Token> operators;
@@ -130,8 +130,8 @@ static std::vector<Token> shunting_yard(token_iterator_t token, token_iterator_t
 /* Rewrite the token stream to convert short form for the expressions to the
  * long one.
  *
- * Short forms are expressions like `element foo` or `index 3`, which are
- * equivalent to `element == foo` and `index == 3`.
+ * Short forms are expressions like `name foo` or `index 3`, which are
+ * equivalent to `name == foo` and `index == 3`.
  */
 static std::vector<Token> add_missing_equals(std::vector<Token> stream) {
     auto out = std::vector<Token>();
@@ -184,8 +184,8 @@ Ast selections::dispatch_parsing(token_iterator_t& begin, const token_iterator_t
         }
 
         auto ident = begin[2].ident();
-        if (ident == "element") {
-            return parse<ElementExpr>(begin, end);
+        if (ident == "type") {
+            return parse<TypeExpr>(begin, end);
         } else if (ident == "name") {
             return parse<NameExpr>(begin, end);
         } else if (ident == "index") {

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -26,8 +26,9 @@ struct function_info_t {
 static std::map<std::string, function_info_t> FUNCTIONS = {
     {"name", {1, true}},
     {"type", {1, true}},
-    {"mass", {1, true}},
+    {"resname", {1, true}},
     {"index", {1, true}},
+    {"mass", {1, true}},
     {"x", {1, false}},
     {"y", {1, false}},
     {"z", {1, false}},
@@ -190,6 +191,8 @@ Ast selections::dispatch_parsing(token_iterator_t& begin, const token_iterator_t
             return parse<NameExpr>(begin, end);
         } else if (ident == "index") {
             return parse<IndexExpr>(begin, end);
+        } else if (ident == "resname") {
+            return parse<ResnameExpr>(begin, end);
         } else if (ident == "mass") {
             return parse<MassExpr>(begin, end);
         } else if (ident == "x" || ident == "y" || ident == "z") {

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -27,6 +27,7 @@ static std::map<std::string, function_info_t> FUNCTIONS = {
     {"name", {1, true}},
     {"type", {1, true}},
     {"resname", {1, true}},
+    {"resid", {1, true}},
     {"index", {1, true}},
     {"mass", {1, true}},
     {"x", {1, false}},
@@ -193,6 +194,8 @@ Ast selections::dispatch_parsing(token_iterator_t& begin, const token_iterator_t
             return parse<IndexExpr>(begin, end);
         } else if (ident == "resname") {
             return parse<ResnameExpr>(begin, end);
+        } else if (ident == "resid") {
+            return parse<ResidExpr>(begin, end);
         } else if (ident == "mass") {
             return parse<MassExpr>(begin, end);
         } else if (ident == "x" || ident == "y" || ident == "z") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,9 +8,9 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT_HASH}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT_HASH}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT_HASH}.tar.gz"
         SHOW_PROGRESS
-        TIMEOUT 30
         EXPECTED_HASH SHA1=f16520453515f21ca838c508eea9d38ac4877443
     )
+
     message(STATUS "Unpacking test data files")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xf ${TESTS_DATA_GIT_HASH}.tar.gz

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -6,77 +6,67 @@ using namespace chemfiles;
 
 
 TEST_CASE("Use the Atom type", "[Atoms]"){
-    Atom a1("H");
-    Atom a2 = Atom();
-    Atom a3(Atom::COARSE_GRAINED, "CH4");
-    Atom a4("W");
-    Atom a5("C", "CB");
-    Atom a6("", "Label only");
-    Atom a7("", "Na");
+    Atom a("H");
+    Atom b;
+    Atom c("C", "C1");
+    Atom d("", "Label only");
 
-    SECTION("Check constructors"){
-        CHECK(a1.element() == "H");
-        CHECK(a1.label() == "H");
-        CHECK(a1.mass() == 1.008);
-        CHECK(a1.type() == Atom::ELEMENT);
-        CHECK(a1.charge() == 0);
+    SECTION("Constructors") {
+        CHECK(a.label() == "H");
+        CHECK(a.element() == "H");
+        CHECK(a.mass() == 1.008);
+        CHECK(a.charge() == 0);
 
-        CHECK(a2.type() == Atom::UNDEFINED);
-        CHECK(a2.element() == "");
-        CHECK(a2.label() == "");
-        CHECK(a2.mass() == 0);
-        CHECK(a2.charge() == 0);
+        CHECK(b.label() == "");
+        CHECK(b.element() == "");
+        CHECK(b.mass() == 0);
+        CHECK(b.charge() == 0);
 
-        CHECK(a3.type() == Atom::COARSE_GRAINED);
-        CHECK(a3.element() == "CH4");
-        CHECK(a3.label() == "CH4");
-        CHECK(a3.mass() == 0);
-        CHECK(a3.charge() == 0);
+        CHECK(c.label() == "C1");
+        CHECK(c.element() == "C");
+        CHECK(c.mass() == 12.011);
+        CHECK(c.charge() == 0);
 
-        CHECK(a5.type() == Atom::ELEMENT);
-        CHECK(a5.element() == "C");
-        CHECK(a5.label() == "CB");
-        CHECK(a5.mass() == 12.011);
-        CHECK(a5.charge() == 0);
-
-        CHECK(a6.type() == Atom::COARSE_GRAINED);
-        CHECK(a6.element() == "Label only");
-        CHECK(a6.label() == "Label only");
-        CHECK(a6.mass() == 0);
-        CHECK(a6.charge() == 0);
-
-        CHECK(a7.type() == Atom::ELEMENT);
-        CHECK(a7.element() == "Na");
-        CHECK(a7.label() == "Na");
-        CHECK(a7.mass() == 22.98976928);
-        CHECK(a7.charge() == 0);
+        CHECK(d.label() == "Label only");
+        CHECK(d.element() == "");
+        CHECK(d.mass() == 0);
+        CHECK(d.charge() == 0);
     }
 
-    SECTION("Set and get properties"){
-        a1.set_type(Atom::DUMMY);
-        CHECK(a1.type() == Atom::DUMMY);
+    SECTION("Set and get properties") {
+        Atom atom;
 
-        a1.set_mass(14.789);
-        CHECK(a1.mass() == 14.789);
+        CHECK(atom.mass() == 0);
+        atom.set_mass(14.789);
+        CHECK(atom.mass() == 14.789);
 
-        a1.set_charge(-2);
-        CHECK(a1.charge() == -2);
+        CHECK(atom.charge() == 0);
+        atom.set_charge(-2);
+        CHECK(atom.charge() == -2);
 
-        a1.set_element("foo");
-        CHECK(a1.element() == "foo");
+        CHECK(atom.label() == "");
+        atom.set_label("HE22");
+        CHECK(atom.label() == "HE22");
 
-        a1.set_label("HE22");
-        CHECK(a1.label() == "HE22");
+        CHECK(atom.element() == "");
+        atom.set_element("foo");
+        CHECK(atom.element() == "foo");
+    }
 
-        CHECK(a4.mass() == 183.84);
-        CHECK(a4.atomic_number() == 74);
-        CHECK(a4.full_name() == "Tungsten");
-        CHECK(a4.covalent_radius() == 1.46);
-        CHECK(a4.vdw_radius() == 2.1);
+    SECTION("Elements properties") {
+        CHECK(a.atomic_number() == 1);
+        CHECK(a.full_name() == "Hydrogen");
+        CHECK(a.covalent_radius() == 0.37);
+        CHECK(a.vdw_radius() == 1.2);
 
-        CHECK(a3.atomic_number() == -1);
-        CHECK(a3.full_name() == "");
-        CHECK(a3.covalent_radius() == -1.0);
-        CHECK(a3.vdw_radius() == -1.0);
+        CHECK(b.atomic_number() == -1);
+        CHECK(b.full_name() == "");
+        CHECK(b.covalent_radius() == -1.0);
+        CHECK(b.vdw_radius() == -1.0);
+
+        CHECK(d.atomic_number() == -1);
+        CHECK(d.full_name() == "");
+        CHECK(d.covalent_radius() == -1.0);
+        CHECK(d.vdw_radius() == -1.0);
     }
 }

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -8,27 +8,27 @@ using namespace chemfiles;
 TEST_CASE("Use the Atom type", "[Atoms]"){
     Atom a("H");
     Atom b;
-    Atom c("C", "C1");
-    Atom d("", "Label only");
+    Atom c("C1", "C");
+    Atom d("name only", "");
 
     SECTION("Constructors") {
-        CHECK(a.label() == "H");
-        CHECK(a.element() == "H");
+        CHECK(a.name() == "H");
+        CHECK(a.type() == "H");
         CHECK(a.mass() == 1.008);
         CHECK(a.charge() == 0);
 
-        CHECK(b.label() == "");
-        CHECK(b.element() == "");
+        CHECK(b.name() == "");
+        CHECK(b.type() == "");
         CHECK(b.mass() == 0);
         CHECK(b.charge() == 0);
 
-        CHECK(c.label() == "C1");
-        CHECK(c.element() == "C");
+        CHECK(c.name() == "C1");
+        CHECK(c.type() == "C");
         CHECK(c.mass() == 12.011);
         CHECK(c.charge() == 0);
 
-        CHECK(d.label() == "Label only");
-        CHECK(d.element() == "");
+        CHECK(d.name() == "name only");
+        CHECK(d.type() == "");
         CHECK(d.mass() == 0);
         CHECK(d.charge() == 0);
     }
@@ -44,13 +44,13 @@ TEST_CASE("Use the Atom type", "[Atoms]"){
         atom.set_charge(-2);
         CHECK(atom.charge() == -2);
 
-        CHECK(atom.label() == "");
-        atom.set_label("HE22");
-        CHECK(atom.label() == "HE22");
+        CHECK(atom.name() == "");
+        atom.set_name("HE22");
+        CHECK(atom.name() == "HE22");
 
-        CHECK(atom.element() == "");
-        atom.set_element("foo");
-        CHECK(atom.element() == "foo");
+        CHECK(atom.type() == "");
+        atom.set_type("foo");
+        CHECK(atom.type() == "foo");
     }
 
     SECTION("Elements properties") {

--- a/tests/c/atom.c
+++ b/tests/c/atom.c
@@ -20,13 +20,13 @@ int main() {
     assert(!chfl_atom_charge(a, &charge));
     assert(fabs(charge) < 1e-6);
 
-    char element[32];
-    assert(!chfl_atom_element(a, element, sizeof(element)));
-    assert(strcmp(element, "He") == 0);
+    char type[32];
+    assert(!chfl_atom_type(a, type, sizeof(type)));
+    assert(strcmp(type, "He") == 0);
 
-    char label[32];
-    assert(!chfl_atom_label(a, label, sizeof(label)));
-    assert(strcmp(label, "He") == 0);
+    char name[32];
+    assert(!chfl_atom_name(a, name, sizeof(name)));
+    assert(strcmp(name, "He") == 0);
 
     assert(!chfl_atom_set_mass(a, 678));
     assert(!chfl_atom_mass(a, &mass));
@@ -36,16 +36,16 @@ int main() {
     assert(!chfl_atom_charge(a, &charge));
     assert(fabs(charge + 1.5) < 1e-6);
 
-    assert(!chfl_atom_set_element(a, "Zn"));
-    assert(!chfl_atom_element(a, element, sizeof(element)));
-    assert(strcmp(element, "Zn") == 0);
+    assert(!chfl_atom_set_type(a, "Zn"));
+    assert(!chfl_atom_type(a, type, sizeof(type)));
+    assert(strcmp(type, "Zn") == 0);
 
-    assert(!chfl_atom_set_label(a, "HB2"));
-    assert(!chfl_atom_label(a, label, sizeof(label)));
-    assert(strcmp(label, "HB2") == 0);
+    assert(!chfl_atom_set_name(a, "HB2"));
+    assert(!chfl_atom_name(a, name, sizeof(name)));
+    assert(strcmp(name, "HB2") == 0);
 
-    assert(!chfl_atom_full_name(a, element, sizeof(element)));
-    assert(strcmp(element, "Zinc") == 0);
+    assert(!chfl_atom_full_name(a, name, sizeof(name)));
+    assert(strcmp(name, "Zinc") == 0);
 
     double radius=0;
     assert(!chfl_atom_vdw_radius(a, &radius));

--- a/tests/c/atom.c
+++ b/tests/c/atom.c
@@ -57,14 +57,6 @@ int main() {
     assert(!chfl_atom_atomic_number(a, &number));
     assert(number == 30);
 
-    chfl_atom_type_t type;
-    assert(!chfl_atom_type(a, &type));
-    assert(type == CHFL_ATOM_ELEMENT);
-
-    assert(!chfl_atom_set_type(a, CHFL_ATOM_DUMMY));
-    assert(!chfl_atom_type(a, &type));
-    assert(type == CHFL_ATOM_DUMMY);
-
     assert(!chfl_atom_free(a));
 
     return EXIT_SUCCESS;

--- a/tests/c/frame.c
+++ b/tests/c/frame.c
@@ -99,9 +99,9 @@ int main() {
 
     topology = chfl_topology_from_frame(frame);
     CHFL_ATOM* atom = chfl_atom_from_topology(topology, 0);
-    char element[32];
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "Zn") == 0);
+    char type[32];
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "Zn") == 0);
     assert(!chfl_atom_free(atom));
 
     atom = chfl_atom_from_topology(topology, 10000);
@@ -109,8 +109,8 @@ int main() {
     assert(!chfl_topology_free(topology));
 
     atom = chfl_atom_from_frame(frame, 1);
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "Ar") == 0);
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "Ar") == 0);
     assert(!chfl_atom_free(atom));
 
     atom = chfl_atom_from_frame(frame, 10000);

--- a/tests/c/selections.c
+++ b/tests/c/selections.c
@@ -12,7 +12,7 @@ static bool find_match(const chfl_match_t* matches, uint64_t n_matches, chfl_mat
 int main() {
     silent_crash_handlers();
     CHFL_FRAME* frame = testing_frame();
-    CHFL_SELECTION* selection = chfl_selection("element O");
+    CHFL_SELECTION* selection = chfl_selection("name O");
 
     assert(frame != NULL);
     assert(selection != NULL);

--- a/tests/c/trajectory.c
+++ b/tests/c/trajectory.c
@@ -62,9 +62,9 @@ static void test_read() {
     assert(n == 0);
 
     CHFL_ATOM* atom = chfl_atom_from_topology(topology, 0);
-    char element[32];
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "O") == 0);
+    char type[32];
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "O") == 0);
     assert(!chfl_atom_free(atom));
     assert(!chfl_topology_free(topology));
 
@@ -98,8 +98,8 @@ static void test_read() {
 
     // Get the atom from a frame
     atom = chfl_atom_from_frame(frame, 1);
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "H") == 0);
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "H") == 0);
     assert(!chfl_atom_free(atom));
 
     // Guess the system topology
@@ -125,8 +125,8 @@ static void test_read() {
     assert(!chfl_trajectory_read_step(file, 10, frame));
 
     atom = chfl_atom_from_frame(frame, 1);
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "Cs") == 0);
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "Cs") == 0);
     assert(!chfl_atom_free(atom));
 
     assert(!chfl_trajectory_close(file));
@@ -136,15 +136,15 @@ static void test_read() {
     assert(!chfl_trajectory_set_topology_with_format(file, "data/xyz/topology.xyz.topology", "XYZ"));
     assert(!chfl_trajectory_read(file, frame));
     atom = chfl_atom_from_frame(frame, 0);
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "Zn") == 0);
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "Zn") == 0);
     assert(!chfl_atom_free(atom));
 
     assert(!chfl_trajectory_set_topology_file(file, "data/xyz/topology.xyz"));
     assert(!chfl_trajectory_read(file, frame));
     atom = chfl_atom_from_frame(frame, 0);
-    assert(!chfl_atom_element(atom, element, sizeof(element)));
-    assert(strcmp(element, "Zn") == 0);
+    assert(!chfl_atom_type(atom, type, sizeof(type)));
+    assert(strcmp(type, "Zn") == 0);
     assert(!chfl_atom_free(atom));
 
     assert(!chfl_trajectory_close(file));

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -40,11 +40,11 @@ TEST_CASE("Read files in PDB format", "[Molfile]"){
 
         CHECK(topology.natoms() == 65);
 
-        CHECK(topology[0].element() == "Zn");
-        CHECK(topology[1].element() == "O");
+        CHECK(topology[0].type() == "Zn");
+        CHECK(topology[1].type() == "O");
 
-        CHECK(topology[0].label() == "ZN");
-        CHECK(topology[1].label() == "O");
+        CHECK(topology[0].name() == "ZN");
+        CHECK(topology[1].name() == "O");
 
         CHECK(topology.bonds().size() == 68);
 

--- a/tests/formats/tng.cpp
+++ b/tests/formats/tng.cpp
@@ -49,12 +49,12 @@ TEST_CASE("Read files in TNG format", "[TNG]"){
         auto topology = file.read().topology();
 
         CHECK(topology.natoms() == 15);
-        CHECK(topology[0].label() == "O");
-        CHECK(topology[0].element() == "O");
-        CHECK(topology[1].label() == "HO1");
-        CHECK(topology[1].element() == "H");
-        CHECK(topology[2].label() == "HO2");
-        CHECK(topology[2].element() == "H");
+        CHECK(topology[0].name() == "O");
+        CHECK(topology[0].type() == "O");
+        CHECK(topology[1].name() == "HO1");
+        CHECK(topology[1].type() == "H");
+        CHECK(topology[2].name() == "HO2");
+        CHECK(topology[2].type() == "H");
 
         CHECK(topology.residues().size() == 5);
         auto residue = topology.residues()[0];

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -249,39 +249,39 @@ TEST_CASE("Parsing", "[selection]") {
         ast = "and -> index($1) == 1\n    -> or -> index($1) == 1\n          -> index($1) == 1";
         CHECK(parse(tokenize("index == 1 and (index == 1 or index == 1)"))->print() == ast);
 
-        CHECK_THROWS_AS(parse(tokenize("element H and")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("element <= 4 and")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("and element H")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("and element <= 4")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("element <= 4 or")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("or element <= 4")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("name H and")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("name <= 4 and")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("and name H")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("and name <= 4")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("name <= 4 or")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("or name <= 4")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("not")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("not element <= 4")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("not name <= 4")), SelectionError);
     }
 
     SECTION("all & none") {
         CHECK(parse(tokenize("all"))->print() == "all");
         CHECK(parse(tokenize("none"))->print() == "none");
 
-        auto ast = "or -> all\n   -> element($1) == H";
-        CHECK(parse(tokenize("all or element H"))->print() == ast);
+        auto ast = "or -> all\n   -> name($1) == H";
+        CHECK(parse(tokenize("all or name H"))->print() == ast);
 
-        ast = "or -> element($1) == H\n   -> none";
-        CHECK(parse(tokenize("element H or none"))->print() == ast);
+        ast = "or -> name($1) == H\n   -> none";
+        CHECK(parse(tokenize("name H or none"))->print() == ast);
 
         CHECK(parse(tokenize("not all"))->print() == "not all");
     }
 
-    SECTION("element") {
-        CHECK(parse(tokenize("element == goo"))->print() == "element($1) == goo");
-        CHECK(parse(tokenize("element($1) == goo"))->print() == "element($1) == goo");
-        CHECK(parse(tokenize("element goo"))->print() == "element($1) == goo");
-        CHECK(parse(tokenize("element($3) goo"))->print() == "element($3) == goo");
-        CHECK(parse(tokenize("element != goo"))->print() == "element($1) != goo");
+    SECTION("type") {
+        CHECK(parse(tokenize("type == goo"))->print() == "type($1) == goo");
+        CHECK(parse(tokenize("type($1) == goo"))->print() == "type($1) == goo");
+        CHECK(parse(tokenize("type goo"))->print() == "type($1) == goo");
+        CHECK(parse(tokenize("type($3) goo"))->print() == "type($3) == goo");
+        CHECK(parse(tokenize("type != goo"))->print() == "type($1) != goo");
 
-        CHECK_THROWS_AS(parse(tokenize("element < bar")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("element >= bar")), SelectionError);
-        CHECK_THROWS_AS(parse(tokenize("element == 45")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("type < bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("type >= bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("type == 45")), SelectionError);
     }
 
     SECTION("name") {
@@ -338,12 +338,12 @@ TEST_CASE("Parsing", "[selection]") {
     }
 
     SECTION("Multiple selections") {
-        auto ast = "and -> mass($1) < 4.000000\n    -> element($3) == O";
-        CHECK(parse(tokenize("mass($1) < 4 and element($3) O"))->print() == ast);
-        ast = "element($4) != Cs";
-        CHECK(parse(tokenize("element($4) != Cs"))->print() == ast);
-        ast = "or -> index($1) < 4\n   -> element($2) == H";
-        CHECK(parse(tokenize("index($1) < 4 or element($2) H"))->print() == ast);
+        auto ast = "and -> mass($1) < 4.000000\n    -> name($3) == O";
+        CHECK(parse(tokenize("mass($1) < 4 and name($3) O"))->print() == ast);
+        ast = "name($4) != Cs";
+        CHECK(parse(tokenize("name($4) != Cs"))->print() == ast);
+        ast = "or -> index($1) < 4\n   -> name($2) == H";
+        CHECK(parse(tokenize("index($1) < 4 or name($2) H"))->print() == ast);
     }
 
     SECTION("Parsing errors") {
@@ -352,7 +352,7 @@ TEST_CASE("Parsing", "[selection]") {
             "index == 23 6",
             "index == 23 njzk",
             "index == 23 !=",
-            "index == 23 element == 1",
+            "index == 23 name == 1",
             /* Bad usage of the boolean operators */
             "index == 23 and ",
             "and index == 23",
@@ -361,12 +361,18 @@ TEST_CASE("Parsing", "[selection]") {
             "or index == 23",
             "not or index == 23",
             "index == 23 not index == 1",
-            /* element name expressions */
-            "element == <",
-            "element == 56",
-            "element < foo",
-            "element 56",
-            "element >=",
+            /* name expressions */
+            "name == <",
+            "name == 56",
+            "name < foo",
+            "name 56",
+            "name >=",
+            /* type expressions */
+            "type == <",
+            "type == 56",
+            "type < foo",
+            "type 56",
+            "type >=",
             /* index expressions */
             "index == <",
             "index == bar",

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -212,6 +212,10 @@ TEST_CASE("Lexing", "[selection]") {
             "è",
             "à",
             "ü",
+            "∀",
+            "ζ",
+            "Ｒ", // weird full width UTF-8 character
+            "形",
             "/",
             "^",
             "`",
@@ -307,6 +311,18 @@ TEST_CASE("Parsing", "[selection]") {
 
         CHECK_THROWS_AS(parse(tokenize("index == bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("index >= 42.3")), SelectionError);
+    }
+
+    SECTION("resname") {
+        CHECK(parse(tokenize("resname == goo"))->print() == "resname($1) == goo");
+        CHECK(parse(tokenize("resname($1) == goo"))->print() == "resname($1) == goo");
+        CHECK(parse(tokenize("resname goo"))->print() == "resname($1) == goo");
+        CHECK(parse(tokenize("resname($3) goo"))->print() == "resname($3) == goo");
+        CHECK(parse(tokenize("resname != goo"))->print() == "resname($1) != goo");
+
+        CHECK_THROWS_AS(parse(tokenize("resname < bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("resname >= bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("resname == 45")), SelectionError);
     }
 
     SECTION("Mass") {

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -300,7 +300,7 @@ TEST_CASE("Parsing", "[selection]") {
         CHECK_THROWS_AS(parse(tokenize("name == 45")), SelectionError);
     }
 
-    SECTION("Index") {
+    SECTION("index") {
         CHECK(parse(tokenize("index == 4"))->print() == "index($1) == 4");
         CHECK(parse(tokenize("index($1) == 4"))->print() == "index($1) == 4");
         CHECK(parse(tokenize("index 5"))->print() == "index($1) == 5");
@@ -325,7 +325,20 @@ TEST_CASE("Parsing", "[selection]") {
         CHECK_THROWS_AS(parse(tokenize("resname == 45")), SelectionError);
     }
 
-    SECTION("Mass") {
+    SECTION("resid") {
+        CHECK(parse(tokenize("resid == 4"))->print() == "resid($1) == 4");
+        CHECK(parse(tokenize("resid($1) == 4"))->print() == "resid($1) == 4");
+        CHECK(parse(tokenize("resid 5"))->print() == "resid($1) == 5");
+        CHECK(parse(tokenize("resid($2) 5"))->print() == "resid($2) == 5");
+
+        CHECK(parse(tokenize("resid <= 42"))->print() == "resid($1) <= 42");
+        CHECK(parse(tokenize("resid != 12"))->print() == "resid($1) != 12");
+
+        CHECK_THROWS_AS(parse(tokenize("resid == bar")), SelectionError);
+        CHECK_THROWS_AS(parse(tokenize("resid >= 42.3")), SelectionError);
+    }
+
+    SECTION("mass") {
         CHECK(parse(tokenize("mass == 4"))->print() == "mass($1) == 4.000000");
         CHECK(parse(tokenize("mass($1) == 4"))->print() == "mass($1) == 4.000000");
         CHECK(parse(tokenize("mass 5"))->print() == "mass($1) == 5.000000");

--- a/tests/selections.cpp
+++ b/tests/selections.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Atoms selections", "[selection]") {
         CHECK(sel.list(frame) == res);
     }
 
-    SECTION("Name") {
+    SECTION("name") {
         auto sel = Selection("name O");
         auto res = std::vector<size_t>{1, 2};
         CHECK(sel.list(frame) == res);
@@ -60,6 +60,18 @@ TEST_CASE("Atoms selections", "[selection]") {
         sel = Selection("name H1");
         res = std::vector<size_t>{0};
         CHECK(sel.list(frame) == res);
+    }
+
+    SECTION("resname") {
+        auto sel = Selection("resname resime");
+        auto res = std::vector<size_t>{2, 3};
+        CHECK(sel.list(frame) == res);
+
+        sel = Selection("resname != resime");
+        CHECK(sel.list(frame).empty());
+
+        sel = Selection("resname == water");
+        CHECK(sel.list(frame).empty());
     }
 
     SECTION("positions") {
@@ -192,6 +204,11 @@ Frame testing_frame() {
     topology.add_bond(0, 1);
     topology.add_bond(1, 2);
     topology.add_bond(2, 3);
+
+    auto res = Residue("resime", 3);
+    res.add_atom(2);
+    res.add_atom(3);
+    topology.add_residue(res);
 
     auto frame = Frame(topology);
     int i = 0;

--- a/tests/selections.cpp
+++ b/tests/selections.cpp
@@ -74,6 +74,19 @@ TEST_CASE("Atoms selections", "[selection]") {
         CHECK(sel.list(frame).empty());
     }
 
+    SECTION("resid") {
+        auto sel = Selection("resid 3");
+        auto res = std::vector<size_t>{2, 3};
+        CHECK(sel.list(frame) == res);
+
+        sel = Selection("resid < 5");
+        res = std::vector<size_t>{2, 3};
+        CHECK(sel.list(frame) == res);
+
+        sel = Selection("resid != 3");
+        CHECK(sel.list(frame).empty());
+    }
+
     SECTION("positions") {
         auto sel = Selection("x < 2");
         auto res = std::vector<size_t>{0, 1};

--- a/tests/selections.cpp
+++ b/tests/selections.cpp
@@ -38,17 +38,17 @@ TEST_CASE("Atoms selections", "[selection]") {
         CHECK(sel.list(frame) == res);
     }
 
-    SECTION("element") {
-        auto sel = Selection("element O");
+    SECTION("type") {
+        auto sel = Selection("type O");
         auto res = std::vector<size_t>{1, 2};
         CHECK(sel.list(frame) == res);
 
-        sel = Selection("element != O");
+        sel = Selection("type != O");
         res = std::vector<size_t>{0, 3};
         CHECK(sel.list(frame) == res);
     }
 
-    SECTION("element") {
+    SECTION("Name") {
         auto sel = Selection("name O");
         auto res = std::vector<size_t>{1, 2};
         CHECK(sel.list(frame) == res);
@@ -95,7 +95,7 @@ TEST_CASE("Atoms selections", "[selection]") {
         auto res = std::vector<size_t>{2};
         CHECK(sel.list(frame) == res);
 
-        sel = Selection("index > 1 and element H");
+        sel = Selection("index > 1 and type H");
         res = std::vector<size_t>{3};
         CHECK(sel.list(frame) == res);
     }
@@ -105,7 +105,7 @@ TEST_CASE("Atoms selections", "[selection]") {
         auto res = std::vector<size_t>{0, 3};
         CHECK(sel.list(frame) == res);
 
-        sel = Selection("index == 1 or element H");
+        sel = Selection("index == 1 or type H");
         res = std::vector<size_t>{0, 1, 3};
         CHECK(sel.list(frame) == res);
     }
@@ -115,7 +115,7 @@ TEST_CASE("Atoms selections", "[selection]") {
         auto res = std::vector<size_t>{0, 1, 2};
         CHECK(sel.list(frame) == res);
 
-        sel = Selection("not element H");
+        sel = Selection("not type H");
         res = std::vector<size_t>{1, 2};
         CHECK(sel.list(frame) == res);
     }
@@ -129,7 +129,7 @@ TEST_CASE("Atoms selections", "[selection]") {
         res = std::vector<size_t>{};
         CHECK(sel.list(frame) == res);
 
-        sel = Selection("atoms :not element H");
+        sel = Selection("atoms :not type H");
         res = std::vector<size_t>{1, 2};
         CHECK(sel.list(frame) == res);
 
@@ -184,7 +184,7 @@ TEST_CASE("Multiple selections", "[selection]") {
 
 Frame testing_frame() {
     auto topology = Topology();
-    topology.append(Atom("H", "H1"));
+    topology.append(Atom("H1", "H"));
     topology.append(Atom("O"));
     topology.append(Atom("O"));
     topology.append(Atom("H"));

--- a/tests/topology.cpp
+++ b/tests/topology.cpp
@@ -7,10 +7,12 @@ TEST_CASE("Use the Topology class", "[Topology]") {
     auto topology = Topology();
 
     topology.append(Atom("H"));
-    CHECK(topology[0].element() == "H");
+    CHECK(topology[0].name() == "H");
+    CHECK(topology[0].type() == "H");
 
     topology.append(Atom("H"));
-    CHECK(topology[1].element() == "H");
+    CHECK(topology[1].name() == "H");
+    CHECK(topology[1].type() == "H");
 
     topology.add_bond(0, 1);
     CHECK(topology.bonds().size() == 1);

--- a/tests/topology.cpp
+++ b/tests/topology.cpp
@@ -7,12 +7,10 @@ TEST_CASE("Use the Topology class", "[Topology]") {
     auto topology = Topology();
 
     topology.append(Atom("H"));
-    CHECK(topology[0].type() == Atom::ELEMENT);
     CHECK(topology[0].element() == "H");
 
     topology.append(Atom("H"));
-    CHECK(topology[0].type() == Atom::ELEMENT);
-    CHECK(topology[0].element() == "H");
+    CHECK(topology[1].element() == "H");
 
     topology.add_bond(0, 1);
     CHECK(topology.bonds().size() == 1);


### PR DESCRIPTION
Some work to make the atoms/residues more usable
- b828926 removes the `Atom::type`, which was not used anywhere;
- 778cf74 rename `label => name` and `element => type`. @pgbarletta, what do you think of this? This match the naming of PDB and TNG formats, and looks like it is also the names used in most software.
- 1831d4a and  0e2c384 add `resname` and `resid` selections.

Also @pgbarletta if/when you update to the this version, take care that the order of parameters of `Atom` constructor where inverted.
