### PR TITLE
Also normalize 1-letter atomic type

### DIFF
--- a/src/Atom.cpp
+++ b/src/Atom.cpp
@@ -18,8 +18,14 @@ static char to_lower(char c) {
 
 static optional<const ElementData&> find_element(const std::string& name) {
     std::map<std::string, ElementData>::const_iterator periodic;
-    if (name.length() == 2) {
-        auto normalized = name;
+    std::string normalized;
+    if (name.length() == 1) {
+        normalized = name;
+        normalized[0] = to_upper(normalized[0]);
+
+        periodic = PERIODIC_INFORMATION.find(normalized);
+    } else if (name.length() == 2) {
+        normalized = name;
         normalized[0] = to_upper(normalized[0]);
         normalized[1] = to_lower(normalized[1]);
 
@@ -27,6 +33,7 @@ static optional<const ElementData&> find_element(const std::string& name) {
     } else {
         periodic = PERIODIC_INFORMATION.find(name);
     }
+
     if (periodic != PERIODIC_INFORMATION.end()) {
         return periodic->second;
     } else {

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -93,6 +93,12 @@ TEST_CASE("Use the Atom type"){
         CHECK(atom.full_name().value() == "Zinc");
         CHECK(atom.covalent_radius().value() == 1.31);
         CHECK(atom.vdw_radius().value() == 2.1);
+
+        atom = Atom("c");
+        CHECK(atom.atomic_number().value() == 6);
+        CHECK(atom.full_name().value() == "Carbon");
+        CHECK(atom.covalent_radius().value() == 0.77);
+        CHECK(atom.vdw_radius().value() == 1.7);
     }
 
     SECTION("Property map") {


### PR DESCRIPTION
We already normalize 2 letters atomic types when looking for atomic properties: `Atom("ZN")` and `Atom("zN")` use the Zinc atomic data.

This introduce the same normalization for 1 letter atomic type, so that `Atom("C")` and `Atom("c")` are the same thing.

@pgbarletta, do you think we should do this? It feels more coherent to me.