### PR TITLE
Fix bonds indexes after removing an atom

### DIFF
--- a/include/chemfiles/Connectivity.hpp
+++ b/include/chemfiles/Connectivity.hpp
@@ -219,8 +219,6 @@ inline bool operator>=(const Improper& lhs, const Improper& rhs) {
 class Connectivity {
 public:
     Connectivity() = default;
-    /// Recalculate the angles and the dihedrals from the bond list
-    void recalculate() const;
     /// Get the bonds in this connectivity
     const sorted_set<Bond>& bonds() const;
     /// Get the angles in this connectivity
@@ -233,8 +231,15 @@ public:
     void add_bond(size_t i, size_t j);
     /// Remove any bond between the atoms `i` and `j`
     void remove_bond(size_t i, size_t j);
+    /// Update the indexes of the bonds after atom removal
+    /// This function shifts all indexes bigger than i in the bonds/angles/dihedrals/impropers
+    /// lists by -1.
+    void atom_removed(size_t i);
 
 private:
+    /// Recalculate the angles and the dihedrals from the bond list
+    void recalculate() const;
+
     /// Biggest index within the atoms we know about. Used to pre-allocate
     /// memory when recomputing bonds.
     size_t biggest_atom_ = 0;

--- a/src/Connectivity.cpp
+++ b/src/Connectivity.cpp
@@ -192,3 +192,28 @@ void Connectivity::remove_bond(size_t i, size_t j) {
         bonds_.erase(pos);
     }
 }
+
+void Connectivity::atom_removed(size_t atom) {
+    auto to_remove = std::vector<Bond>();
+    auto to_add = std::vector<Bond>();
+    for (auto& bond: bonds_) {
+        if (bond[0] == atom || bond[1] == atom) {
+            throw error("can not shift atomic indexes that still have a bond");
+        }
+        if (bond[0] > atom || bond[1] > atom) {
+            to_remove.push_back(bond);
+
+            auto i = bond[0] > atom ? bond[0] - 1 : bond[0];
+            auto j = bond[1] > atom ? bond[1] - 1 : bond[1];
+            to_add.push_back({i, j});
+        }
+    }
+
+    for (auto bond: to_remove) {
+        this->remove_bond(bond[0], bond[1]);
+    }
+
+    for (auto bond: to_add) {
+        this->add_bond(bond[0], bond[1]);
+    }
+}

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -59,12 +59,15 @@ void Topology::remove(size_t i) {
         );
     }
     atoms_.erase(atoms_.begin() + static_cast<std::ptrdiff_t>(i));
+    // Remove all bonds with the removed atom
     auto bonds = connect_.bonds();
     for (auto& bond : bonds) {
         if (bond[0] == i || bond[1] == i) {
             connect_.remove_bond(bond[0], bond[1]);
         }
     }
