### PR TITLE
Allow to access Property kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added `Frame::distance`, `Frame::angle` and `Frame::dihedral` to get
   geometric information on the system, accounting for periodic boundary
   conditions.  
+* Added a `Property` class to store arbitrary properties in `Frame` and `Atom`.
 
 ### Changes in supported formats
 
@@ -46,6 +47,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `chfl_cell_wrap` to work with periodic boundary conditions.
 * `chfl_residue` does not take the optional residue id as parameter, instead you
   should use `chfl_residue_with_id`.
+* Added `CHFL_PROPERTY` and related functions.
 
 ### Deprecation and removals
 

--- a/doc/src/capi/chfl_property.rst
+++ b/doc/src/capi/chfl_property.rst
@@ -13,6 +13,8 @@ Function manipulating ``CHFL_PROPERTY``
 
 .. doxygenfunction:: chfl_property_vector3d
 
+.. doxygenfunction:: chfl_property_get_kind
+
 .. doxygenfunction:: chfl_property_get_bool
 
 .. doxygenfunction:: chfl_property_get_double

--- a/include/chemfiles/Property.hpp
+++ b/include/chemfiles/Property.hpp
@@ -20,6 +20,14 @@ namespace chemfiles {
 /// `Vector3D`.
 class CHFL_EXPORT Property final {
 public:
+    /// Possible types holded by a property
+    enum kind {
+        BOOL = 0,
+        DOUBLE = 1,
+        STRING = 2,
+        VECTOR3D = 3,
+    };
+
     /// Create a property holding a boolean value.
     Property(bool value): kind_(BOOL), bool_(value) {}
     /// Create a property holding a double value.
@@ -106,6 +114,11 @@ public:
         }
     }
 
+    /// Get the kind of property, *i.e.* the type of the holded value
+    kind get_kind() const {
+        return this->kind_;
+    }
+
     /// Get the boolean value stored in this Property
     ///
     /// @throws PropertyError if this property does not hold a boolean value
@@ -130,13 +143,7 @@ private:
     /// Get the kind name as a string
     std::string kind_as_string() const;
 
