### PR TITLE
Add arbitrary properties to atoms and frames

### DIFF
--- a/doc/src/capi/chfl_atom.rst
+++ b/doc/src/capi/chfl_atom.rst
@@ -37,4 +37,8 @@ Function manipulating ``CHFL_ATOM``
 
 .. doxygenfunction:: chfl_atom_atomic_number
 
+.. doxygenfunction:: chfl_atom_set_property
+
+.. doxygenfunction:: chfl_atom_get_property
+
 .. doxygenfunction:: chfl_atom_free

--- a/doc/src/capi/chfl_frame.rst
+++ b/doc/src/capi/chfl_frame.rst
@@ -41,4 +41,8 @@ Function manipulating ``CHFL_FRAME``
 
 .. doxygenfunction:: chfl_frame_dihedral
 
+.. doxygenfunction:: chfl_frame_set_property
+
+.. doxygenfunction:: chfl_frame_get_property
+
 .. doxygenfunction:: chfl_frame_free

--- a/doc/src/capi/chfl_property.rst
+++ b/doc/src/capi/chfl_property.rst
@@ -1,0 +1,24 @@
+.. _capi-property:
+
+Function manipulating ``CHFL_PROPERTY``
+---------------------------------------
+
+.. doxygentypedef:: CHFL_PROPERTY
+
+.. doxygenfunction:: chfl_property_bool
+
+.. doxygenfunction:: chfl_property_double
+
+.. doxygenfunction:: chfl_property_string
+
+.. doxygenfunction:: chfl_property_vector3d
+
+.. doxygenfunction:: chfl_property_get_bool
+
+.. doxygenfunction:: chfl_property_get_double
+
+.. doxygenfunction:: chfl_property_get_string
+
+.. doxygenfunction:: chfl_property_get_vector3d
+
+.. doxygenfunction:: chfl_property_free

--- a/doc/src/capi/index.rst
+++ b/doc/src/capi/index.rst
@@ -14,6 +14,7 @@ following opaque pointer types:
 * :ref:`CHFL_TOPOLOGY <capi-topology>` maps to the :ref:`Topology <class-Topology>` class.
 * :ref:`CHFL_RESIDUE <capi-residue>` maps to the :ref:`Residue <class-Residue>` class.
 * :ref:`CHFL_SELECTION <capi-selection>` maps to the :ref:`Selection <class-Selection>` class.
+* :ref:`CHFL_PROPERTY <capi-property>` maps to the :ref:`Property <class-Property>` class.
 
 The user is reponsible for memory management when using these types.
 Constructors functions (functions returning pointers to types defined above)
@@ -38,4 +39,5 @@ the Chemfiles library.
     chfl_atom
     chfl_cell
     chfl_selection
+    chfl_property
     misc

--- a/doc/src/classes/index.rst
+++ b/doc/src/classes/index.rst
@@ -19,6 +19,7 @@ begining of your program in order to bring all the class in the main namespace.
    atom
    unitcell
    selection
+   property
    misc
 
 .. _exported-macro:

--- a/doc/src/classes/property.rst
+++ b/doc/src/classes/property.rst
@@ -1,0 +1,7 @@
+.. _class-Property:
+
+Property
+========
+
+.. doxygenclass:: chemfiles::Property
+    :members:

--- a/include/chemfiles.h
+++ b/include/chemfiles.h
@@ -6,6 +6,7 @@
 
 #include "chemfiles/capi/types.h"
 #include "chemfiles/capi/misc.h"
+#include "chemfiles/capi/property.h"
 #include "chemfiles/capi/atom.h"
 #include "chemfiles/capi/residue.h"
 #include "chemfiles/capi/topology.h"

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -8,6 +8,7 @@
 
 #include "chemfiles/exports.hpp"
 #include "chemfiles/optional.hpp"
+#include "chemfiles/Property.hpp"
 
 namespace chemfiles {
 
@@ -63,16 +64,33 @@ public:
     /// Try to get the atomic number of the atom.
     optional<uint64_t> atomic_number() const;
 
+    /// Set an arbitrary property for this atom with the given `name` and
+    /// `value`. If a property with this name already exist, it is replaced
+    /// with the new value.
+    void set(std::string name, Property value);
+
+    /// Get the property with the given `name` for this atom if it exists.
+    optional<const Property&> get(const std::string& name) const;
+    
 private:
+    /// the atom name
     std::string name_;
+    /// the atom type
     std::string type_;
+    /// the atom mass
     double mass_ = 0;
+    /// the atom charge
     double charge_ = 0;
+    /// Additional properties of this atom
+    property_map properties_;
+
+    friend bool operator==(const Atom&, const Atom&);
 };
 
 inline bool operator==(const Atom& lhs, const Atom& rhs) {
     return (lhs.name() == rhs.name() && lhs.type() == rhs.type() &&
-            lhs.mass() == rhs.mass() && lhs.charge() == rhs.charge());
+            lhs.mass() == rhs.mass() && lhs.charge() == rhs.charge() &&
+            lhs.properties_ == rhs.properties_);
 }
 
 } // namespace chemfiles

--- a/include/chemfiles/Error.hpp
+++ b/include/chemfiles/Error.hpp
@@ -45,6 +45,11 @@ struct CHFL_EXPORT OutOfBounds: public Error {
     OutOfBounds(const std::string& err): Error(err) {}
 };
 
