### PR TITLE
Change the selections variables syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   atomic data, positions and velocities.
 * Add "Selection::string" function and the corresponding `chfl_selection_string`
   to get the string used to build a selection.
+* Selection variables uses the `#3` syntax instead of the `$3` syntax to allow
+  passing selection string as shell arguments.
 
 ### Changes in supported formats
 

--- a/doc/selections.rst
+++ b/doc/selections.rst
@@ -20,7 +20,7 @@ one, two, three or four independent atoms; and ``bonds``, ``angles`` and
 
 A selection is built using a context and a set of constraints separated by a
 colon. For example, ``atoms: name == H`` will select all atoms whose name is
-``H``. ``angles: name($2) == O and distance($1, $3) < 1.5`` will select all sets
+``H``. ``angles: name(#2) == O and distance(#1, #3) < 1.5`` will select all sets
 of three bonded atoms forming an angle such that the name of the second atom is
 ``O`` and the distance between the first and the third atom is less than 1.5.
 
@@ -29,19 +29,19 @@ which can be applied to one or more atoms. The ``name``, ``mass`` and ``z``
 selectors are applied to one atom and give the name, the mass and the z
 coordinate of this atom. Other selectors can be applied to two or more atoms,
 like ``distance`` or ``angle``. When using a selection with more than one atom,
-selectors refers to the different atoms with the ``$1``, ``$2``, ``$3`` or
-``$4`` variables: ``name($3)`` will give the name of the third atom, and so on.
+selectors refers to the different atoms with the ``#1``, ``#2``, ``#3`` or
+``#4`` variables: ``name(#3)`` will give the name of the third atom, and so on.
 Then we compare the selector result for a given atom with a value, either from
-another selector --- ``name($1) != name($2)`` --- or a literal value ---
-``mass($2) < 4``. The comparison operators are ``==`` (equals); ``!=`` (not
+another selector --- ``name(#1) != name(#2)`` --- or a literal value ---
+``mass(#2) < 4``. The comparison operators are ``==`` (equals); ``!=`` (not
 equals); ``<`` (less than), ``<=`` (less or equals); ``>`` (more than); and ``>=``
 (more or equals).
 
 Finally, constraints are combined with boolean operators. The ``and`` operator
 is true if both side of the expression are true; the ``or`` operator is true if
 either side of the expression is true; and the ``not`` operator reverse true to
-false and false to true. ``name($1) == H and not x($1) < 5.0`` and ``(z($2) < 45
-and name($4) == O) or name($1) == C`` are complex selections using booleans
+false and false to true. ``name(#1) == H and not x(#1) < 5.0`` and ``(z(#2) < 45
+and name(#4) == O) or name(#1) == C`` are complex selections using booleans
 operators.
 
 In order to remove ambiguity when using multiple boolean operations, selections
@@ -77,7 +77,7 @@ Elisions
 
 This multiple selection language can be a bit verbose for simpler cases, so it
 is sometimes allowed to remove parts of the selection. First, in the ``atom``
-context, the ``$1`` variable is optional, and ``atom: name($1) == H`` is
+context, the ``#1`` variable is optional, and ``atom: name(#1) == H`` is
 equivalent to ``atom: name == H``.
 
 Then, if no context is given, the ``atom`` context is used. This make ``atom:
@@ -86,6 +86,6 @@ name == H`` equivalent to ``name == H``.
 And finally, the ``==`` comparison operator is the default one if no operator is
 precised. This means that we can write ``name H`` instead of ``name == H``.
 
-At the end, using all these elisions rules, ``atom: name($1) == H or name($1) ==
-O`` is equivalent to ``name H or name O``; and ``bond: name($1) == C and
-mass($2) == 4.5`` is equivalent to ``bond: name($1) C and mass($2) 4.5``.
+At the end, using all these elisions rules, ``atom: name(#1) == H or name(#1) ==
+O`` is equivalent to ``name H or name O``; and ``bond: name(#1) == C and
+mass(#2) == 4.5`` is equivalent to ``bond: name(#1) C and mass(#2) 4.5``.

--- a/include/chemfiles/selections/lexer.hpp
+++ b/include/chemfiles/selections/lexer.hpp
@@ -44,7 +44,7 @@ public:
         OR,        //! "or" token
         IDENT,     //! Generic identifier
         NUMBER,    //! Number
-        VARIABLE,  //! "$(\d)" token
+        VARIABLE,  //! "#(\d+)" token
     };
 
     //! Basic copy and move constructors

--- a/src/selections/expr.cpp
+++ b/src/selections/expr.cpp
@@ -92,7 +92,7 @@ Ast parse<NoneExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 /****************************************************************************************/
 std::string TypeExpr::print(unsigned /*unused*/) const {
     auto op = equals_ ? "==" : "!=";
-    return "type($" + std::to_string(argument_ + 1) + ") " + op + " " + type_;
+    return "type(#" + std::to_string(argument_ + 1) + ") " + op + " " + type_;
 }
 
 std::vector<bool> TypeExpr::evaluate(const Frame& frame, const std::vector<Match>& matches) const {
@@ -131,7 +131,7 @@ Ast parse<TypeExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 /****************************************************************************************/
 std::string NameExpr::print(unsigned /*unused*/) const {
     auto op = equals_ ? "==" : "!=";
-    return "name($" + std::to_string(argument_ + 1) + ") " + op + " " + name_;
+    return "name(#" + std::to_string(argument_ + 1) + ") " + op + " " + name_;
 }
 
 std::vector<bool> NameExpr::evaluate(const Frame& frame, const std::vector<Match>& matches) const {
@@ -169,7 +169,7 @@ Ast parse<NameExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 /****************************************************************************************/
 std::string ResnameExpr::print(unsigned /*unused*/) const {
     auto op = equals_ ? "==" : "!=";
-    return "resname($" + std::to_string(argument_ + 1) + ") " + op + " " + name_;
+    return "resname(#" + std::to_string(argument_ + 1) + ") " + op + " " + name_;
 }
 
 std::vector<bool> ResnameExpr::evaluate(const Frame& frame, const std::vector<Match>& matches) const {
@@ -213,7 +213,7 @@ Ast parse<ResnameExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 
 /****************************************************************************************/
 std::string ResidExpr::print(unsigned /*unused*/) const {
-    return "resid($" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
+    return "resid(#" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
            " " + std::to_string(id_);
 }
 
@@ -263,7 +263,7 @@ Ast parse<ResidExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 
 /****************************************************************************************/
 std::string PositionExpr::print(unsigned /*unused*/) const {
-    return coord_.to_string() + "($" + std::to_string(argument_ + 1) + ") " +
+    return coord_.to_string() + "(#" + std::to_string(argument_ + 1) + ") " +
            binop_str(op_) + " " + std::to_string(val_);
 }
 
@@ -307,7 +307,7 @@ Ast parse<PositionExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 
 /****************************************************************************************/
 std::string VelocityExpr::print(unsigned /*unused*/) const {
-    return "v" + coord_.to_string() + "($" + std::to_string(argument_ + 1) +
+    return "v" + coord_.to_string() + "(#" + std::to_string(argument_ + 1) +
             ") " + binop_str(op_) + " " + std::to_string(val_);
 }
 
@@ -356,7 +356,7 @@ Ast parse<VelocityExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 
 /****************************************************************************************/
 std::string IndexExpr::print(unsigned /*unused*/) const {
-    return "index($" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
+    return "index(#" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
            " " + std::to_string(val_);
 }
 
@@ -399,7 +399,7 @@ Ast parse<IndexExpr>(token_iterator_t& begin, const token_iterator_t& end) {
 
 /****************************************************************************************/
 std::string MassExpr::print(unsigned /*unused*/) const {
-    return "mass($" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
+    return "mass(#" + std::to_string(argument_ + 1) + ") " + binop_str(op_) +
            " " + std::to_string(val_);
 }
 

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -39,7 +39,7 @@ std::string Token::str() const {
     case Token::COMMA:
         return ",";
     case Token::VARIABLE:
-        return "$" + std::to_string(variable_);
+        return "#" + std::to_string(variable_);
     case Token::EQ:
         return "==";
     case Token::NEQ:
@@ -98,7 +98,7 @@ static std::vector<std::string> split(const std::string& data) {
     std::string token;
     std::vector<std::string> tokens;
     for (auto c : data) {
-        if (c == '(' || c == ')' || c == '$' || c == ',') {
+        if (c == '(' || c == ')' || c == '#' || c == ',') {
             // Handle some tokens that may not be separated from the others
             // tokens by spaces, by splitting them manually.
             if (token.length() != 0) {
@@ -171,9 +171,9 @@ std::vector<Token> selections::tokenize(const std::string& input) {
         } else if (word == ">=") {
             tokens.emplace_back(Token(Token::GE));
             continue;
-        } else if (word == "$") {
+        } else if (word == "#") {
             if (i == splited.size() - 1) {
-                throw SelectionError("Missing value after '$'");
+                throw SelectionError("Missing value after '#'");
             }
             // Get the next word and try to parse a number out of it
             word = splited[++i];

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -147,7 +147,7 @@ static std::vector<Token> add_missing_equals(std::vector<Token> stream) {
                     continue;
                 }
             } else {
-                // Skip the following possible tokens: '(' - '$x' - ')'
+                // Skip the following possible tokens: '(' - '#x' - ')'
                 next = it + 4;
                 if (next < stream.cend() && !next->is_operator() &&
                     it[1].type() == Token::LPAREN && it[2].is_variable() &&

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -183,15 +183,15 @@ TEST_CASE("Lexing", "[selection]") {
     }
 
     SECTION("Functions") {
-        CHECK(tokenize("$9")[0].type() == Token::VARIABLE);
-        CHECK(tokenize("$ 9")[0].type() == Token::VARIABLE);
-        CHECK(tokenize("$255")[0].type() == Token::VARIABLE);
+        CHECK(tokenize("#9")[0].type() == Token::VARIABLE);
+        CHECK(tokenize("# 9")[0].type() == Token::VARIABLE);
+        CHECK(tokenize("#255")[0].type() == Token::VARIABLE);
 
-        CHECK_THROWS_AS(tokenize("$ gabo"), SelectionError);
-        CHECK_THROWS_AS(tokenize("$"), SelectionError);
-        CHECK_THROWS_AS(tokenize("78 $"), SelectionError);
-        CHECK_THROWS_AS(tokenize("bhics $"), SelectionError);
-        CHECK_THROWS_AS(tokenize("$256"), SelectionError);
+        CHECK_THROWS_AS(tokenize("# gabo"), SelectionError);
+        CHECK_THROWS_AS(tokenize("#"), SelectionError);
+        CHECK_THROWS_AS(tokenize("78 #"), SelectionError);
+        CHECK_THROWS_AS(tokenize("bhics #"), SelectionError);
+        CHECK_THROWS_AS(tokenize("#256"), SelectionError);
 
         CHECK(tokenize(",")[0].type() == Token::COMMA);
         auto toks = tokenize(",bagyu");
@@ -235,22 +235,22 @@ TEST_CASE("Lexing", "[selection]") {
 TEST_CASE("Parsing", "[selection]") {
     // This section uses the pretty-printing of AST to check the parsing
     SECTION("Operators") {
-        auto ast = "and -> index($1) == 1\n    -> index($1) == 1";
+        auto ast = "and -> index(#1) == 1\n    -> index(#1) == 1";
         CHECK(parse(tokenize("index == 1 and index == 1"))->print() == ast);
 
-        ast = "or -> index($1) == 1\n   -> index($1) == 1";
+        ast = "or -> index(#1) == 1\n   -> index(#1) == 1";
         CHECK(parse(tokenize("index == 1 or index == 1"))->print() == ast);
 
-        ast = "not index($1) == 1";
+        ast = "not index(#1) == 1";
         CHECK(parse(tokenize("not index == 1"))->print() == ast);
 
-        ast = "and -> index($1) == 1\n    -> not index($1) == 1";
+        ast = "and -> index(#1) == 1\n    -> not index(#1) == 1";
         CHECK(parse(tokenize("index == 1 and not index == 1"))->print() == ast);
 
-        ast = "or -> and -> index($1) == 1\n          -> index($1) == 1\n   -> index($1) == 1";
+        ast = "or -> and -> index(#1) == 1\n          -> index(#1) == 1\n   -> index(#1) == 1";
         CHECK(parse(tokenize("index == 1 and index == 1 or index == 1"))->print() == ast);
 
-        ast = "and -> index($1) == 1\n    -> or -> index($1) == 1\n          -> index($1) == 1";
+        ast = "and -> index(#1) == 1\n    -> or -> index(#1) == 1\n          -> index(#1) == 1";
         CHECK(parse(tokenize("index == 1 and (index == 1 or index == 1)"))->print() == ast);
 
         CHECK_THROWS_AS(parse(tokenize("name H and")), SelectionError);
@@ -267,21 +267,21 @@ TEST_CASE("Parsing", "[selection]") {
         CHECK(parse(tokenize("all"))->print() == "all");
         CHECK(parse(tokenize("none"))->print() == "none");
 
-        auto ast = "or -> all\n   -> name($1) == H";
+        auto ast = "or -> all\n   -> name(#1) == H";
         CHECK(parse(tokenize("all or name H"))->print() == ast);
 
-        ast = "or -> name($1) == H\n   -> none";
+        ast = "or -> name(#1) == H\n   -> none";
         CHECK(parse(tokenize("name H or none"))->print() == ast);
 
         CHECK(parse(tokenize("not all"))->print() == "not all");
     }
 
     SECTION("type") {
-        CHECK(parse(tokenize("type == goo"))->print() == "type($1) == goo");
-        CHECK(parse(tokenize("type($1) == goo"))->print() == "type($1) == goo");
-        CHECK(parse(tokenize("type goo"))->print() == "type($1) == goo");
-        CHECK(parse(tokenize("type($3) goo"))->print() == "type($3) == goo");
-        CHECK(parse(tokenize("type != goo"))->print() == "type($1) != goo");
+        CHECK(parse(tokenize("type == goo"))->print() == "type(#1) == goo");
+        CHECK(parse(tokenize("type(#1) == goo"))->print() == "type(#1) == goo");
+        CHECK(parse(tokenize("type goo"))->print() == "type(#1) == goo");
+        CHECK(parse(tokenize("type(#3) goo"))->print() == "type(#3) == goo");
+        CHECK(parse(tokenize("type != goo"))->print() == "type(#1) != goo");
 
         CHECK_THROWS_AS(parse(tokenize("type < bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("type >= bar")), SelectionError);
@@ -289,11 +289,11 @@ TEST_CASE("Parsing", "[selection]") {
     }
 
     SECTION("name") {
-        CHECK(parse(tokenize("name == goo"))->print() == "name($1) == goo");
-        CHECK(parse(tokenize("name($1) == goo"))->print() == "name($1) == goo");
-        CHECK(parse(tokenize("name goo"))->print() == "name($1) == goo");
-        CHECK(parse(tokenize("name($3) goo"))->print() == "name($3) == goo");
-        CHECK(parse(tokenize("name != goo"))->print() == "name($1) != goo");
+        CHECK(parse(tokenize("name == goo"))->print() == "name(#1) == goo");
+        CHECK(parse(tokenize("name(#1) == goo"))->print() == "name(#1) == goo");
+        CHECK(parse(tokenize("name goo"))->print() == "name(#1) == goo");
+        CHECK(parse(tokenize("name(#3) goo"))->print() == "name(#3) == goo");
+        CHECK(parse(tokenize("name != goo"))->print() == "name(#1) != goo");
 
         CHECK_THROWS_AS(parse(tokenize("name < bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("name >= bar")), SelectionError);
@@ -301,24 +301,24 @@ TEST_CASE("Parsing", "[selection]") {
     }
 
     SECTION("index") {
-        CHECK(parse(tokenize("index == 4"))->print() == "index($1) == 4");
-        CHECK(parse(tokenize("index($1) == 4"))->print() == "index($1) == 4");
-        CHECK(parse(tokenize("index 5"))->print() == "index($1) == 5");
-        CHECK(parse(tokenize("index($2) 5"))->print() == "index($2) == 5");
+        CHECK(parse(tokenize("index == 4"))->print() == "index(#1) == 4");
+        CHECK(parse(tokenize("index(#1) == 4"))->print() == "index(#1) == 4");
+        CHECK(parse(tokenize("index 5"))->print() == "index(#1) == 5");
+        CHECK(parse(tokenize("index(#2) 5"))->print() == "index(#2) == 5");
 
-        CHECK(parse(tokenize("index <= 42"))->print() == "index($1) <= 42");
-        CHECK(parse(tokenize("index != 12"))->print() == "index($1) != 12");
+        CHECK(parse(tokenize("index <= 42"))->print() == "index(#1) <= 42");
+        CHECK(parse(tokenize("index != 12"))->print() == "index(#1) != 12");
 
         CHECK_THROWS_AS(parse(tokenize("index == bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("index >= 42.3")), SelectionError);
     }
 
     SECTION("resname") {
-        CHECK(parse(tokenize("resname == goo"))->print() == "resname($1) == goo");
-        CHECK(parse(tokenize("resname($1) == goo"))->print() == "resname($1) == goo");
-        CHECK(parse(tokenize("resname goo"))->print() == "resname($1) == goo");
-        CHECK(parse(tokenize("resname($3) goo"))->print() == "resname($3) == goo");
-        CHECK(parse(tokenize("resname != goo"))->print() == "resname($1) != goo");
+        CHECK(parse(tokenize("resname == goo"))->print() == "resname(#1) == goo");
+        CHECK(parse(tokenize("resname(#1) == goo"))->print() == "resname(#1) == goo");
+        CHECK(parse(tokenize("resname goo"))->print() == "resname(#1) == goo");
+        CHECK(parse(tokenize("resname(#3) goo"))->print() == "resname(#3) == goo");
+        CHECK(parse(tokenize("resname != goo"))->print() == "resname(#1) != goo");
 
         CHECK_THROWS_AS(parse(tokenize("resname < bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("resname >= bar")), SelectionError);
@@ -326,39 +326,39 @@ TEST_CASE("Parsing", "[selection]") {
     }
 
     SECTION("resid") {
-        CHECK(parse(tokenize("resid == 4"))->print() == "resid($1) == 4");
-        CHECK(parse(tokenize("resid($1) == 4"))->print() == "resid($1) == 4");
-        CHECK(parse(tokenize("resid 5"))->print() == "resid($1) == 5");
-        CHECK(parse(tokenize("resid($2) 5"))->print() == "resid($2) == 5");
+        CHECK(parse(tokenize("resid == 4"))->print() == "resid(#1) == 4");
+        CHECK(parse(tokenize("resid(#1) == 4"))->print() == "resid(#1) == 4");
+        CHECK(parse(tokenize("resid 5"))->print() == "resid(#1) == 5");
+        CHECK(parse(tokenize("resid(#2) 5"))->print() == "resid(#2) == 5");
 
-        CHECK(parse(tokenize("resid <= 42"))->print() == "resid($1) <= 42");
-        CHECK(parse(tokenize("resid != 12"))->print() == "resid($1) != 12");
+        CHECK(parse(tokenize("resid <= 42"))->print() == "resid(#1) <= 42");
+        CHECK(parse(tokenize("resid != 12"))->print() == "resid(#1) != 12");
 
         CHECK_THROWS_AS(parse(tokenize("resid == bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("resid >= 42.3")), SelectionError);
     }
 
     SECTION("mass") {
-        CHECK(parse(tokenize("mass == 4"))->print() == "mass($1) == 4.000000");
-        CHECK(parse(tokenize("mass($1) == 4"))->print() == "mass($1) == 4.000000");
-        CHECK(parse(tokenize("mass 5"))->print() == "mass($1) == 5.000000");
-        CHECK(parse(tokenize("mass($2) 5"))->print() == "mass($2) == 5.000000");
+        CHECK(parse(tokenize("mass == 4"))->print() == "mass(#1) == 4.000000");
+        CHECK(parse(tokenize("mass(#1) == 4"))->print() == "mass(#1) == 4.000000");
+        CHECK(parse(tokenize("mass 5"))->print() == "mass(#1) == 5.000000");
+        CHECK(parse(tokenize("mass(#2) 5"))->print() == "mass(#2) == 5.000000");
 
-        CHECK(parse(tokenize("mass <= 42"))->print() == "mass($1) <= 42.000000");
-        CHECK(parse(tokenize("mass != 12"))->print() == "mass($1) != 12.000000");
+        CHECK(parse(tokenize("mass <= 42"))->print() == "mass(#1) <= 42.000000");
+        CHECK(parse(tokenize("mass != 12"))->print() == "mass(#1) != 12.000000");
 
         CHECK_THROWS_AS(parse(tokenize("mass <= bar")), SelectionError);
     }
 
     SECTION("Position & velocity") {
-        CHECK(parse(tokenize("x == 4"))->print() == "x($1) == 4.000000");
-        CHECK(parse(tokenize("x($1) == 4"))->print() == "x($1) == 4.000000");
-        CHECK(parse(tokenize("y < 4"))->print() == "y($1) < 4.000000");
-        CHECK(parse(tokenize("z >= 4"))->print() == "z($1) >= 4.000000");
+        CHECK(parse(tokenize("x == 4"))->print() == "x(#1) == 4.000000");
+        CHECK(parse(tokenize("x(#1) == 4"))->print() == "x(#1) == 4.000000");
+        CHECK(parse(tokenize("y < 4"))->print() == "y(#1) < 4.000000");
+        CHECK(parse(tokenize("z >= 4"))->print() == "z(#1) >= 4.000000");
 
-        CHECK(parse(tokenize("vx == 4"))->print() == "vx($1) == 4.000000");
-        CHECK(parse(tokenize("vy < 4"))->print() == "vy($1) < 4.000000");
-        CHECK(parse(tokenize("vz >= 4"))->print() == "vz($1) >= 4.000000");
+        CHECK(parse(tokenize("vx == 4"))->print() == "vx(#1) == 4.000000");
+        CHECK(parse(tokenize("vy < 4"))->print() == "vy(#1) < 4.000000");
+        CHECK(parse(tokenize("vz >= 4"))->print() == "vz(#1) >= 4.000000");
 
         CHECK_THROWS_AS(parse(tokenize("x <= bar")), SelectionError);
         CHECK_THROWS_AS(parse(tokenize("vy > bar")), SelectionError);
@@ -367,12 +367,12 @@ TEST_CASE("Parsing", "[selection]") {
     }
 
     SECTION("Multiple selections") {
-        auto ast = "and -> mass($1) < 4.000000\n    -> name($3) == O";
-        CHECK(parse(tokenize("mass($1) < 4 and name($3) O"))->print() == ast);
-        ast = "name($4) != Cs";
-        CHECK(parse(tokenize("name($4) != Cs"))->print() == ast);
-        ast = "or -> index($1) < 4\n   -> name($2) == H";
-        CHECK(parse(tokenize("index($1) < 4 or name($2) H"))->print() == ast);
+        auto ast = "and -> mass(#1) < 4.000000\n    -> name(#3) == O";
+        CHECK(parse(tokenize("mass(#1) < 4 and name(#3) O"))->print() == ast);
+        ast = "name(#4) != Cs";
+        CHECK(parse(tokenize("name(#4) != Cs"))->print() == ast);
+        ast = "or -> index(#1) < 4\n   -> name(#2) == H";
+        CHECK(parse(tokenize("index(#1) < 4 or name(#2) H"))->print() == ast);
     }
 
     SECTION("Parsing errors") {


### PR DESCRIPTION
Using `$1`, `$2`, `$3` will lead to errors when passing selections as strings in a shell script. This replace them by the `#1`, `#2`, `#3` syntax.

I am opening this as a pull request to gather feedback on the change. I'll merge this PR later in the week.