+    // Shift all bonds indexes
+    connect_.atom_removed(i);
 }
 
 const std::vector<Bond>& Topology::bonds() const {

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -96,6 +96,11 @@ TEST_CASE("Unit cell") {
     CHECK(frame.cell().shape() == UnitCell::ORTHORHOMBIC);
 }
 
+TEST_CASE("Frame errors") {
+    auto frame = Frame(5);
+    CHECK_THROWS_AS(frame.set_topology(Topology()), Error);
+}
+
 TEST_CASE("Guess topology") {
     SECTION("Simple case") {
         auto frame = Frame();
@@ -131,10 +136,7 @@ TEST_CASE("Guess topology") {
         topology = frame.topology();
         CHECK(topology.bonds().size() == 3);
         CHECK(topology.angles().size() == 3);
-
-        // Wrong topology size
-        frame = Frame(5);
-        CHECK_THROWS_AS(frame.set_topology(Topology()), Error);
+        CHECK(topology.bonds() == (std::vector<Bond>{{0, 1}, {0, 2}, {0, 3}}));
     }
 
     SECTION("Cleanup supplementaty H-H bonds") {

--- a/tests/topology.cpp
+++ b/tests/topology.cpp
@@ -203,42 +203,72 @@ TEST_CASE("Out of bounds errors") {
 }
 
 TEST_CASE("Add and remove items in the topology") {
-    auto topology = Topology();
+    SECTION("Atoms") {
+        auto topology = Topology();
+        for (unsigned i=0; i<4; i++) {
+            topology.add_atom(Atom("H"));
+        }
+        topology.add_atom(Atom("O"));
+        topology.add_atom(Atom("O"));
 
-    for (unsigned i=0; i<4; i++) {
-        topology.add_atom(Atom("H"));
+        CHECK(topology.natoms() == 6);
+
+        topology.remove(4);
+        CHECK(topology.natoms() == 5);
     }
-    topology.add_atom(Atom("O"));
-    topology.add_atom(Atom("O"));
 
-    topology.add_bond(0, 4);
-    topology.add_bond(1, 4);
-    topology.add_bond(2, 5);
-    topology.add_bond(3, 5);
+    SECTION("Bonds") {
+        auto topology = Topology();
+        for (unsigned i=0; i<4; i++) {
+            topology.add_atom(Atom("H"));
+        }
+        topology.add_atom(Atom("O"));
+        topology.add_atom(Atom("O"));
 
-    CHECK(topology.bonds() == (std::vector<Bond>{{0, 4}, {1, 4}, {2, 5}, {3, 5}}));
-    CHECK(topology.angles() == (std::vector<Angle>{{0, 4, 1}, {2, 5, 3}}));
-    CHECK(topology.dihedrals() == (std::vector<Dihedral>{}));
+        topology.add_bond(0, 4);
+        topology.add_bond(1, 4);
+        topology.add_bond(2, 5);
+        topology.add_bond(3, 5);
 
-    topology.add_atom(Atom("O"));
-    topology.add_bond(3, 6);
-    CHECK(topology.bonds().size() == 5);
-    CHECK(topology.dihedrals()[0] == Dihedral(2, 5, 3, 6));
+        CHECK(topology.bonds() == (std::vector<Bond>{{0, 4}, {1, 4}, {2, 5}, {3, 5}}));
+        CHECK(topology.angles() == (std::vector<Angle>{{0, 4, 1}, {2, 5, 3}}));
+        CHECK(topology.dihedrals() == (std::vector<Dihedral>{}));
 
-    topology.remove(6);
-    CHECK(topology.natoms() == 6);
-    CHECK(topology.bonds().size() == 4);
+        topology.add_atom(Atom("O"));
+        topology.add_bond(3, 6);
+        CHECK(topology.bonds().size() == 5);
+        CHECK(topology.dihedrals()[0] == Dihedral(2, 5, 3, 6));
 
-    // we can not resize while there are bonds betweena atoms to remove
-    CHECK_THROWS_AS(topology.resize(5), Error);
+        topology.remove(6);
+        CHECK(topology.bonds().size() == 4);
 
-    topology.remove_bond(2, 5);
-    topology.remove_bond(3, 5);
-    CHECK(topology.natoms() == 6);
-    CHECK(topology.bonds().size() == 2);
+        // we can not resize while there are bonds betweena atoms to remove
+        CHECK_THROWS_AS(topology.resize(5), Error);
 
-    // Now that the bonds are gone, we can resize
-    topology.resize(5);
+        topology.remove_bond(2, 5);
+        topology.remove_bond(3, 5);
+        CHECK(topology.natoms() == 6);
+        CHECK(topology.bonds().size() == 2);
+
+        // Now that the bonds are gone, we can resize
+        topology.resize(5);
+    }
+
+    SECTION("Bonds and atoms") {
+        auto topology = Topology();
+        for (unsigned i=0; i<4; i++) {
+            topology.add_atom(Atom(""));
+        }
+
+        topology.add_bond(0, 2);
+        topology.add_bond(1, 3);
+
+        CHECK(topology.bonds() == (std::vector<Bond>{{0, 2}, {1, 3}}));
+
+        // Checking that the stored bonds indexes are updated
+        topology.remove(2);
+        CHECK(topology.bonds() == (std::vector<Bond>{{1, 2}}));
+    }
 }
 
 TEST_CASE("Residues in topologies") {


### PR DESCRIPTION
Removing an atom might shift other atomic indexes, we need to account for that and shift the bonds accordingly