+/// Exception for errors related to frame and atomic properties
+struct CHFL_EXPORT PropertyError: public Error {
+    PropertyError(const std::string& err): Error(err) {}
+};
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/Frame.hpp
+++ b/include/chemfiles/Frame.hpp
@@ -130,6 +130,14 @@ public:
     /// @throws chemfiles::OutOfBounds if `i`, `j`, `k` or `m` are not in bounds
     double dihedral(size_t i, size_t j, size_t k, size_t m) const;
 
+    /// Set an arbitrary property for this frame with the given `name` and
+    /// `value`. If a property with this name already exist, it is replaced
+    /// with the new value.
+    void set(std::string name, Property value);
+
+    /// Get the property with the given `name` for this frame if it exists.
+    optional<const Property&> get(const std::string& name) const;
+
 private:
     Frame(const Frame&) = default;
     Frame& operator=(const Frame&) = default;
@@ -144,6 +152,8 @@ private:
     Topology topology_;
     /// Unit cell of the system
     UnitCell cell_;
+    /// Properties stored in this frame
+    property_map properties_;
 };
 
 } // namespace chemfiles

--- a/include/chemfiles/Property.hpp
+++ b/include/chemfiles/Property.hpp
@@ -1,0 +1,147 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#ifndef CHEMFILES_PROPERTY_HPP
+#define CHEMFILES_PROPERTY_HPP
+
+#include <string>
+
+#include "chemfiles/exports.hpp"
+#include "chemfiles/types.hpp"
+#include "chemfiles/Error.hpp"
+
+namespace chemfiles {
+
+/// This class holds the data used in properties by the `Atom` and the `Frame`
+/// classes. A property can have various types: bool, double, string or
+/// `Vector3D`.
+class CHFL_EXPORT Property final {
+public:
+    /// Create a property holding a boolean value.
+    Property(bool value): kind_(BOOL), bool_(value) {}
+    /// Create a property holding a double value.
+    Property(double value): kind_(DOUBLE), double_(value) {}
+    /// Create a property holding a `Vector3D` value.
+    Property(Vector3D value): kind_(VECTOR3D), vector3d_(value) {}
+    /// Create a property holding a string value.
+    Property(std::string value): kind_(STRING), string_(value) {}
+
+    // ==== The following construtors are here to help with overloading
+    // ==== resolution.
+    /// Create a property holding a string value from a const char*.
+    Property(const char* value): kind_(STRING), string_(value) {}
+    /// Create a property holding a double value from an int.
+    Property(int value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+    /// Create a property holding a double value from a long.
+    Property(long value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+    /// Create a property holding a double value from a long long.
+    Property(long long value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+    /// Create a property holding a double value from an unsigned.
+    Property(unsigned value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+    /// Create a property holding a double value from an unsigned long.
+    Property(unsigned long value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+    /// Create a property holding a double value from an unsigned long long.
+    Property(unsigned long long value): kind_(DOUBLE), double_(static_cast<double>(value)) {}
+
+    /// The copy constructor for Property
+    Property(const Property& other): Property(false) {
+        *this = other;
+    }
+
+    /// The move constructor for Property
+    Property(Property&& other): Property(false) {
+        *this = std::move(other);
+    }
+
+    /// The copy assignement operator for Property
+    Property& operator=(const Property& other) {
+        this->~Property();
+        this->kind_ = other.kind_;
+        switch (this->kind_) {
+        case BOOL:
+            new(&this->bool_) bool(other.bool_);
+            break;
+        case DOUBLE:
+            new (&this->double_) double(other.double_);
+            break;
+        case STRING:
+            new (&this->string_) std::string(other.string_);
+            break;
+        case VECTOR3D:
+            new (&this->vector3d_) Vector3D(other.vector3d_);
+            break;
+        }
+        return *this;
+    }
+
+    /// The move assignement operator for Property
+    Property& operator=(Property&& other) {
+        this->~Property();
+        this->kind_ = other.kind_;
+        switch (this->kind_) {
+        case BOOL:
+            new(&this->bool_) bool(std::move(other.bool_));
+            break;
+        case DOUBLE:
+            new (&this->double_) double(std::move(other.double_));
+            break;
+        case STRING:
+            new (&this->string_) std::string(std::move(other.string_));
+            break;
+        case VECTOR3D:
+            new (&this->vector3d_) Vector3D(std::move(other.vector3d_));
+            break;
+        }
+        return *this;
+    }
+
+    /// The destructor for Property
+    ~Property() {
+        if (kind_ == STRING) {
+            using std::string;
+            this->string_.~string();
+        }
+    }
+
+    /// Get the boolean value stored in this Property
+    ///
+    /// @throws PropertyError if this property does not hold a boolean value
+    bool as_bool() const;
+
+    /// Get the double value stored in this Property
+    ///
+    /// @throws PropertyError if this property does not hold a double value
+    double as_double() const;
+
+    /// Get the Vector3D value stored in this Property
+    ///
+    /// @throws PropertyError if this property does not hold a Vector3D value
+    Vector3D as_vector3d() const;
+
+    /// Get the string value stored in this Property
+    ///
+    /// @throws PropertyError if this property does not hold a string value
+    const std::string& as_string() const;
+
+private:
+    /// Get the kind name as a string
+    std::string kind_as_string() const;
+
+    enum {
+        BOOL,
+        STRING,
+        DOUBLE,
+        VECTOR3D,
+    } kind_;
+
+    union {
+        bool bool_;
+        std::string string_;
+        double double_;
+        Vector3D vector3d_;
+    };
+};
+
+} // namespace chemfiles
+
+#endif

--- a/include/chemfiles/Property.hpp
+++ b/include/chemfiles/Property.hpp
@@ -5,9 +5,12 @@
 #define CHEMFILES_PROPERTY_HPP
 
 #include <string>
+#include <unordered_map>
 
 #include "chemfiles/exports.hpp"
+#include "chemfiles/optional.hpp"
 #include "chemfiles/types.hpp"
+#include "chemfiles/utils.hpp"
 #include "chemfiles/Error.hpp"
 
 namespace chemfiles {
@@ -140,7 +143,48 @@ private:
         double double_;
         Vector3D vector3d_;
     };
+
+    friend bool operator==(const Property&, const Property&);
 };
+
+inline bool operator==(const Property& lhs, const Property& rhs) {
+    if (lhs.kind_ != rhs.kind_) {
+        return false;
+    }
+    switch (lhs.kind_) {
+    case Property::BOOL:
+        return lhs.bool_ == rhs.bool_;
+    case Property::STRING:
+        return lhs.string_ == rhs.string_;
+    case Property::DOUBLE:
+        return lhs.double_ == rhs.double_;
+    case Property::VECTOR3D:
+        return lhs.vector3d_ == rhs.vector3d_;
+    }
+    unreachable();
+}
+
+/// A property map for inclusion in a Frame or an Atom.
+class property_map final {
+public:
+    property_map(): data_() {}
+
+    /// Set an arbitrary property with the given `name` and `value`. If a
+    /// property with this name already exist, it is replaced with the new
+    /// value.
+    void set(std::string name, Property value);
+
+    /// Get the property with the given `name` if it exists.
+    optional<const Property&> get(const std::string& name) const;
+
+private:
+    std::unordered_map<std::string, Property> data_;
+    friend bool operator==(const property_map&, const property_map&);
+};
+
+inline bool operator==(const property_map& lhs, const property_map& rhs) {
+    return lhs.data_ == rhs.data_;
+}
 
 } // namespace chemfiles
 

--- a/include/chemfiles/capi.hpp
+++ b/include/chemfiles/capi.hpp
@@ -65,6 +65,7 @@ inline size_t checked_cast(uint64_t value) {
     CATCH_AND_RETURN(SelectionError, CHFL_SELECTION_ERROR)                     \
     CATCH_AND_RETURN(ConfigurationError, CHFL_CONFIGURATION_ERROR)             \
     CATCH_AND_RETURN(OutOfBounds, CHFL_OUT_OF_BOUNDS)                          \
+    CATCH_AND_RETURN(PropertyError, CHFL_PROPERTY_ERROR)                       \
     CATCH_AND_RETURN(Error, CHFL_GENERIC_ERROR)                                \
     catch (const std::exception& e) {                                          \
         CAPI_LAST_ERROR = std::string(e.what());                               \
@@ -84,6 +85,7 @@ inline size_t checked_cast(uint64_t value) {
     CATCH_AND_GOTO_ERROR(SelectionError)                                       \
     CATCH_AND_GOTO_ERROR(ConfigurationError)                                   \
     CATCH_AND_GOTO_ERROR(OutOfBounds)                                          \
+    CATCH_AND_GOTO_ERROR(PropertyError)                                        \
     CATCH_AND_GOTO_ERROR(Error)                                                \
     catch (const std::exception& e) {                                          \
         CAPI_LAST_ERROR = std::string(e.what());                               \

--- a/include/chemfiles/capi/atom.h
+++ b/include/chemfiles/capi/atom.h
@@ -189,6 +189,32 @@ CHFL_EXPORT chfl_status chfl_atom_atomic_number(
     const CHFL_ATOM* const atom, uint64_t* number
 );
 
+/// Add a new `property` with the given `name` to this `atom`.
+///
+/// If a property with the same name already exists, this function override the
+/// existing property with the new one.
+///
+/// @example{tests/capi/doc/chfl_atom/property.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_atom_set_property(
+    CHFL_ATOM* const atom, const char* name, const CHFL_PROPERTY* const property
+);
+
+/// Get a property with the given `name` in this `atom`.
+///
+/// This function returns `NULL` is no property exist with the given name.
+///
+/// The user of this function is responsible to deallocate memory using the
+/// `chfl_property_free` function.
+///
+/// @example{tests/capi/doc/chfl_atom/property.c}
+/// @return A pointer to the property, or NULL in case of error.
+///         You can use `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_atom_get_property(
+    const CHFL_ATOM* const atom, const char* name
+);
+
 /// Free the memory associated with an `atom`.
 ///
 /// @example{tests/capi/doc/chfl_atom/chfl_atom.c}

--- a/include/chemfiles/capi/frame.h
+++ b/include/chemfiles/capi/frame.h
@@ -221,6 +221,32 @@ CHFL_EXPORT chfl_status chfl_frame_dihedral(
     const CHFL_FRAME* const frame, uint64_t i, uint64_t j, uint64_t k, uint64_t m, double* dihedral
 );
 
+/// Add a new `property` with the given `name` to this `frame`.
+///
+/// If a property with the same name already exists, this function override the
+/// existing property with the new one.
+///
+/// @example{tests/capi/doc/chfl_frame/property.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_frame_set_property(
+    CHFL_FRAME* const frame, const char* name, const CHFL_PROPERTY* const property
+);
+
+/// Get a property with the given `name` in this `frame`.
+///
+/// This function returns `NULL` is no property exist with the given name.
+///
+/// The user of this function is responsible to deallocate memory using the
+/// `chfl_property_free` function.
+///
+/// @example{tests/capi/doc/chfl_frame/property.c}
+/// @return A pointer to the property, or NULL in case of error.
+///         You can use `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_frame_get_property(
+    const CHFL_FRAME* const frame, const char* name
+);
+
 /// Free the memory associated with a `frame`.
 ///
 /// @example{tests/capi/doc/chfl_frame/chfl_frame.c}

--- a/include/chemfiles/capi/property.h
+++ b/include/chemfiles/capi/property.h
@@ -1,0 +1,116 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#ifndef CHEMFILES_CHFL_PROPERTY_H
+#define CHEMFILES_CHFL_PROPERTY_H
+
+#include "chemfiles/capi/types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Create a new property holding a boolean `value`.
+///
+/// The caller of this function should free the allocated memory using
+/// `chfl_property_free`.
+///
+/// @example{tests/capi/doc/chfl_property/bool.c}
+/// @return A pointer to the property, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_property_bool(bool value);
+
+/// Create a new property holding a double `value`.
+///
+/// The caller of this function should free the allocated memory using
+/// `chfl_property_free`.
+///
+/// @example{tests/capi/doc/chfl_property/double.c}
+/// @return A pointer to the property, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_property_double(double value);
+
+/// Create a new property holding a string `value`.
+///
+/// The caller of this function should free the allocated memory using
+/// `chfl_property_free`.
+///
+/// @example{tests/capi/doc/chfl_property/string.c}
+/// @return A pointer to the property, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_property_string(const char* value);
+
+/// Create a new property holding a 3D vector `value`.
+///
+/// The caller of this function should free the allocated memory using
+/// `chfl_property_free`.
+///
+/// @example{tests/capi/doc/chfl_property/vector3d.c}
+/// @return A pointer to the property, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
+CHFL_EXPORT CHFL_PROPERTY* chfl_property_vector3d(const chfl_vector3d value);
+
+/// Get the boolean value holded by this `property` in the location pointed to
+/// by `data`.
+///
+/// This function returns CHFL_PROPERTY_ERROR if the property is not a boolean
+/// property.
+///
+/// @example{tests/capi/doc/chfl_property/bool.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_property_get_bool(
+    const CHFL_PROPERTY* const property, bool* data
+);
+
+/// Get the double value holded by this `property` in the location pointed to
+/// by `data`.
+///
+/// This function returns CHFL_PROPERTY_ERROR if the property is not a double
+/// property.
+///
+/// @example{tests/capi/doc/chfl_property/double.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_property_get_double(
+    const CHFL_PROPERTY* const property, double* data
+);
+
+/// Get the string value holded by this `property` in the given `buffer`.
+///
+/// This function returns CHFL_PROPERTY_ERROR if the property is not a sring
+/// property.
+///
+/// The buffer size must be passed in `buffsize`. This function will truncate
+/// the property to fit in the buffer.
+///
+/// @example{tests/capi/doc/chfl_property/string.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_property_get_string(
+    const CHFL_PROPERTY* const property, char* const buffer, uint64_t buffsize
+);
+
+/// Get the 3D vector value holded by this `property` in the location pointed to
+/// by `data`.
+///
+/// This function returns CHFL_PROPERTY_ERROR if the property is not a 3D vector
+/// property.
+///
+/// @example{tests/capi/doc/chfl_property/vector3d.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_property_get_vector3d(
+    const CHFL_PROPERTY* const property, chfl_vector3d data
+);
+
+/// Free the memory associated with a `property`.
+///
+/// @example{tests/capi/doc/chfl_property/bool.c}
+/// @return `CHFL_SUCCESS`
+CHFL_EXPORT chfl_status chfl_property_free(CHFL_PROPERTY* property);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -17,6 +17,7 @@ namespace chemfiles {
     class UnitCell;
     class Topology;
     class Residue;
+    class Property;
 }
 struct CAPISelection;
 typedef chemfiles::Trajectory CHFL_TRAJECTORY;
