### PR TITLE
Make global state thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   for periodic boundary conditions.
 * Added a `Property` class to store arbitrary properties in `Frame` and `Atom`.
 * Added support for improper dihedral angles in `Topology`.
+* `chemfiles::add_configuration` and `chemfiles::set_warning_callback` are now
+  thread safe, and will block upon concurrent usage.
 
 ### Changes in supported formats
 
@@ -54,13 +56,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   should use `chfl_residue_with_id`.
 * Added `chfl_residue_atoms` to get the list of atoms in a residue.
 * Added `CHFL_PROPERTY` and related functions.
+* `chfl_add_configuration` and `chfl_set_warning_callback` are now thread safe,
+  and will block upon concurrent usage.
 
 ### Deprecation and removals
 
 * `Topology::isbond`, `Topology::isangle`, `Topology::isdihedral`, and the
   corresponding C functions `chfl_topology_isbond`, `chfl_topology_isangle`
   `chfl_topology_isdihedral` are removed.
-
 
 ## 0.7 (25 Feb 2017)
 

--- a/include/chemfiles/Configuration.hpp
+++ b/include/chemfiles/Configuration.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "chemfiles/mutex.hpp"
+
 namespace chemfiles {
 
 /// Configuration for chemfiles.
@@ -27,11 +29,17 @@ namespace chemfiles {
 /// with `Ht`.
 class Configuration {
 public:
+    Configuration& operator=(const Configuration&) = delete;
+    Configuration(const Configuration&) = delete;
+    Configuration(Configuration&&) = delete;
+    Configuration& operator=(Configuration&&) = delete;
+
     /// Get the renamed atomic type for `type`. If their is no renaming to
     /// perform for this atomic type, the initial atomic type is returned.
     static const std::string& rename(const std::string& type) {
-        auto it = instance().types_rename_.find(type);
-        if (it != instance().types_rename_.end()) {
+        auto types = instance().types_.lock();
+        auto it = types->find(type);
+        if (it != types->end()) {
             return it->second;
         } else {
             return type;
@@ -43,25 +51,19 @@ public:
     /// data is replaced by the one in this file.
     ///
     /// If the file at `path` can not be opened, a `ConfigurationError` is
-    /// thrown. This function is not protected against data-race: calling it
-    /// while using the configuration from other thread is undefined.
-    static void add_configuration(const std::string& path);
+    /// thrown.
+    static void add(const std::string& path);
 
 private:
     Configuration();
-    Configuration& operator=(const Configuration&) = delete;
-    Configuration(const Configuration&) = delete;
-    Configuration(Configuration&&) = delete;
-    Configuration& operator=(Configuration&&) = delete;
+    void read(const std::string& path);
 
-    /// Read the configuration file at the given path
-    void read_configuration(std::string path);
-    /// Get a lazyly-created Configuration. The configuration will be
-    /// initialized on the first call to this function.
+    // Get the Configuration instance
     static Configuration& instance();
 
+    using types_map = std::unordered_map<std::string, std::string>;
     /// Map for old-type => new-type renaming
-    std::unordered_map<std::string, std::string> types_rename_;
+    mutex<types_map> types_;
 };
 
 } // namespace chemfiles

--- a/include/chemfiles/generic.hpp
+++ b/include/chemfiles/generic.hpp
@@ -26,9 +26,6 @@ void CHFL_EXPORT set_warning_callback(warning_callback callback);
 ///
 /// If the file at `path` can not be opened, or if the configuration file is
 /// invalid, a `ConfigurationError` is thrown.
-///
-/// This function is not protected against data-race: calling it while using
-/// the configuration from other thread is undefined.
 void CHFL_EXPORT add_configuration(const std::string& path);
 
 } // namespace chemfiles

--- a/include/chemfiles/mutex.hpp
+++ b/include/chemfiles/mutex.hpp
@@ -20,8 +20,16 @@ public:
         return data_;
     }
 
+    T* operator->() {
+        return &data_;
+    }
+
     const T& operator*() const {
         return data_;
+    }
+
+    const T* operator->() const {
+        return &data_;
     }
 
 private:
@@ -41,6 +49,8 @@ class mutex {
 public:
     /// Create a new mutex containing the given `data`
     mutex(T data): data_(std::move(data)), mutex_() {}
+    /// Create a new mutex containing a default constructed T
+    mutex(): mutex(T()) {}
 
     mutex(const mutex&) = delete;
     mutex& operator=(const mutex&) = delete;

--- a/include/chemfiles/mutex.hpp
+++ b/include/chemfiles/mutex.hpp
@@ -1,0 +1,71 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#ifndef CHEMFILES_MUTEX_HPP
+#define CHEMFILES_MUTEX_HPP
+
+#include <mutex>
+
+namespace chemfiles {
+
+template<class T> class mutex;
+
+/// A lock guard that guarantee exlusive access to the underlying data.
+///
+/// When the lock guard is destroyed, it releases the associated mutex.
+template<class T>
+class lock_guard {
+public:
+    T& operator*() {
+        return data_;
+    }
+
+    const T& operator*() const {
+        return data_;
+    }
+
+private:
+    lock_guard(T& data, std::unique_lock<std::mutex>&& guard):
+        data_(data), guard_(std::move(guard)) {}
+
+    T& data_;
+    std::unique_lock<std::mutex> guard_;
+
+    friend class mutex<T>;
+};
+
+/// A `std::mutex` wrapper that own some associated data, and ensure that the
+/// mutex is always locked before accessing the data
+template<class T>
+class mutex {
+public:
+    /// Create a new mutex containing the given `data`
+    mutex(T data): data_(std::move(data)), mutex_() {}
+
+    mutex(const mutex&) = delete;
+    mutex& operator=(const mutex&) = delete;
+    mutex(mutex&&) = default;
+    mutex& operator=(mutex&&) = default;
+
+    ~mutex() {
+        // deadlock if someone is trying to destroy this `chemfiles::mutex`
+        // while still holding a lock on the underlying `mutex_`.
+        mutex_.lock();
+        mutex_.unlock();
+    }
+
+    /// Lock the mutex, and return a `lock_guard`. The `lock_guard` allow to
+    /// access the locked data, and will release the mutex when it goes out of
+    /// scope.
+    lock_guard<T> lock() {
+        return lock_guard<T>(data_, std::unique_lock<std::mutex>(mutex_));
+    }
+
+private:
+    T data_;
+    std::mutex mutex_;
+};
+
+} // namespace chemfiles
+
+#endif

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -10,9 +10,9 @@
 #include "chemfiles/generic.hpp"
 using namespace chemfiles;
 
-/// Get the list of directories up to `leaf`. For example, if `leaf` is
-/// `C:\foo\bar\baz\`, this function returns `{C:\, C:\foo\, C:\foo\bar\,
-/// C:\foo\bar\baz\}`.
+// Get the list of directories up to `leaf`. For example, if `leaf` is
+// `C:\foo\bar\baz\`, this function returns `{C:\, C:\foo\, C:\foo\bar\,
+// C:\foo\bar\baz\}`.
 static std::vector<std::string> list_directories(std::string leaf);
 
 Configuration& Configuration::instance() {
@@ -25,12 +25,12 @@ Configuration::Configuration() {
     for (auto& dir: directories) {
         auto path = dir + "/" + ".chemfilesrc";
         if (std::ifstream(path)) {
-            read_configuration(path);
+            read(path);
         }
     }
 }
 
-void Configuration::read_configuration(std::string path) {
+void Configuration::read(const std::string& path) {
     toml::Table data;
     try {
         data = toml::parse(path);
@@ -40,6 +40,7 @@ void Configuration::read_configuration(std::string path) {
         );
     }
 
+    auto types = types_.lock();
     if (data.find("types") != data.end() && data.at("types").type() == toml::value_t::Table) {
         auto rename = toml::get<toml::Table>(data.at("types"));
         for (auto& entry: rename) {
@@ -51,14 +52,14 @@ void Configuration::read_configuration(std::string path) {
                 );
             }
             auto new_name = toml::get<std::string>(entry.second);
-            types_rename_[std::move(old_name)] = std::move(new_name);
+            (*types)[std::move(old_name)] = std::move(new_name);
         }
     }
 }
 
-void Configuration::add_configuration(const std::string& path) {
+void Configuration::add(const std::string& path) {
     if (std::ifstream(path)) {
-        instance().read_configuration(path);
+        instance().read(path);
     } else {
         throw configuration_error("Can not open configuration file at {}", path);
     }

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -25,7 +25,7 @@ namespace chemfiles {
     extern template class Molfile<MOLDEN>;
 }
 
-FormatFactory::FormatFactory() : formats_(), extensions_() {
+FormatFactory::FormatFactory() {
     this->register_name<XYZFormat>("XYZ");
     this->register_extension<XYZFormat>(".xyz");
 
@@ -70,22 +70,24 @@ FormatFactory::FormatFactory() : formats_(), extensions_() {
 }
 
 FormatFactory& FormatFactory::get() {
-    static auto instance = FormatFactory();
-    return instance;
+    static FormatFactory instance_;
+    return instance_;
 }
 
 format_creator_t FormatFactory::name(const std::string& name) {
-    if (formats_.find(name) == formats_.end()) {
+    auto formats = formats_.lock();
+    if (formats->find(name) == formats->end()) {
         throw format_error("can not find a format named '{}'", name);
     }
-    return formats_.at(name);
+    return formats->at(name);
 }
 
 format_creator_t FormatFactory::extension(const std::string& extension) {
-    if (extensions_.find(extension) == extensions_.end()) {
+    auto extensions = extensions_.lock();
+    if (extensions->find(extension) == extensions->end()) {
         throw format_error(
             "can not find a format associated with the '{}' extension.", extension
         );
     }
-    return extensions_.at(extension);
+    return extensions->at(extension);
 }

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -25,5 +25,5 @@ void chemfiles::warning(std::string message) {
 }
 
 void chemfiles::add_configuration(const std::string& path) {
-    Configuration::add_configuration(path);
+    Configuration::add(path);
 }

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -2,20 +2,26 @@
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
 #include <iostream>
+
 #include "chemfiles/warnings.hpp"
 #include "chemfiles/Configuration.hpp"
 #include "chemfiles/generic.hpp"
+#include "chemfiles/mutex.hpp"
 
-static chemfiles::warning_callback CALLBACK = [](std::string message){
+using namespace chemfiles;
+
+static mutex<warning_callback> CALLBACK = {[](std::string message){
     std::cerr << "[chemfiles] " << message << std::endl;
-};
+}};
 
 void chemfiles::set_warning_callback(warning_callback callback) {
-    CALLBACK = callback;
+    auto guard = CALLBACK.lock();
+    *guard = callback;
 }
 
 void chemfiles::warning(std::string message) {
-    CALLBACK(std::move(message));
+    auto guard = CALLBACK.lock();
+    (*guard)(std::move(message));
 }
 
 void chemfiles::add_configuration(const std::string& path) {


### PR DESCRIPTION
There are three global state points in the code, two are user-visible:
- the Configuration class;
- the warning system;
- the FormatFactory class; 

This PR make all of the thread-safe by wrapping the accessed data inside a mutex.