### PR TITLE
Fix pdb MODEL reading

### DIFF
--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -262,9 +262,9 @@ bool forward(TextFile& file) {
 
             if (line.substr(0, 6) == "ENDMDL") {
                 auto position = file.tellg();
-                line = file.readline();
+                auto next = file.readline();
                 file.seekg(position);
-                if (line.substr(0, 3) == "END") {
+                if (next.substr(0, 3) == "END") {
                     // We found another record starting by END in the next line,
                     // we skip this one and wait for the next one
                     return false;
@@ -273,8 +273,8 @@ bool forward(TextFile& file) {
 
             if (line.substr(0, 3) == "END") {
                 return true;
-
             }
+
         } catch (const FileError&) {
             return false;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "a94c07b6a78083026e8b306fa662d82fb6341fc8")
+set(TESTS_DATA_GIT "c26f254cd7bff7e476bf065403fbd0a6a47fea38")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -8,7 +8,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=faabdb1722d401edfd9b867a25112b938eaa2187
+        EXPECTED_HASH SHA1=3b45cce20431c575364f896d763c48f5e9e31705
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -269,15 +269,11 @@ TEST_CASE("PDB files with big values") {
         positions[9998] = Vector3D(4., 5., 6.);
         positions[9999] = Vector3D(7., 8., 9.);
 
-        {
-            auto trajectory = Trajectory(tmpfile, 'w');
-            trajectory.write(frame);
-        }
+        Trajectory(tmpfile, 'w').write(frame);
 
-        auto in_trajectory = Trajectory(tmpfile, 'r');
-        auto in_frame = in_trajectory.read();
-        auto in_topology = in_frame.topology();
-        auto in_positions = in_frame.positions();
+        // Re-read the file we just wrote
+        frame = Trajectory(tmpfile, 'r').read();
+        positions = frame.positions();
 
         // If resSeq is has more than 4 characters, coordinates won't be read
         // correctly
@@ -293,7 +289,7 @@ TEST_CASE("PDB files with big values") {
         for(size_t i=0; i<10001; i++) {
             Atom atom("A");
             topology.add_atom(atom);
-            Residue residue("ANA", i+1);
+            Residue residue("ANA", i + 1);
             residue.add_atom(i);
             topology.add_residue(residue);
         }
@@ -303,15 +299,11 @@ TEST_CASE("PDB files with big values") {
         positions[9998] = Vector3D(4., 5., 6.);
         positions[9999] = Vector3D(7., 8., 9.);
 
-        {
-            auto trajectory = Trajectory(tmpfile, 'w');
-            trajectory.write(frame);
-        }
+        Trajectory(tmpfile, 'w').write(frame);
 
-        auto in_trajectory = Trajectory(tmpfile, 'r');
-        auto in_frame = in_trajectory.read();
-        auto in_topology = in_frame.topology();
-        auto in_positions = in_frame.positions();
+        // Re-read the file we just wrote
+        frame = Trajectory(tmpfile, 'r').read();
+        positions = frame.positions();
 
         // If resSeq is has more than 4 characters, coordinates won't be read
         // correctly

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -133,6 +133,17 @@ TEST_CASE("Read files in PDB format") {
         frame = file.read();
         CHECK(frame.natoms() == 7);
     }
+
+    SECTION("Handle multiple MODEL without END") {
+        Trajectory file("data/pdb/model.pdb");
+        CHECK(file.nsteps() == 2);
+
+        auto frame = file.read();
+        CHECK(frame.natoms() == 2223);
+
+        frame = file.read();
+        CHECK(frame.natoms() == 2223);
+    }
 }
 
 TEST_CASE("Write files in PDB format") {


### PR DESCRIPTION
Fix #103 

The issue was that the `line` variable was overwritten in forward when checking for consecutive `ENDMDL/END` lines. This meant that the number of steps as seen by the Trajectory class was off, thus creating the errors.

@pgbarletta, if this looks good to you, I'll merge it