### PR TITLE
Ensure that only whitelisted headers can be included in the public interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,9 @@ script:
   - make -j2
   - ctest -j2 --output-on-failure
   - cd $TRAVIS_BUILD_DIR
-  # Check C API documentation
+  # Run various additional checks
   - ./scripts/ci/check-capi.py
+  - ./scripts/ci/check-public-headers.py
   # Build docs
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/include/chemfiles/Property.hpp
+++ b/include/chemfiles/Property.hpp
@@ -10,7 +10,7 @@
 #include "chemfiles/exports.hpp"
 #include "chemfiles/optional.hpp"
 #include "chemfiles/types.hpp"
-#include "chemfiles/utils.hpp"
+#include "chemfiles/unreachable.hpp"
 #include "chemfiles/Error.hpp"
 
 namespace chemfiles {

--- a/include/chemfiles/unreachable.hpp
+++ b/include/chemfiles/unreachable.hpp
@@ -1,0 +1,25 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#ifndef CHEMFILES_UNREACHABLE_HPP
+#define CHEMFILES_UNREACHABLE_HPP
+
+#include "chemfiles/Error.hpp"
+
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_unreachable)
+    #define unreachable() __builtin_unreachable()
+#elif GCC_VERSION >= 40500
+    #define unreachable() __builtin_unreachable()
+#elif defined(_MSC_VER)
+    #define unreachable() __assume(false)
+#else
+    #define unreachable() do {                     \
+        throw Error("entered unreachable code");   \
+    } while (false)
+#endif
+
+#endif

--- a/include/chemfiles/utils.hpp
+++ b/include/chemfiles/utils.hpp
@@ -75,21 +75,6 @@ inline long long int string2longlong(const std::string& string) {
     }
 }
 
-#ifndef __has_builtin
-  #define __has_builtin(x) 0
-#endif
-
-#if __has_builtin(__builtin_unreachable)
-    #define unreachable() __builtin_unreachable()
-#elif GCC_VERSION >= 40500
-    #define unreachable() __builtin_unreachable()
-#elif defined(_MSC_VER)
-    #define unreachable() __assume(false)
-#else
-    #define unreachable() do {                     \
-        throw Error("entered unreachable code");   \
-    } while (false)
-#endif
 }
 
 #endif

--- a/scripts/ci/check-public-headers.py
+++ b/scripts/ci/check-public-headers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+"""
+This script check that only whitelisted headers are included (transitivly) by
+including chemfiles.h or chemfiles.hpp.
+"""
+import os
+import sys
+import re
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+GENERATED_HEADERS = ["chemfiles/config.hpp", "chemfiles/exports.hpp"]
+ERRORS = 0
+
+WHITELIST = [
+    # standard C99 headers
+    "stdbool.h", "stdint.h",
+    # standard C++11 headers
+    "iterator", "functional", "cstdint", "array", "utility", "cassert",
+    "string", "memory", "exception", "limits", "algorithm", "stdexcept",
+    "vector", "cmath", "type_traits", "unordered_map",
+    # chemfiles helper headers
+    "chemfiles/span.hpp",
+    "chemfiles/optional.hpp",
+    "chemfiles/exports.hpp",
+    "chemfiles/config.hpp",
+    "chemfiles/sorted_set.hpp",
+    "chemfiles/unreachable.hpp",
+    # chemfiles main headers
+    "chemfiles/generic.hpp",
+    "chemfiles/types.hpp",
+    "chemfiles/Atom.hpp",
+    "chemfiles/Frame.hpp",
+    "chemfiles/Error.hpp",
+    "chemfiles/Residue.hpp",
+    "chemfiles/Property.hpp",
+    "chemfiles/Topology.hpp",
+    "chemfiles/UnitCell.hpp",
+    "chemfiles/Trajectory.hpp",
+    "chemfiles/Selections.hpp",
+    "chemfiles/Connectivity.hpp",
+    # chemfiles capi headers
+    "chemfiles/capi/atom.h",
+    "chemfiles/capi/selection.h",
+    "chemfiles/capi/trajectory.h",
+    "chemfiles/capi/residue.h",
+    "chemfiles/capi/property.h",
+    "chemfiles/capi/cell.h",
+    "chemfiles/capi/frame.h",
+    "chemfiles/capi/types.h",
+    "chemfiles/capi/topology.h",
+    "chemfiles/capi/misc.h",
+]
+
+
+def error(message):
+    global ERRORS
+    ERRORS += 1
+    print(message)
+
+
+def included_headers(path):
+    includes = set()
+    with open(path) as fd:
+        for line in fd:
+            if "#include" in line:
+                matched = re.match("#include\s*[\"<](.*)[\">]", line)
+                if not matched:
+                    error("bad include in {}: {}".format(path, line))
+                header = matched.groups()[0]
+                includes.add(header)
+                if header.startswith("chemfiles"):
+                    if header not in GENERATED_HEADERS:
+                        path = os.path.join(ROOT, "include", header)
+                        includes.update(included_headers(path))
+    return includes
+
+
+def check_allowded(headers):
+    for header in headers:
+        if header not in WHITELIST:
+            error("private header {} is publicly reachable".format(header))
+
+
+if __name__ == '__main__':
+    headers = included_headers(os.path.join(ROOT, "include", "chemfiles.h"))
+    check_allowded(headers)
+
+    headers = included_headers(os.path.join(ROOT, "include", "chemfiles.hpp"))
+    check_allowded(headers)
+
+    if ERRORS != 0:
+        sys.exit(1)

--- a/src/UnitCell.cpp
+++ b/src/UnitCell.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 
 #include "chemfiles/ErrorFmt.hpp"
-#include "chemfiles/utils.hpp"
+#include "chemfiles/unreachable.hpp"
 #include "chemfiles/UnitCell.hpp"
 using namespace chemfiles;
 

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -5,6 +5,7 @@
 
 #include "chemfiles/ErrorFmt.hpp"
 #include "chemfiles/utils.hpp"
+#include "chemfiles/unreachable.hpp"
 #include "chemfiles/selections/lexer.hpp"
 
 using namespace chemfiles;


### PR DESCRIPTION
This should prevent accidental pollution.