-    enum {
-        BOOL,
-        STRING,
-        DOUBLE,
-        VECTOR3D,
-    } kind_;
-
+    kind kind_;
     union {
         bool bool_;
         std::string string_;

--- a/include/chemfiles/capi/property.h
+++ b/include/chemfiles/capi/property.h
@@ -9,6 +9,18 @@
 extern "C" {
 #endif
 
+/// Possible values holded by a CHFL_PROPERTY
+typedef enum {
+    /// Bool value
+    CHFL_PROPERTY_BOOL = 0,
+    /// Double value
+    CHFL_PROPERTY_DOUBLE = 1,
+    /// String value
+    CHFL_PROPERTY_STRING = 2,
+    /// chfl_vector3d value
+    CHFL_PROPERTY_VECTOR3D = 3,
+} chfl_property_kind;
+
 /// Create a new property holding a boolean `value`.
 ///
 /// The caller of this function should free the allocated memory using
@@ -48,6 +60,15 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_property_string(const char* value);
 /// @return A pointer to the property, or NULL in case of error. You can use
 ///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_PROPERTY* chfl_property_vector3d(const chfl_vector3d value);
+
+/// Get the type of value holded by this `property` in `kind`.
+///
+/// @example{tests/capi/doc/chfl_property/get_kind.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_property_get_kind(
+    const CHFL_PROPERTY* const property, chfl_property_kind* kind
+);
 
 /// Get the boolean value holded by this `property` in the location pointed to
 /// by `data`.

--- a/src/capi/property.cpp
+++ b/src/capi/property.cpp
@@ -7,6 +7,8 @@
 #include "chemfiles/Property.hpp"
 using namespace chemfiles;
 
+static_assert(sizeof(chfl_property_kind) == sizeof(int), "Wrong size for chfl_property_kind enum");
+
 extern "C" CHFL_PROPERTY* chfl_property_bool(bool value) {
     CHFL_PROPERTY* property = nullptr;
     CHFL_ERROR_GOTO(
@@ -49,6 +51,14 @@ extern "C" CHFL_PROPERTY* chfl_property_vector3d(const chfl_vector3d value) {
 error:
     delete property;
     return nullptr;
+}
+
+extern "C" chfl_status chfl_property_get_kind(const CHFL_PROPERTY* const property, chfl_property_kind* kind) {
+    CHECK_POINTER(property);
+    CHECK_POINTER(kind);
+    CHFL_ERROR_CATCH(
+        *kind = static_cast<chfl_property_kind>(property->get_kind());
+    )
 }
 
 extern "C" chfl_status chfl_property_get_bool(const CHFL_PROPERTY* const property, bool* value) {

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -305,19 +305,19 @@ void PDBFormat::write(const Frame& frame) {
         auto& pos = frame.positions()[i];
 
         std::string atom_hetatm = "HETATM";
-        auto atom_property = frame.topology()[i].get("is_hetatm");
-        if (atom_property) {
-          try {
-            if (atom_property->as_bool()) {
-              atom_hetatm = "HETATM";
-            } else{
-              atom_hetatm = "ATOM  ";
+        auto is_hetatm = frame.topology()[i].get("is_hetatm");
+        if (is_hetatm) {
+            if (is_hetatm->get_kind() == Property::BOOL) {
+                if (is_hetatm->as_bool()) {
+                    atom_hetatm = "HETATM";
+                } else {
+                    atom_hetatm = "ATOM  ";
+                }
+            } else {
+                warning(
+                    "\'is_hetatm\' property is not a boolean in PDB writer, using HETATM"
+                );
             }
-          }
-          catch (const PropertyError &e) {
-            warning("\'is_hetatm\' property set to non-bool variable."
-            "Defaulting to HETATM");
-          }
         }
 
         std::string resname;

--- a/tests/capi/doc/chfl_property/kind.c
+++ b/tests/capi/doc/chfl_property/kind.c
@@ -1,0 +1,18 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    CHFL_PROPERTY* property = chfl_property_double(256);
+
+    chfl_property_kind kind;
+    chfl_property_get_kind(property, &kind);
+    assert(kind == CHFL_PROPERTY_DOUBLE);
+
+    chfl_property_free(property);
+    // [example]
+    return 0;
+}

--- a/tests/capi/property.cpp
+++ b/tests/capi/property.cpp
@@ -21,6 +21,10 @@ TEST_CASE("Property") {
         chfl_vector3d dummy_vector = {0};
         CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
 
+        chfl_property_kind kind;
+        CHECK_STATUS(chfl_property_get_kind(property, &kind));
+        CHECK(kind == CHFL_PROPERTY_BOOL);
+
         CHECK_STATUS(chfl_property_free(property));
     }
 
@@ -39,6 +43,10 @@ TEST_CASE("Property") {
         chfl_vector3d dummy_vector = {0};
         CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
 
+        chfl_property_kind kind;
+        CHECK_STATUS(chfl_property_get_kind(property, &kind));
+        CHECK(kind == CHFL_PROPERTY_DOUBLE);
+
         CHECK_STATUS(chfl_property_free(property));
     }
 
@@ -56,6 +64,10 @@ TEST_CASE("Property") {
         CHECK(chfl_property_get_bool(property, &dummy_bool) == CHFL_PROPERTY_ERROR);
         chfl_vector3d dummy_vector = {0};
         CHECK(chfl_property_get_vector3d(property, dummy_vector) == CHFL_PROPERTY_ERROR);
+
+        chfl_property_kind kind;
+        CHECK_STATUS(chfl_property_get_kind(property, &kind));
+        CHECK(kind == CHFL_PROPERTY_STRING);
 
         CHECK_STATUS(chfl_property_free(property));
     }
@@ -77,6 +89,10 @@ TEST_CASE("Property") {
         CHECK(chfl_property_get_bool(property, &dummy_bool) == CHFL_PROPERTY_ERROR);
         double dummy_double = 0;
         CHECK(chfl_property_get_double(property, &dummy_double) == CHFL_PROPERTY_ERROR);
+
+        chfl_property_kind kind;
+        CHECK_STATUS(chfl_property_get_kind(property, &kind));
+        CHECK(kind == CHFL_PROPERTY_VECTOR3D);
 
         CHECK_STATUS(chfl_property_free(property));
     }

--- a/tests/property.cpp
+++ b/tests/property.cpp
@@ -11,6 +11,8 @@ TEST_CASE("Property") {
         auto property = Property(false);
 
         CHECK(property.as_bool() == false);
+        CHECK(property.get_kind() == Property::BOOL);
+
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -20,48 +22,57 @@ TEST_CASE("Property") {
         auto property = Property(42.0);
 
         CHECK(property.as_double() == 42.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
+
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(23.0f);
         CHECK(property.as_double() == 23.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(23);
         CHECK(property.as_double() == 23.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(24l);
         CHECK(property.as_double() == 24.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(25ll);
         CHECK(property.as_double() == 25.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(26u);
         CHECK(property.as_double() == 26.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(27ul);
         CHECK(property.as_double() == 27.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(28ull);
         CHECK(property.as_double() == 28.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -69,6 +80,7 @@ TEST_CASE("Property") {
         short val_short = 29;
         property = Property(val_short);
         CHECK(property.as_double() == 29.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -76,6 +88,7 @@ TEST_CASE("Property") {
         char val_char = 30;
         property = Property(val_char);
         CHECK(property.as_double() == 30.0);
+        CHECK(property.get_kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -84,12 +97,14 @@ TEST_CASE("Property") {
     SECTION("String") {
         auto property = Property(std::string("test"));
         CHECK(property.as_string() == "test");
+        CHECK(property.get_kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property("test-2");
         CHECK(property.as_string() == "test-2");
+        CHECK(property.get_kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -97,6 +112,7 @@ TEST_CASE("Property") {
         char data[] = {'e', 'm', 'p', 't', 'y', '\0'};
         property = Property(data);
         CHECK(property.as_string() == "empty");
+        CHECK(property.get_kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -104,6 +120,7 @@ TEST_CASE("Property") {
         char* val_char = data;
         property = Property(val_char);
         CHECK(property.as_string() == "empty");
+        CHECK(property.get_kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -113,6 +130,7 @@ TEST_CASE("Property") {
         auto property = Property(Vector3D(0.0, 1.1, 2.2));
 
         CHECK(property.as_vector3d() == Vector3D(0.0, 1.1, 2.2));
+        CHECK(property.get_kind() == Property::VECTOR3D);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);


### PR DESCRIPTION
This means that instead of writing

```cpp
auto property = Property(...);

try {
   auto value = property.as_double();
} catch (const PropertyError&) {
   // ...
} 
```

one can write simpler code as

```cpp
auto property = Property(...);

if (property.get_kind() == Property::DOUBLE) {
   auto value = property.as_double();
} else {
   // ...
} 
```

This will be handy for the dynamic languages binding of property, allowing to directly extract a property value without checking for all possible kinds.