### PR TITLE
1st step in MODEL/ENDMDL support for PDB format. Added step_ variable…

### DIFF
--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -41,6 +41,9 @@ private:
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekg` them instead of reading the whole step.
     std::vector<std::streampos> steps_positions_;
+    // Last red step.
+    size_t step_;
+
 };
 
 } // namespace chemfiles

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -26,6 +26,8 @@ public:
     void read(Frame& frame) override;
     void write(const Frame& frame) override;
     size_t nsteps() override;
+    ~PDBFormat();
+    
 private:
     // Read CRYST1 record
     void read_CRYST1(Frame& frame, const std::string& line);
@@ -43,6 +45,8 @@ private:
     std::vector<std::streampos> steps_positions_;
     // Last red step.
     size_t step_;
+    // If the object is used to write a file set to true.
+    bool written_ = false;
 
 };
 

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -27,7 +27,7 @@ public:
     void write(const Frame& frame) override;
     size_t nsteps() override;
     ~PDBFormat();
-    
+
 private:
     // Read CRYST1 record
     void read_CRYST1(Frame& frame, const std::string& line);
@@ -43,9 +43,10 @@ private:
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekg` them instead of reading the whole step.
     std::vector<std::streampos> steps_positions_;
-    // Last red step.
-    size_t step_;
-    // If the object is used to write a file set to true.
+    /// Number of models written/read to the file.
+    size_t models_;
+    /// Did we wrote a frame to the file? This is used to check wheter we need
+    /// to write a final `END` record in the destructor
     bool written_ = false;
 
 };

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -45,7 +45,7 @@ enum class Record {
 static Record get_record(const std::string& line);
 
 PDBFormat::PDBFormat(const std::string& path, File::Mode mode)
-  : file_(TextFile::create(path, mode)), step_(0) {
+  : file_(TextFile::create(path, mode)), models_(0) {
     while (!file_->eof()) {
         auto position = file_->tellg();
         if (!file_ || position == std::streampos(-1)) {
@@ -89,7 +89,7 @@ void PDBFormat::read(Frame& frame) {
             read_CONECT(frame, line);
             break;
         case Record::MODEL:
-            ++step_;
+            models_++;
             break;
         case Record::END:
             goto end; // We have read a frame!
@@ -297,7 +297,7 @@ static std::string to_pdb_index(uint64_t i) {
 
 void PDBFormat::write(const Frame& frame) {
     written_ = true;
-    fmt::print(*file_, "MODEL {:>4}\n", step_+1);
+    fmt::print(*file_, "MODEL {:>4}\n", models_ + 1);
 
     auto& cell = frame.cell();
     check_values_size(Vector3D(cell.a(), cell.b(), cell.c()), 9, "cell lengths");
@@ -410,7 +410,7 @@ void PDBFormat::write(const Frame& frame) {
 
     fmt::print(*file_, "ENDMDL\n");
 
-    ++step_;
+    models_++;
     steps_positions_.push_back(file_->tellg());
 }
 

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -245,6 +245,7 @@ bool forward(TextFile& file) {
 
             if (line.substr(0, 6) == "ENDMDL" &&
             file.readline().substr(0, 3) == "END" ) {
+              // An ENDMDL was followed and an END. This means `END`.
               return false;
             }
 
@@ -425,7 +426,7 @@ void check_values_size(const Vector3D& values, unsigned width, const std::string
 }
 
 PDBFormat::~PDBFormat() {
-  if (written_) {
-    fmt::print(*file_, "END\n");
-  }
+    if (written_) {
+      fmt::print(*file_, "END\n");
+    }
 }

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -264,7 +264,7 @@ Record get_record(const std::string& line) {
                rec == "CAVEAT" || rec == "COMPND" || rec == "EXPDTA" ||
                rec == "KEYWDS" || rec == "OBSLTE" || rec == "SOURCE" ||
                rec == "SPLIT " || rec == "SPRSDE" || rec == "TITLE " ||
-               rec == "JRNL  " || rec.substr(0, 5) == "MODEL" ) {
+               rec == "JRNL  " || rec == "MODEL " ) {
         return Record::IGNORED_;
     } else {
         return Record::UNKNOWN_;
@@ -393,7 +393,7 @@ void PDBFormat::write(const Frame& frame) {
             fmt::print(*file_, "\n");
         }
     }
-    
+
     fmt::print(*file_, "ENDMDL\n");
 
     ++step_;

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -242,9 +242,15 @@ bool forward(TextFile& file) {
     while (true) {
         try {
             auto line = file.readline();
-            // Applies to 'END' and 'ENDMDL' records.
+
+            if (line.substr(0, 6) == "ENDMDL" &&
+            file.readline().substr(0, 3) == "END" ) {
+              return false;
+            }
+
             if (line.substr(0, 3) == "END") {
                 return true;
+
             }
         } catch (const FileError&) {
             return false;
@@ -270,7 +276,7 @@ Record get_record(const std::string& line) {
                rec == "CAVEAT" || rec == "COMPND" || rec == "EXPDTA" ||
                rec == "KEYWDS" || rec == "OBSLTE" || rec == "SOURCE" ||
                rec == "SPLIT " || rec == "SPRSDE" || rec == "TITLE " ||
-               rec == "JRNL  ") {
+               rec == "JRNL  " || rec == "TER   ") {
         return Record::IGNORED_;
     } else {
         return Record::UNKNOWN_;

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -31,6 +31,8 @@ enum class Record {
     ATOM,
     HETATM,
     CONECT,
+    // Beggining of model.
+    MODEL,
     // End of file
     END,
     // Ignored records
@@ -86,6 +88,9 @@ void PDBFormat::read(Frame& frame) {
         case Record::CONECT:
             read_CONECT(frame, line);
             break;
+        case Record::MODEL:
+            ++step_;
+            break;
         case Record::END:
             goto end; // We have read a frame!
         case Record::IGNORED_:
@@ -102,7 +107,6 @@ end:
     for (auto& residue: residues_) {
         frame.topology().add_residue(residue.second);
     }
-    ++step_;
 }
 
 void PDBFormat::read_CRYST1(Frame& frame, const std::string& line) {
@@ -250,7 +254,7 @@ bool forward(TextFile& file) {
 
 Record get_record(const std::string& line) {
     auto rec = line.substr(0, 6);
-    if (rec.substr(0, 3) == "END") { // Handle missing whitespaces in END
+    if(rec.substr(0, 3) == "END") { // Handle missing whitespaces in END
         return Record::END;
     } else if (rec == "CRYST1") {
         return Record::CRYST1;
@@ -260,11 +264,13 @@ Record get_record(const std::string& line) {
         return Record::HETATM;
     } else if (rec == "CONECT") {
         return Record::CONECT;
+    } else if (rec == "MODEL "){
+        return Record::MODEL;
     } else if (rec == "REMARK" || rec == "MASTER" || rec == "AUTHOR" ||
                rec == "CAVEAT" || rec == "COMPND" || rec == "EXPDTA" ||
                rec == "KEYWDS" || rec == "OBSLTE" || rec == "SOURCE" ||
                rec == "SPLIT " || rec == "SPRSDE" || rec == "TITLE " ||
-               rec == "JRNL  " || rec == "MODEL " ) {
+               rec == "JRNL  ") {
         return Record::IGNORED_;
     } else {
         return Record::UNKNOWN_;

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -295,6 +295,7 @@ static std::string to_pdb_index(uint64_t i) {
 }
 
 void PDBFormat::write(const Frame& frame) {
+    written_ = true;
     fmt::print(*file_, "MODEL {:>4}\n", step_+1);
 
     auto& cell = frame.cell();
@@ -421,4 +422,10 @@ void check_values_size(const Vector3D& values, unsigned width, const std::string
             "value in {} is too big for representation in PDB format", context
         );
     }
+}
+
+PDBFormat::~PDBFormat() {
+  if (written_) {
+    fmt::print(*file_, "END\n");
+  }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "7563f17f1d85865c811543f1d78fa474d0b9d9b1")
+set(TESTS_DATA_GIT "f5d3c71fd8b70d4eee4abd3aec499c4d5b027521")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -8,7 +8,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=4645b5ad8ecf49ce29243f035b4667552ff0ee65
+        EXPECTED_HASH SHA1=c15da8d74675834822e5e1047970dbfe0011df11
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -184,9 +184,9 @@ TEST_CASE("Write files in PDB format") {
 
     frame.resize(7);
     positions = frame.positions();
-    for(size_t i=0; i<7; i++)
+    for(size_t i=0; i<7; i++) {
         positions[i] = Vector3D(4, 5, 6);
-
+    }
     topology.add_atom(Atom("E"));
     topology.add_atom(Atom("F"));
     topology.add_atom(Atom("G"));

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -12,7 +12,7 @@ static bool contains(const std::vector<T> haystack, const T& needle) {
     return std::find(haystack.begin(), haystack.end(), needle) != haystack.end();
 }
 
-TEST_CASE("Read files in PDB format"){
+TEST_CASE("Read files in PDB format") {
     SECTION("Read next step") {
         Trajectory file("data/pdb/water.pdb");
         Frame frame = file.read();
@@ -35,7 +35,7 @@ TEST_CASE("Read files in PDB format"){
         CHECK(approx_eq(positions[296], Vector3D(6.798, 11.509, 12.704), 1e-4));
     }
 
-    SECTION("Read a specific step"){
+    SECTION("Read a specific step") {
         Trajectory file("data/pdb/water.pdb");
 
         auto frame = file.read_step(2);
@@ -111,16 +111,27 @@ TEST_CASE("Read files in PDB format"){
     }
 
     SECTION("Read ATOM/HETATM information") {
-      Trajectory file("data/pdb/hemo.pdb");
-      Frame frame = file.read();
+        Trajectory file("data/pdb/hemo.pdb");
+        Frame frame = file.read();
 
-      for (size_t i = 0; i < 73; i++) {
-        CHECK(frame.topology()[i].get("is_hetatm")->as_bool());
-      }
-      for (size_t i = 73; i < 522; i++) {
-        CHECK(frame.topology()[i].get("is_hetatm")->as_bool() == false);
-      }
+        for (size_t i = 0; i < 73; i++) {
+            CHECK(frame.topology()[i].get("is_hetatm")->as_bool());
+        }
 
+        for (size_t i = 73; i < 522; i++) {
+            CHECK(frame.topology()[i].get("is_hetatm")->as_bool() == false);
+        }
+    }
+
+    SECTION("Handle multiple END records") {
+        Trajectory file("data/pdb/end-endmdl.pdb");
+        CHECK(file.nsteps() == 2);
+
+        auto frame = file.read();
+        CHECK(frame.natoms() == 4);
+
+        frame = file.read();
+        CHECK(frame.natoms() == 7);
     }
 }
 

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -127,6 +127,7 @@ TEST_CASE("Read files in PDB format"){
 TEST_CASE("Write files in PDB format") {
     auto tmpfile = NamedTempPath(".pdb");
     const auto EXPECTED_CONTENT =
+    "MODEL    1\n"
     "CRYST1   22.000   22.000   22.000  90.00  90.00  90.00 P 1           1\n"
     "ATOM      1 A    XXX X   1       1.000   2.000   3.000  1.00  0.00           A\n"
     "HETATM    2 B    XXX X   2       1.000   2.000   3.000  1.00  0.00           B\n"
@@ -134,7 +135,9 @@ TEST_CASE("Write files in PDB format") {
     "HETATM    4 D    XXX X   4       1.000   2.000   3.000  1.00  0.00           D\n"
     "CONECT    1    2\n"
     "CONECT    2    1\n"
+    "ENDMDL\n"
     "END\n"
+    "MODEL    1\n"
     "CRYST1   22.000   22.000   22.000  90.00  90.00  90.00 P 1           1\n"
     "ATOM      1 A    XXX X   4       4.000   5.000   6.000  1.00  0.00           A\n"
     "HETATM    2 B    foo X   3       4.000   5.000   6.000  1.00  0.00           B\n"
@@ -152,6 +155,7 @@ TEST_CASE("Write files in PDB format") {
     "CONECT    6    5    7\n"
     "CONECT    7    1    2    3    4\n"
     "CONECT    7    5    6\n"
+    "ENDMDL\n"
     "END\n";
 
     Topology topology;

--- a/tests/trajectory.cpp
+++ b/tests/trajectory.cpp
@@ -107,10 +107,12 @@ TEST_CASE("Associate an unit cell and a trajectory") {
     SECTION("Writing") {
         auto tmpfile = NamedTempPath(".pdb");
         const auto EXPECTED_CONTENT =
+        "MODEL    1\n"
         "CRYST1    3.000    4.000    5.000  90.00  90.00  90.00 P 1           1\n"
         "HETATM    1      XXX X   1       1.000   2.000   3.000  1.00  0.00            \n"
         "HETATM    2      XXX X   2       1.000   2.000   3.000  1.00  0.00            \n"
-        "HETATM    3      XXX X   3       1.000   2.000   3.000  1.00  0.00            \n"        
+        "HETATM    3      XXX X   3       1.000   2.000   3.000  1.00  0.00            \n"
+        "ENDMDL\n"
         "END\n";
 
         Frame frame(3);


### PR DESCRIPTION
… support in the PDB format and added MODEL record as an IGNORED record.

From: https://github.com/chemfiles/chemfiles/issues/103

OK, I'm gonna need some help with this. I couldn't find the code to check for the last frame of the trajectory. That is, how do I know, inside the `PDBFormat::Write` function, that the current `Frame` is the last of the trajectory I'm writing?
If write a 10 frames trajectory, this is how my PDB file is ending:
```
MODEL   11
CRYST1    0.000    0.000    0.000  90.00  90.00  90.00 P 1           1
ENDMDL
```
I could fix this and add the `END` statement if I could detect the last frame. 
Or maybe I'm not using `step_` and `steps_positions_`  properly. If this is the case, then I could fix the bad ending, but I would still need a place where to add the `END` record (which by the way, is not mandatory). Maybe inside the `~Trajectory` destructor like you said? But I would have to check, ---for the `Trajectory` object being deleted---, that:
`format_ == std::unique_ptr<PDBFormat>` is `True`
and that is was written to a file, which I wouldn't know how to do. 
Maybe this `END` statement should come just before closing a PDB format file? And where does that happen? 
I don't know, I'm getting hazy.