@@ -26,6 +27,7 @@ typedef chemfiles::UnitCell CHFL_CELL;
 typedef chemfiles::Topology CHFL_TOPOLOGY;
 typedef chemfiles::Residue CHFL_RESIDUE;
 typedef CAPISelection CHFL_SELECTION;
+typedef chemfiles::Property CHFL_PROPERTY;
 #else
 /// An opaque type handling trajectories files.
 ///
@@ -98,6 +100,11 @@ typedef struct CHFL_RESIDUE CHFL_RESIDUE;
 /// <value>` structure, where `<operator>` is a comparison operator in
 /// `== != < <= > >=`.
 typedef struct CHFL_SELECTION CHFL_SELECTION;
+
+/// This class holds the data used in properties in `CHFL_FRAME` and
+/// `CHFL_ATOM`. A property can have various types: bool, double, string or
+/// `chfl_vector3d`.
+typedef struct CHFL_PROPERTY CHFL_PROPERTY;
 #endif
 
 /// `chfl_status` list the possible values for the return status code of

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -119,6 +119,8 @@ typedef enum {
     CHFL_CONFIGURATION_ERROR = 5,
     /// Status code for out of bounds errors.
     CHFL_OUT_OF_BOUNDS = 6,
+    /// Status code for errors related to properties.
+    CHFL_PROPERTY_ERROR = 7,
     /// Status code for any other error from Chemfiles.
     CHFL_GENERIC_ERROR = 254,
     /// Status code for error in the C++ standard library.

--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -37,7 +37,7 @@ static optional<const ElementData&> find_element(const std::string& name) {
 Atom::Atom(std::string name): Atom(name, name) {}
 
 Atom::Atom(std::string name, std::string type):
-    name_(std::move(name)), type_(std::move(type)) {
+    name_(std::move(name)), type_(std::move(type)), properties_() {
     auto element = find_element(type_);
     if (element) {
         mass_ = element->mass;
@@ -78,4 +78,12 @@ optional<uint64_t> Atom::atomic_number() const {
     } else {
         return nullopt;
     }
+}
+
+void Atom::set(std::string name, Property value) {
+    properties_.set(std::move(name), std::move(value));
+}
+
+optional<const Property&> Atom::get(const std::string& name) const {
+    return properties_.get(name);
 }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -190,3 +190,11 @@ double Frame::dihedral(size_t i, size_t j, size_t k, size_t m) const {
     auto b = cross(rjk, rkm);
     return atan2(norm(rjk) * dot(b, rij), dot(a, b));
 }
+
+void Frame::set(std::string name, Property value) {
+    properties_.set(std::move(name), std::move(value));
+}
+
+optional<const Property&> Frame::get(const std::string& name) const {
+    return properties_.get(name);
+}

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -1,0 +1,60 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include "chemfiles/Property.hpp"
+#include "chemfiles/utils.hpp"
+using namespace chemfiles;
+
+bool Property::as_bool() const {
+    if (kind_ == BOOL) {
+        return bool_;
+    } else {
+        throw PropertyError(
+            "Tried to use 'as_bool' on a " + kind_as_string() + " property"
+        );
+    }
+}
+
+double Property::as_double() const {
+    if (kind_ == DOUBLE) {
+        return double_;
+    } else {
+        throw PropertyError(
+            "Tried to use 'as_double' on a " + kind_as_string() + " property"
+        );
+    }
+}
+
+Vector3D Property::as_vector3d() const {
+    if (kind_ == VECTOR3D) {
+        return vector3d_;
+    } else {
+        throw PropertyError(
+            "Tried to use 'as_vector3d' on a " + kind_as_string() + " property"
+        );
+    }
+}
+
+const std::string& Property::as_string() const {
+    if (kind_ == STRING) {
+        return string_;
+    } else {
+        throw PropertyError(
+            "Tried to use 'as_string' on a " + kind_as_string() + " property"
+        );
+    }
+}
+
+std::string Property::kind_as_string() const {
+    switch (this->kind_) {
+    case BOOL:
+        return "bool";
+    case DOUBLE:
+        return "double";
+    case STRING:
+        return "string";
+    case VECTOR3D:
+        return "Vector3D";
+    }
+    unreachable();
+}

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -58,3 +58,22 @@ std::string Property::kind_as_string() const {
     }
     unreachable();
 }
+
+
+void property_map::set(std::string name, Property value) {
+    // We can not move value here, because we might need it later. C++17 solves
+    // this with insert_or_assign.
+    auto inserted = data_.emplace(std::move(name), value);
+    if (!inserted.second) {
+        inserted.first->second = std::move(value);
+    }
+}
+
+optional<const Property&> property_map::get(const std::string& name) const {
+    auto property = data_.find(name);
+    if (property != data_.end()) {
+        return property->second;
+    } else {
+        return nullopt;
+    }
+}

--- a/src/capi/atom.cpp
+++ b/src/capi/atom.cpp
@@ -172,6 +172,31 @@ extern "C" chfl_status chfl_atom_atomic_number(const CHFL_ATOM* const atom, uint
     )
 }
 
+extern "C" chfl_status chfl_atom_set_property(CHFL_ATOM* const atom, const char* name, const CHFL_PROPERTY* const property) {
+    CHECK_POINTER(atom);
+    CHECK_POINTER(name);
+    CHECK_POINTER(property);
+    CHFL_ERROR_CATCH(
+        atom->set(name, *property);
+    )
+}
+
+extern "C" CHFL_PROPERTY* chfl_atom_get_property(const CHFL_ATOM* const atom, const char* name) {
+    CHFL_PROPERTY* property = nullptr;
+    CHECK_POINTER_GOTO(atom);
+    CHECK_POINTER_GOTO(name);
+    CHFL_ERROR_GOTO(
+        auto atom_property = atom->get(name);
+        if (atom_property) {
+            property = new Property(*atom_property);
+        }
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
 extern "C" chfl_status chfl_atom_free(CHFL_ATOM* const atom) {
     delete atom;
     return CHFL_SUCCESS;

--- a/src/capi/frame.cpp
+++ b/src/capi/frame.cpp
@@ -179,6 +179,31 @@ extern "C" chfl_status chfl_frame_dihedral(const CHFL_FRAME* const frame, uint64
     )
 }
 
+extern "C" chfl_status chfl_frame_set_property(CHFL_FRAME* const frame, const char* name, const CHFL_PROPERTY* const property) {
+    CHECK_POINTER(frame);
+    CHECK_POINTER(name);
+    CHECK_POINTER(property);
+    CHFL_ERROR_CATCH(
+        frame->set(name, *property);
+    )
+}
+
+extern "C" CHFL_PROPERTY* chfl_frame_get_property(const CHFL_FRAME* const frame, const char* name) {
+    CHFL_PROPERTY* property = nullptr;
+    CHECK_POINTER_GOTO(frame);
+    CHECK_POINTER_GOTO(name);
+    CHFL_ERROR_GOTO(
+        auto atom_property = frame->get(name);
+        if (atom_property) {
+            property = new Property(*atom_property);
+        }
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
 extern "C" chfl_status chfl_frame_free(CHFL_FRAME* const frame) {
     delete frame;
     return CHFL_SUCCESS;

--- a/src/capi/property.cpp
+++ b/src/capi/property.cpp
@@ -1,0 +1,94 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include "chemfiles/capi/property.h"
+#include "chemfiles/capi.hpp"
+
+#include "chemfiles/Property.hpp"
+using namespace chemfiles;
+
+extern "C" CHFL_PROPERTY* chfl_property_bool(bool value) {
+    CHFL_PROPERTY* property = nullptr;
+    CHFL_ERROR_GOTO(
+        property = new Property(value);
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
+extern "C" CHFL_PROPERTY* chfl_property_double(double value) {
+    CHFL_PROPERTY* property = nullptr;
+    CHFL_ERROR_GOTO(
+        property = new Property(value);
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
+extern "C" CHFL_PROPERTY* chfl_property_string(const char* value) {
+    CHFL_PROPERTY* property = nullptr;
+    CHFL_ERROR_GOTO(
+        property = new Property(value);
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
+extern "C" CHFL_PROPERTY* chfl_property_vector3d(const chfl_vector3d value) {
+    CHFL_PROPERTY* property = nullptr;
+    CHFL_ERROR_GOTO(
+        property = new Property(vector3d(value[0], value[1], value[2]));
+    )
+    return property;
+error:
+    delete property;
+    return nullptr;
+}
+
+extern "C" chfl_status chfl_property_get_bool(const CHFL_PROPERTY* const property, bool* value) {
+    CHECK_POINTER(property);
+    CHECK_POINTER(value);
+    CHFL_ERROR_CATCH(
+        *value = property->as_bool();
+    )
+}
+
+extern "C" chfl_status chfl_property_get_double(const CHFL_PROPERTY* const property, double* value) {
+    CHECK_POINTER(property);
+    CHECK_POINTER(value);
+    CHFL_ERROR_CATCH(
+        *value = property->as_double();
+    )
+}
+
+extern "C" chfl_status chfl_property_get_string(const CHFL_PROPERTY* const property, char* const buffer, uint64_t buffsize) {
+    CHECK_POINTER(property);
+    CHECK_POINTER(buffer);
+    CHFL_ERROR_CATCH(
+        auto string = property->as_string();
+        strncpy(buffer, string.c_str(), checked_cast(buffsize) - 1);
+        buffer[buffsize - 1] = '\0';
+    )
+}
+
+extern "C" chfl_status chfl_property_get_vector3d(const CHFL_PROPERTY* const property, chfl_vector3d value) {
+    CHECK_POINTER(property);
+    CHECK_POINTER(value);
+    CHFL_ERROR_CATCH(
+        auto vector = property->as_vector3d();
+        value[0] = vector[0];
+        value[1] = vector[1];
+        value[2] = vector[2];
+    )
+}
+
+extern "C" chfl_status chfl_property_free(CHFL_PROPERTY* property) {
+    delete property;
+    return CHFL_SUCCESS;
+}

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -94,4 +94,17 @@ TEST_CASE("Use the Atom type"){
         CHECK(atom.covalent_radius().value() == 1.31);
         CHECK(atom.vdw_radius().value() == 2.1);
     }
+
+    SECTION("Property map") {
+        auto atom = Atom("H");
+        atom.set("foo", 35);
+        atom.set("bar", false);
+
+        CHECK(atom.get("foo")->as_double() == 35.0);
+        CHECK(atom.get("bar")->as_bool() == false);
+
+        atom.set("foo", "test");
+        CHECK(atom.get("foo")->as_string() == "test");
+        CHECK_FALSE(atom.get("not here"));
+    }
 }

--- a/tests/capi/atom.cpp
+++ b/tests/capi/atom.cpp
@@ -97,4 +97,26 @@ TEST_CASE("chfl_atom") {
 
         CHECK_STATUS(chfl_atom_free(atom));
     }
+
+    SECTION("Property") {
+        CHFL_ATOM* atom = chfl_atom("Zn");
+        REQUIRE(atom);
+
+        CHFL_PROPERTY* property = chfl_property_double(-23);
+        REQUIRE(property);
+
+        CHECK_STATUS(chfl_atom_set_property(atom, "this", property));
+        CHECK_STATUS(chfl_property_free(property));
+        property = nullptr;
+
+        property = chfl_atom_get_property(atom, "this");
+        double value = 0;
+        CHECK_STATUS(chfl_property_get_double(property, &value));
+        CHECK(value == -23);
+
+        CHECK_FALSE(chfl_atom_get_property(atom, "that"));
+
+        CHECK_STATUS(chfl_property_free(property));
+        CHECK_STATUS(chfl_atom_free(atom));
+    }
 }

--- a/tests/capi/doc/chfl_atom/property.c
+++ b/tests/capi/doc/chfl_atom/property.c
@@ -1,0 +1,26 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+#include <stdlib.h>
+
+int main() {
+    // [example]
+    CHFL_ATOM* atom = chfl_atom("Na");
+    CHFL_PROPERTY* property = chfl_property_double(-23);
+
+    chfl_atom_set_property(atom, "this", property);
+    chfl_property_free(property);
+
+    property = chfl_atom_get_property(atom, "this");
+
+    double value = 0;
+    chfl_property_get_double(property, &value);
+    assert(value == -23);
+
+    chfl_property_free(property);
+    chfl_atom_free(atom);
+    // [example]
+    return 0;
+}

--- a/tests/capi/doc/chfl_frame/property.c
+++ b/tests/capi/doc/chfl_frame/property.c
@@ -1,0 +1,26 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+#include <stdlib.h>
+
+int main() {
+    // [example]
+    CHFL_FRAME* frame = chfl_frame();
+    CHFL_PROPERTY* property = chfl_property_double(-23);
+
+    chfl_frame_set_property(frame, "this", property);
+    chfl_property_free(property);
+
+    property = chfl_frame_get_property(frame, "this");
+
+    double value = 0;
+    chfl_property_get_double(property, &value);
+    assert(value == -23);
+
+    chfl_property_free(property);
+    chfl_frame_free(frame);
+    // [example]
+    return 0;
+}

--- a/tests/capi/doc/chfl_property/bool.c
+++ b/tests/capi/doc/chfl_property/bool.c
@@ -1,0 +1,18 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    CHFL_PROPERTY* property = chfl_property_bool(true);
+
+    bool value = false;
+    chfl_property_get_bool(property, &value);
+    assert(value == true);
+
+    chfl_property_free(property);
+    // [example]
+    return 0;
+}

--- a/tests/capi/doc/chfl_property/double.c
+++ b/tests/capi/doc/chfl_property/double.c
@@ -1,0 +1,18 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    CHFL_PROPERTY* property = chfl_property_double(256);
+
+    double value = 0;
+    chfl_property_get_double(property, &value);
+    assert(value == 256);
+
+    chfl_property_free(property);
+    // [example]
+    return 0;
+}

--- a/tests/capi/doc/chfl_property/string.c
+++ b/tests/capi/doc/chfl_property/string.c
@@ -1,0 +1,19 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+#include <string.h>
+
+int main() {
+    // [example]
+    CHFL_PROPERTY* property = chfl_property_string("a great property");
+
+    char value[32];
+    chfl_property_get_string(property, value, sizeof(value));
+    assert(strcmp(value, "a great property") == 0);
+
+    chfl_property_free(property);
+    // [example]
+    return 0;
+}

--- a/tests/capi/doc/chfl_property/vector3d.c
+++ b/tests/capi/doc/chfl_property/vector3d.c
@@ -1,0 +1,21 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+#include <math.h>
+
+int main() {
+    // [example]
+    CHFL_PROPERTY* property = chfl_property_vector3d((chfl_vector3d){2, 3.2, -1});
+
+    chfl_vector3d value = {0};
+    chfl_property_get_vector3d(property, value);
+    assert(fabs(value[0] - 2) < 1e-12);
+    assert(fabs(value[1] - 3.2) < 1e-12);
+    assert(fabs(value[2] - -1) < 1e-12);
+
+    chfl_property_free(property);
+    // [example]
+    return 0;
+}

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -320,4 +320,26 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_atom_free(atom));
         CHECK_STATUS(chfl_frame_free(frame));
     }
+
+    SECTION("Property") {
+        CHFL_FRAME* frame = chfl_frame();
+        REQUIRE(frame);
+
+        CHFL_PROPERTY* property = chfl_property_double(-23);
+        REQUIRE(property);
+
+        CHECK_STATUS(chfl_frame_set_property(frame, "this", property));
+        CHECK_STATUS(chfl_property_free(property));
+        property = nullptr;
+
+        property = chfl_frame_get_property(frame, "this");
+        double value = 0;
+        CHECK_STATUS(chfl_property_get_double(property, &value));
+        CHECK(value == -23);
+
+        CHECK_FALSE(chfl_frame_get_property(frame, "that"));
+
+        CHECK_STATUS(chfl_property_free(property));
+        CHECK_STATUS(chfl_frame_free(frame));
+    }
 }

--- a/tests/capi/property.cpp
+++ b/tests/capi/property.cpp
@@ -1,0 +1,83 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include "catch.hpp"
+#include "helpers.hpp"
+#include "chemfiles.h"
+
+TEST_CASE("Property") {
+    SECTION("Bool") {
+        CHFL_PROPERTY* property = chfl_property_bool(false);
+        REQUIRE(property);
+
+        bool value = true;
+        CHECK_STATUS(chfl_property_get_bool(property, &value));
+        CHECK(value == false);
+
+        char dummy_char = '\0';
+        CHECK(chfl_property_get_string(property, &dummy_char, 0) == CHFL_PROPERTY_ERROR);
+        double dummy_double = 0;
+        CHECK(chfl_property_get_double(property, &dummy_double) == CHFL_PROPERTY_ERROR);
+        chfl_vector3d dummy_vector = {0};
+        CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
+
+        CHECK_STATUS(chfl_property_free(property));
+    }
+
+    SECTION("Double") {
+        CHFL_PROPERTY* property = chfl_property_double(42);
+        REQUIRE(property);
+
+        double value = 0;
+        CHECK_STATUS(chfl_property_get_double(property, &value));
+        CHECK(value == 42.0);
+
+        char dummy_char = '\0';
+        CHECK(chfl_property_get_string(property, &dummy_char, 0) == CHFL_PROPERTY_ERROR);
+        bool dummy_bool = false;
+        CHECK(chfl_property_get_bool(property, &dummy_bool) == CHFL_PROPERTY_ERROR);
+        chfl_vector3d dummy_vector = {0};
+        CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
+
+        CHECK_STATUS(chfl_property_free(property));
+    }
+
+    SECTION("String") {
+        CHFL_PROPERTY* property = chfl_property_string("foobar");
+        REQUIRE(property);
+
+        char value[32];
+        CHECK_STATUS(chfl_property_get_string(property, value, sizeof(value)));
+        CHECK(value == std::string("foobar"));
+
+        double dummy_double = 0;
+        CHECK(chfl_property_get_double(property, &dummy_double) == CHFL_PROPERTY_ERROR);
+        bool dummy_bool = false;
+        CHECK(chfl_property_get_bool(property, &dummy_bool) == CHFL_PROPERTY_ERROR);
+        chfl_vector3d dummy_vector = {0};
+        CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
+
+        CHECK_STATUS(chfl_property_free(property));
+    }
+
+    SECTION("Vector3D") {
+        chfl_vector3d initial = {1, 3, 4};
+        CHFL_PROPERTY* property = chfl_property_vector3d(initial);
+        REQUIRE(property);
+
+        chfl_vector3d value = {0};
+        CHECK_STATUS(chfl_property_get_vector3d(property, value));
+        CHECK(value[0] == 1.0);
+        CHECK(value[1] == 3.0);
+        CHECK(value[2] == 4.0);
+
+        char dummy_char = '\0';
+        CHECK(chfl_property_get_string(property, &dummy_char, 0) == CHFL_PROPERTY_ERROR);
+        bool dummy_bool = false;
+        CHECK(chfl_property_get_bool(property, &dummy_bool) == CHFL_PROPERTY_ERROR);
+        double dummy_double = 0;
+        CHECK(chfl_property_get_double(property, &dummy_double) == CHFL_PROPERTY_ERROR);
+
+        CHECK_STATUS(chfl_property_free(property));
+    }
+}

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -213,3 +213,16 @@ TEST_CASE("PBC functions") {
         CHECK(roughly(frame.dihedral(4, 5, 6, 7), 1.045378962606));
     }
 }
+
+TEST_CASE("Property map") {
+    auto frame = Frame();
+    frame.set("foo", 35);
+    frame.set("bar", false);
+
+    CHECK(frame.get("foo")->as_double() == 35.0);
+    CHECK(frame.get("bar")->as_bool() == false);
+
+    frame.set("foo", "test");
+    CHECK(frame.get("foo")->as_string() == "test");
+    CHECK_FALSE(frame.get("not here"));
+}

--- a/tests/property.cpp
+++ b/tests/property.cpp
@@ -1,0 +1,120 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <catch.hpp>
+#include "helpers.hpp"
+#include "chemfiles/Property.hpp"
+using namespace chemfiles;
+
+TEST_CASE("Property") {
+    SECTION("Bool") {
+        auto property = Property(false);
+
+        CHECK(property.as_bool() == false);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+    }
+
+    SECTION("Double") {
+        auto property = Property(42.0);
+
+        CHECK(property.as_double() == 42.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(23.0f);
+        CHECK(property.as_double() == 23.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(23);
+        CHECK(property.as_double() == 23.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(24l);
+        CHECK(property.as_double() == 24.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(25ll);
+        CHECK(property.as_double() == 25.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(26u);
+        CHECK(property.as_double() == 26.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(27ul);
+        CHECK(property.as_double() == 27.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property(28ull);
+        CHECK(property.as_double() == 28.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        short val_short = 29;
+        property = Property(val_short);
+        CHECK(property.as_double() == 29.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        char val_char = 30;
+        property = Property(val_char);
+        CHECK(property.as_double() == 30.0);
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+    }
+
+    SECTION("String") {
+        auto property = Property(std::string("test"));
+        CHECK(property.as_string() == "test");
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        property = Property("test-2");
+        CHECK(property.as_string() == "test-2");
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        char data[] = {'e', 'm', 'p', 't', 'y', '\0'};
+        property = Property(data);
+        CHECK(property.as_string() == "empty");
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+
+        char* val_char = data;
+        property = Property(val_char);
+        CHECK(property.as_string() == "empty");
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+        CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
+    }
+
+    SECTION("Vector3D") {
+        auto property = Property(vector3d(0.0, 1.1, 2.2));
+
+        CHECK(property.as_vector3d() == vector3d(0.0, 1.1, 2.2));
+        CHECK_THROWS_AS(property.as_bool(), PropertyError);
+        CHECK_THROWS_AS(property.as_string(), PropertyError);
+        CHECK_THROWS_AS(property.as_double(), PropertyError);
+    }
+}


### PR DESCRIPTION
Fix #85.

@pgbarletta, this can replace your implementation from #96 if you are ok with it. You can then add the PDB part of this =)

If you have some time and you could give this a quick look to tell me if anything looks weird,  it would be great! Compared to our last discussion on the topic, I changed to return type of `Frame::get` and `Atom::get` to `optional<const Property&>`, because the other functions on Atom already use this.

The alternative would be to return `const Property&` and throw an exception on missing data.