### PR TITLE
Allow external code to acess Format metadata

### DIFF
--- a/doc/src/devdoc/contributing.rst
+++ b/doc/src/devdoc/contributing.rst
@@ -1,54 +1,64 @@
 Contributing
 ============
 
-Chemfiles is an open-source project, that I make on my free time. Any contribution,
-from documentation improvement to new features including bug fixes are very welcome!
+Chemfiles is an open-source project, that I make on my free time. Any
+contribution, from documentation improvement to new features including bug fixes
+are very welcome!
 
 I would like to help, what can I do ?
 -------------------------------------
 
-Lot of things! Just pick one considering the time you can spend, and your technical
-skills.
+Lot of things! Just pick one considering the time you can spend, and your
+technical skills. And do not hesitate to come by out `gitter chat room`_ to say
+hello and ask any question you can have!
+
+.. _gitter chat room: https://gitter.im/chemfiles/chemfiles
 
 Improving the code
 ^^^^^^^^^^^^^^^^^^
 
-There are multiple way to improve the code. You can either `pick up a TODO`_ in the
-code, or any `issue`_ in the list. If you plan to add a new feature which is not in
-the issue list, please open a new one so that every one knows you are working on it,
-and so that the implementation can be discussed!
+You can pick any `issue`_ in the list. `E-Easy`_ issues are specially directed
+at first time contributors, and comes with step by step explanation of how to
+solve the issue.
 
-.. _pick up a TODO: https://github.com/chemfiles/chemfiles/search?utf8=%E2%9C%93&q=todo
+If you plan to add a new feature which is not in the issue list, please open a
+new one so that every one knows you are working on it, and so that the
+implementation strategy can be discussed!
+
 .. _issue: https://github.com/chemfiles/chemfiles/issues
+.. _E-Easy: https://github.com/chemfiles/chemfiles/issues?q=is%3Aissue+is%3Aopen+label%3AE-easy
 
 Improve documentation
 ^^^^^^^^^^^^^^^^^^^^^
 
-This documentation try to be easy to use, but there is always room for improvements.
-You can easily edit any :file:`.rst` file on `the github repository
-<https://github.com/chemfiles/chemfiles/tree/master/doc>`_, and propose your changes
-even with no git knowledge. All you need is a Github account.
+This documentation try to be easy to use, but there is always room for
+improvements.  You can easily edit any :file:`.rst` file on `the github
+repository <https://github.com/chemfiles/chemfiles/tree/master/doc>`_, and
+propose your changes even with no git knowledge. All you need is a Github
+account.
 
 Share and spread the word
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you think that chemfiles is awesome, share it! The more users it will have, the
-more features we can add to it, together!
+If you think that chemfiles is awesome, share it! The more users it will have,
+the more features we can add to it, together!
 
 External project used
 ---------------------
 
-A few external projects are used in chemfiles developement, and you will need a bit
-of knowledge of them to contribute. Depending on what you want to do, not all these
-projects are needed.
+A few external projects are used in chemfiles developement, and you will need a
+bit of knowledge of them to contribute. Depending on what you want to do, not
+all these projects are needed.
 
-- Source code versionning: `git`_, together with `github`_ web interface for issues
-  and pull requests.
-- documentation: `sphinx`_ for generating HTML and PDF documentation, `Doxygen`_ for
-  documenting the source code, and `breathe`_ to use Doxygen content in sphinx.
-- Build system: `cmake`_ is used as a cross-plateform, cross-build system generator.
-- Automatic testing: `CATCH`_ provide an nice unit test framework, and `travis`_ run
-  these tests each time the code is pushed to the repository.
+- Source code versionning: `git`_, together with `github`_ web interface for
+  issues and pull requests.
+- documentation: `sphinx`_ for generating HTML and PDF documentation, `Doxygen`_
+  for documenting the source code, and `breathe`_ to use Doxygen content in
+  sphinx.
+- Build system: `cmake`_ is used as a cross-plateform, cross-build system
+  generator.
+- Automatic testing: `CATCH`_ provide an nice unit test framework, and `travis`_
+  run these tests each time the code is pushed to the repository.
 
 
 .. _git: https://git-scm.com/
@@ -64,16 +74,16 @@ projects are needed.
 Coding style, and other formating issues
 ----------------------------------------
 
-When writing code for chemfiles, please respect the overall coding style. This is not
-only a question of style, but make it easier to enter in the project if all the files
-are formatted consistently. Do not use non standard features of any programming
-language unless there is no other way to do it. In that case, please wrap the code in
-``#ifdef`` macros, and add cases for at least Linux, OS X and Windows. You should add
-unit tests for each new piece of code, they will be run on `travis`_ before your
-changes are merged.
+When writing code for chemfiles, please respect the overall coding style. This
+is not only a question of style, but make it easier to enter in the project if
+all the files are formatted consistently. Do not use non standard features of
+any programming language unless there is no other way to do it. In that case,
+please wrap the code in ``#ifdef`` macros, and add cases for at least Linux,
+macOS and Windows. You should add unit tests for each new piece of code, they
+will be run on `travis`_ before your changes are merged.
 
-Git messages should be informatives, and describe the *what*, not the *how*. If your
-commit concern the documentation, please add the ``[doc]`` at the beggining of the
-message.
+Git messages should be informatives, and describe the *what*, not the *how*. If
+your commit concern the documentation, please add the ``[doc]`` at the beggining
+of the message.
 
 Happy coding!

--- a/doc/src/devdoc/internals.rst
+++ b/doc/src/devdoc/internals.rst
@@ -36,7 +36,14 @@ with parsing data from the file.
 
 Every ``Format`` class can be associated to an extension and a format name, the
 associations are managed by the ``FormatFactory`` class. New file and formats
-should be registered with this class.
+should be registered with this class, by specializing the
+:cpp:func:`chemfiles::format_information` template and calling
+:cpp:func:`chemfiles::FormatFactory::add_format`.
 
 .. doxygenclass:: chemfiles::FormatFactory
     :members:
+
+.. doxygenclass:: chemfiles::FormatInfo
+    :members:
+
+.. doxygenfunction:: chemfiles::format_information

--- a/include/chemfiles/Format.hpp
+++ b/include/chemfiles/Format.hpp
@@ -6,8 +6,10 @@
 
 #include <memory>
 #include <string>
+#include <functional>
 
 #include "chemfiles/exports.hpp"
+#include "chemfiles/Error.hpp"
 
 namespace chemfiles {
 class Frame;
@@ -52,6 +54,50 @@ public:
     /// @return The number of frames
     virtual size_t nsteps() = 0;
 };
+
+class CHFL_EXPORT FormatInfo {
+public:
+    /// Create a `FormatInfo` with the given `name`.
+    ///
+    /// @throws Error if the format name is the empty string
+    FormatInfo(std::string name): name_(std::move(name)), extension_() {
+        if (name_ == "") {
+            throw Error("a format name can not be an empty string");
+        }
+    }
+
+    /// Get the format name
+    const std::string& name() const {
+        return name_;
+    }
+
+    /// Set the format extension, use this to allow users to use this format
+    /// automatically with files having this extension. The extension should
+    /// start by a dot (`".xxx"`).
+    FormatInfo& with_extension(std::string extension) {
+        if (extension.length() < 1 || extension[0] != '.') {
+            throw Error("a format extension must start with a dot");
+        }
+        extension_ = std::move(extension);
+        return *this;
+    }
+
+    /// Get the format extension.
+    ///
+    /// If the extension was not set, this returns an empty string
+    const std::string& extension() const {
+        return extension_;
+    }
+
+private:
+    std::string name_;
+    std::string extension_;
+};
+
+template<class Format>
+FormatInfo format_information() {
+    throw Error("format_informations is unimplemented for this format");
+}
 
 } // namespace chemfiles
 

--- a/include/chemfiles/Format.hpp
+++ b/include/chemfiles/Format.hpp
@@ -55,6 +55,16 @@ public:
     virtual size_t nsteps() = 0;
 };
 
+/// Metadata associated with a format.
+///
+/// This class uses the builder patern, chaining functions calls to set the
+/// class attributes:
+///
+/// ```cpp
+/// auto meta = FormatInfo("MyFormat").with_extension(".mft").description(
+///     "some description"
+/// );
+/// ```
 class CHFL_EXPORT FormatInfo {
 public:
     /// Create a `FormatInfo` with the given `name`.
@@ -106,6 +116,22 @@ private:
     std::string description_;
 };
 
+/// Get the metadata associated with `Format`.
+///
+/// In order to implement a new format, one should specialise this function
+/// with the corresponding format:
+///
+/// ```cpp
+/// class MyFormat: public Format {
+///     // ...
+/// };
+///
+/// namespace chemfiles {
+///     template<> FormatInfo format_information<MyFormat>() {
+///         return FormatInfo("MyFormat").with_extension(".mft");
+///     }
+/// }
+/// ```
 template<class Format>
 FormatInfo format_information() {
     throw Error("format_informations is unimplemented for this format");

--- a/include/chemfiles/Format.hpp
+++ b/include/chemfiles/Format.hpp
@@ -89,9 +89,21 @@ public:
         return extension_;
     }
 
+    /// Add a format description to this format
+    FormatInfo& description(std::string description) {
+        description_ = std::move(description);
+        return *this;
+    }
+
+    /// Get the format description.
+    const std::string& description() const {
+        return description_;
+    }
+
 private:
     std::string name_;
     std::string extension_;
+    std::string description_;
 };
 
 template<class Format>

--- a/include/chemfiles/FormatFactory.hpp
+++ b/include/chemfiles/FormatFactory.hpp
@@ -51,6 +51,9 @@ public:
         });
     }
 
+    /// Get the metadata for all registered formats 
+    std::vector<FormatInfo> formats();
+
 private:
     using formats_map_t = std::vector<std::pair<FormatInfo, format_creator_t>>;
     using iterator = formats_map_t::const_iterator;

--- a/include/chemfiles/FormatFactory.hpp
+++ b/include/chemfiles/FormatFactory.hpp
@@ -29,23 +29,20 @@ public:
     /// Get the instance of the TrajectoryFactory
     static FormatFactory& get();
 
-    /// @brief Get a `format_creator_t` from a format name.
-    /// @param name the format name
-    /// @return A `format_creator_t` corresponding to the format, if the format
-    ///         name is found in the list of registered formats.
+    /// Get a `format_creator_t` from a format name.
     ///
+    /// @param name the format name
     /// @throws FormatError if the format can not be found
     format_creator_t name(const std::string& name);
 
-    /// @brief Get a `format_creator_t` from a format extention.
-    /// @param extension the format extention
-    /// @return A `format_creator_t` corresponding to the format, if the format
-    ///         extension is found in the list of registered extensions.
+    /// Get a `format_creator_t` from a format extention.
     ///
+    /// @param extension the format extention
     /// @throws FormatError if the format can not be found
     format_creator_t extension(const std::string& extension);
 
-    /// @brief Register a format `F` with the given `name`
+    /// Register a format `F` with the given `name`
+    ///
     /// @param name the format name
     /// @throws FormatError if the name is already used by another format
     ///
@@ -66,7 +63,8 @@ public:
         });
     }
 
-    /// @brief Register a format `F` with the given `extension`
+    /// Register a format `F` with the given `extension`
+    ///
     /// @param extension the format extension
     /// @throws FormatError if the extension is already used by another format
     ///

--- a/include/chemfiles/formats/AmberNetCDF.hpp
+++ b/include/chemfiles/formats/AmberNetCDF.hpp
@@ -48,6 +48,8 @@ private:
     bool validated_;
 };
 
+template<> FormatInfo format_information<AmberNetCDFFormat>();
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -221,6 +221,8 @@ private:
     DataTypes types_;
 };
 
+template<> FormatInfo format_information<LAMMPSDataFormat>();
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/formats/Molfile.hpp
+++ b/include/chemfiles/formats/Molfile.hpp
@@ -82,6 +82,15 @@ private:
     optional<Topology> topology_;
 };
 
+template<> FormatInfo format_information<Molfile<DCD>>();
+template<> FormatInfo format_information<Molfile<GRO>>();
+template<> FormatInfo format_information<Molfile<TRR>>();
+template<> FormatInfo format_information<Molfile<XTC>>();
+template<> FormatInfo format_information<Molfile<TRJ>>();
+template<> FormatInfo format_information<Molfile<MOL2>>();
+template<> FormatInfo format_information<Molfile<LAMMPS>>();
+template<> FormatInfo format_information<Molfile<MOLDEN>>();
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -48,8 +48,9 @@ private:
     /// Did we wrote a frame to the file? This is used to check wheter we need
     /// to write a final `END` record in the destructor
     bool written_ = false;
-
 };
+
+template<> FormatInfo format_information<PDBFormat>();
 
 } // namespace chemfiles
 

--- a/include/chemfiles/formats/TNG.hpp
+++ b/include/chemfiles/formats/TNG.hpp
@@ -33,6 +33,8 @@ private:
     int64_t natoms_ = 0;
 };
 
+template<> FormatInfo format_information<TNGFormat>();
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/formats/Tinker.hpp
+++ b/include/chemfiles/formats/Tinker.hpp
@@ -33,6 +33,8 @@ private:
     std::vector<std::streampos> steps_positions_;
 };
 
+template<> FormatInfo format_information<TinkerFormat>();
+
 } // namespace chemfiles
 
 #endif

--- a/include/chemfiles/formats/XYZ.hpp
+++ b/include/chemfiles/formats/XYZ.hpp
@@ -28,6 +28,8 @@ private:
     std::vector<std::streampos> steps_positions_;
 };
 
+template<> FormatInfo format_information<XYZFormat>();
+
 } // namespace chemfiles
 
 #endif

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -137,6 +137,15 @@ format_creator_t FormatFactory::extension(const std::string& extension) {
     return it->second;
 }
 
+std::vector<FormatInfo> FormatFactory::formats() {
+    auto formats = formats_.lock();
+    auto metadata = std::vector<FormatInfo>();
+    metadata.reserve(formats->size());
+    for (auto& pair: *formats) {
+        metadata.emplace_back(pair.first);
+    }
+    return metadata;
+}
 
 // Compute the edit distance between two strings using Wagner–Fischer algorithm
 unsigned edit_distance(const std::string& first, const std::string& second) {

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -20,8 +20,6 @@
 
 using namespace chemfiles;
 
-static unsigned edit_distance(const std::string& first, const std::string& second);
-
 namespace chemfiles {
     extern template class Molfile<DCD>;
     extern template class Molfile<GRO>;
@@ -33,48 +31,25 @@ namespace chemfiles {
     extern template class Molfile<MOLDEN>;
 }
 
+static unsigned edit_distance(const std::string& first, const std::string& second);
+
 FormatFactory::FormatFactory() {
-    this->register_name<XYZFormat>("XYZ");
-    this->register_extension<XYZFormat>(".xyz");
-
-    this->register_name<PDBFormat>("PDB");
-    this->register_extension<PDBFormat>(".pdb");
-
-    this->register_name<TNGFormat>("TNG");
-    this->register_extension<TNGFormat>(".tng");
-
-    this->register_name<AmberNetCDFFormat>("Amber NetCDF");
-    this->register_extension<AmberNetCDFFormat>(".nc");
-
-    this->register_name<TinkerFormat>("Tinker");
-    this->register_extension<TinkerFormat>(".arc");
-
-    this->register_name<LAMMPSDataFormat>("LAMMPS Data");
+    this->add_format<XYZFormat>();
+    this->add_format<PDBFormat>();
+    this->add_format<TNGFormat>();
+    this->add_format<AmberNetCDFFormat>();
+    this->add_format<TinkerFormat>();
+    this->add_format<LAMMPSDataFormat>();
 
     // VMD molfile plugins
-    this->register_name<Molfile<DCD>>("DCD");
-    this->register_extension<Molfile<DCD>>(".dcd");
-
-    this->register_name<Molfile<GRO>>("GRO");
-    this->register_extension<Molfile<GRO>>(".gro");
-
-    this->register_name<Molfile<TRR>>("TRR");
-    this->register_extension<Molfile<TRR>>(".trr");
-
-    this->register_name<Molfile<XTC>>("XTC");
-    this->register_extension<Molfile<XTC>>(".xtc");
-
-    this->register_name<Molfile<TRJ>>("TRJ");
-    this->register_extension<Molfile<TRJ>>(".trj");
-
-    this->register_name<Molfile<LAMMPS>>("LAMMPS");
-    this->register_extension<Molfile<LAMMPS>>(".lammpstrj");
-
-    this->register_name<Molfile<MOL2>>("MOL2");
-    this->register_extension<Molfile<MOL2>>(".mol2");
-
-    this->register_name<Molfile<MOLDEN>>("Molden");
-    this->register_extension<Molfile<MOLDEN>>(".molden");
+    this->add_format<Molfile<DCD>>();
+    this->add_format<Molfile<GRO>>();
+    this->add_format<Molfile<TRR>>();
+    this->add_format<Molfile<XTC>>();
+    this->add_format<Molfile<TRJ>>();
+    this->add_format<Molfile<MOL2>>();
+    this->add_format<Molfile<LAMMPS>>();
+    this->add_format<Molfile<MOLDEN>>();
 }
 
 FormatFactory& FormatFactory::get() {
@@ -82,13 +57,51 @@ FormatFactory& FormatFactory::get() {
     return instance_;
 }
 
+FormatFactory::iterator FormatFactory::find_name(const formats_map_t& formats, const std::string& name) {
+    for (auto it = formats.begin(); it != formats.end(); it++) {
+        if (it->first.name() == name) {
+            return it;
+        }
+    }
+    return formats.end();
+}
+
+FormatFactory::iterator FormatFactory::find_extension(const formats_map_t& formats, const std::string& extension) {
+    for (iterator it = formats.begin(); it != formats.end(); it++) {
+        if (it->first.extension() == extension) {
+            return it;
+        }
+    }
+    return formats.end();
+}
+
+void FormatFactory::register_format(FormatInfo info, format_creator_t creator) {
+    auto formats = formats_.lock();
+    if (info.name() == "" && info.extension() == "") {
+        throw format_error(
+            "can not register a format with no name and no extension"
+        );
+    } else if (info.name() != "" && find_name(*formats, info.name()) != formats->end()) {
+        throw format_error(
+            "the name '{}' is already associated with a format."
+        );
+    } else if (info.extension() != "" && find_extension(*formats, info.extension()) != formats->end()) {
+        throw format_error(
+            "the extension '{}' is already associated with a format."
+        );
+    } else {
+        formats->push_back({info, creator});
+    }
+}
+
 format_creator_t FormatFactory::name(const std::string& name) {
     auto formats = formats_.lock();
-    if (formats->find(name) == formats->end()) {
+    auto it = find_name(*formats, name);
+    if (it == formats->end()) {
         auto suggestions = std::vector<std::string>();
         for (auto& node: *formats) {
-            if (edit_distance(name, node.first) < 4) {
-                suggestions.push_back(node.first);
+            if (edit_distance(name, node.first.name()) < 4) {
+                suggestions.push_back(node.first.name());
             }
         }
 
@@ -110,17 +123,18 @@ format_creator_t FormatFactory::name(const std::string& name) {
 
         throw FormatError(message.str());
     }
-    return formats->at(name);
+    return it->second;
 }
 
 format_creator_t FormatFactory::extension(const std::string& extension) {
-    auto extensions = extensions_.lock();
-    if (extensions->find(extension) == extensions->end()) {
+    auto formats = formats_.lock();
+    auto it = find_extension(*formats, extension);
+    if (it == formats->end()) {
         throw format_error(
             "can not find a format associated with the '{}' extension.", extension
         );
     }
-    return extensions->at(extension);
+    return it->second;
 }
 
 

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -8,6 +8,10 @@
 #include "chemfiles/warnings.hpp"
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<AmberNetCDFFormat>() {
+    return FormatInfo("Amber NetCDF").with_extension(".nc");
+}
+
 //! Check the validity of a NetCDF file
 static bool is_valid(const NcFile& file_, size_t natoms) {
     bool writing = (natoms != static_cast<size_t>(-1));

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -9,7 +9,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<AmberNetCDFFormat>() {
-    return FormatInfo("Amber NetCDF").with_extension(".nc");
+    return FormatInfo("Amber NetCDF").with_extension(".nc").description(
+        "Amber convention for binary NetCDF molecular trajectories"
+    );
 }
 
 //! Check the validity of a NetCDF file

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -17,6 +17,10 @@
 
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<LAMMPSDataFormat>() {
+    return FormatInfo("LAMMPS Data");
+}
+
 atom_style::atom_style(const std::string& name): name_(name) {
     if (name == "angle") {
         style_ = ANGLE;

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -18,7 +18,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<LAMMPSDataFormat>() {
-    return FormatInfo("LAMMPS Data");
+    return FormatInfo("LAMMPS Data").description(
+        "LAMMPS text input data file"
+    );
 }
 
 atom_style::atom_style(const std::string& name): name_(name) {

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -306,33 +306,49 @@ template class chemfiles::Molfile<LAMMPS>;
 template class chemfiles::Molfile<MOLDEN>;
 
 template<> FormatInfo chemfiles::format_information<Molfile<DCD>>() {
-    return FormatInfo("DCD").with_extension(".dcd");
+    return FormatInfo("DCD").with_extension(".dcd").description(
+        "DCD binary format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<GRO>>() {
-    return FormatInfo("GRO").with_extension(".gro");
+    return FormatInfo("GRO").with_extension(".gro").description(
+        "GROMACS .gro text format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<TRR>>() {
-    return FormatInfo("TRR").with_extension(".trr");
+    return FormatInfo("TRR").with_extension(".trr").description(
+        "GROMACS .trr binary portable format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<TRJ>>() {
-    return FormatInfo("TRJ").with_extension(".trj");
+    return FormatInfo("TRJ").with_extension(".trj").description(
+        "GROMACS .xtc binary format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<XTC>>() {
-    return FormatInfo("XTC").with_extension(".xtc");
+    return FormatInfo("XTC").with_extension(".xtc").description(
+        "GROMACS .xtc binary compressed portable format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<MOL2>>() {
-    return FormatInfo("MOL2").with_extension(".mol2");
+    return FormatInfo("MOL2").with_extension(".mol2").description(
+        "TRIPOS mol2 text format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<LAMMPS>>() {
-    return FormatInfo("LAMMPS").with_extension(".lammpstrj");
+    return FormatInfo("LAMMPS").with_extension(".lammpstrj").description(
+        "LAMMPS text trajectory format"
+    );
 }
 
 template<> FormatInfo chemfiles::format_information<Molfile<MOLDEN>>() {
-    return FormatInfo("Molden").with_extension(".molden");
+    return FormatInfo("Molden").with_extension(".molden").description(
+        "Molden text format"
+    );
 }

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -301,6 +301,38 @@ template class chemfiles::Molfile<GRO>;
 template class chemfiles::Molfile<TRR>;
 template class chemfiles::Molfile<XTC>;
 template class chemfiles::Molfile<TRJ>;
-template class chemfiles::Molfile<LAMMPS>;
 template class chemfiles::Molfile<MOL2>;
+template class chemfiles::Molfile<LAMMPS>;
 template class chemfiles::Molfile<MOLDEN>;
+
+template<> FormatInfo chemfiles::format_information<Molfile<DCD>>() {
+    return FormatInfo("DCD").with_extension(".dcd");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<GRO>>() {
+    return FormatInfo("GRO").with_extension(".gro");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<TRR>>() {
+    return FormatInfo("TRR").with_extension(".trr");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<TRJ>>() {
+    return FormatInfo("TRJ").with_extension(".trj");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<XTC>>() {
+    return FormatInfo("XTC").with_extension(".xtc");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<MOL2>>() {
+    return FormatInfo("MOL2").with_extension(".mol2");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<LAMMPS>>() {
+    return FormatInfo("LAMMPS").with_extension(".lammpstrj");
+}
+
+template<> FormatInfo chemfiles::format_information<Molfile<MOLDEN>>() {
+    return FormatInfo("Molden").with_extension(".molden");
+}

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -15,7 +15,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<PDBFormat>() {
-    return FormatInfo("PDB").with_extension(".pdb");
+    return FormatInfo("PDB").with_extension(".pdb").description(
+        "PDB (RCSB Protein Data Bank) text format"
+    );
 }
 
 /// Check the number of digits before the decimal separator to be sure than

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -14,6 +14,10 @@
 
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<PDBFormat>() {
+    return FormatInfo("PDB").with_extension(".pdb");
+}
+
 /// Check the number of digits before the decimal separator to be sure than
 /// we can represen them. In case of error, use the given `context` in the error
 /// message

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -9,7 +9,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<TNGFormat>() {
-    return FormatInfo("TNG").with_extension(".tng");
+    return FormatInfo("TNG").with_extension(".tng").description(
+        "Trajectory New Generation binary format"
+    );
 }
 
 /// A buffer for TNG allocated data. It will not allocate its own memory, but

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -8,6 +8,10 @@
 #include "chemfiles/ErrorFmt.hpp"
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<TNGFormat>() {
+    return FormatInfo("TNG").with_extension(".tng");
+}
+
 /// A buffer for TNG allocated data. It will not allocate its own memory, but
 /// will `free` the memory on destruction. It can be used in replacement of the
 /// pointer type in TNG API.

--- a/src/formats/Tinker.cpp
+++ b/src/formats/Tinker.cpp
@@ -14,6 +14,10 @@
 
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<TinkerFormat>() {
+    return FormatInfo("Tinker").with_extension(".arc");
+}
+
 /// Fast-forward the file for one step, returning `false` if the file does
 /// not contain one more step.
 static bool forward(TextFile& file);

--- a/src/formats/Tinker.cpp
+++ b/src/formats/Tinker.cpp
@@ -15,7 +15,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<TinkerFormat>() {
-    return FormatInfo("Tinker").with_extension(".arc");
+    return FormatInfo("Tinker").with_extension(".arc").description(
+        "Tinker XYZ text format"
+    );
 }
 
 /// Fast-forward the file for one step, returning `false` if the file does

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -15,6 +15,10 @@
 
 using namespace chemfiles;
 
+template<> FormatInfo chemfiles::format_information<XYZFormat>() {
+    return FormatInfo("XYZ").with_extension(".xyz");
+}
+
 /// Fast-forward the file for one step, returning `false` if the file does
 /// not contain one more step.
 static bool forward(TextFile& file);

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -16,7 +16,9 @@
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<XYZFormat>() {
-    return FormatInfo("XYZ").with_extension(".xyz");
+    return FormatInfo("XYZ").with_extension(".xyz").description(
+        "XYZ text format"
+    );
 }
 
 /// Fast-forward the file for one step, returning `false` if the file does

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -48,6 +48,28 @@ TEST_CASE("Geting registered format"){
 
     CHECK_THROWS_AS(FormatFactory::get().name("UNKOWN"), FormatError);
     CHECK_THROWS_AS(FormatFactory::get().extension(".UNKOWN"), FormatError);
+
+    try {
+        FormatFactory::get().name("Dully");
+        CHECK(false);
+    } catch (const FormatError& e) {
+        CHECK(std::string(e.what()) == "can not find a format named 'Dully'. Did you mean 'Dummy'?");
+    }
+
+    try {
+        FormatFactory::get().name("DUMMY");
+        CHECK(false);
+    } catch (const FormatError& e) {
+        CHECK(std::string(e.what()) == "can not find a format named 'DUMMY'. Did you mean 'Dummy'?");
+    }
+
+    FormatFactory::get().register_name<DummyFormat>("Dunny");
+    try {
+        FormatFactory::get().name("Dully");
+        CHECK(false);
+    } catch (const FormatError& e) {
+        CHECK(std::string(e.what()) == "can not find a format named 'Dully'. Did you mean 'Dunny' or 'Dummy'?");
+    }
 }
 
 TEST_CASE("Check error throwing in formats"){
@@ -61,5 +83,4 @@ TEST_CASE("Check error throwing in formats"){
     CHECK_THROWS_AS(trajectory.read(), FormatError);
     CHECK_THROWS_AS(trajectory.read_step(2), FormatError);
     CHECK_THROWS_AS(trajectory.write(frame), FormatError);
-
 }

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -66,6 +66,8 @@ TEST_CASE("Geting registered format"){
     } catch (const FormatError& e) {
         CHECK(std::string(e.what()) == "can not find a format named 'Dully'. Did you mean 'Dummy' or 'Dunny'?");
     }
+
+    CHECK(FormatFactory::get().formats().back().name() == "Dunny");
 }
 
 TEST_CASE("Check error throwing in formats"){

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -13,32 +13,28 @@
 #include "chemfiles/FormatFactory.hpp"
 using namespace chemfiles;
 
-// Dummy format clase
-class DummyFormat: public Format {
-public:
-    DummyFormat(const std::string&, File::Mode){}
+struct DummyFormat: public Format {
+    DummyFormat(const std::string&, File::Mode) {}
     size_t nsteps() override {return 42;}
 };
 
-TEST_CASE("Registering a new format"){
-    FormatFactory::get().register_extension<DummyFormat>(".testing");
-    // We can not register the same format twice
-    CHECK_THROWS_AS(
-        FormatFactory::get().register_extension<DummyFormat>(".testing"),
-        FormatError
-    );
+struct DunnyFormat: public Format {
+    DunnyFormat(const std::string&, File::Mode) {}
+    size_t nsteps() override {return 0;}
+};
 
-    FormatFactory::get().register_name<DummyFormat>("Testing");
-    // We can not register the same format twice
-    CHECK_THROWS_AS(
-        FormatFactory::get().register_name<DummyFormat>("Testing"),
-        FormatError
-    );
+namespace chemfiles {
+    template<> FormatInfo format_information<DummyFormat>() {
+        return FormatInfo("Dummy").with_extension(".dummy");
+    }
+
+    template<> FormatInfo format_information<DunnyFormat>() {
+        return FormatInfo("Dunny");
+    }
 }
 
 TEST_CASE("Geting registered format"){
-    FormatFactory::get().register_extension<DummyFormat>(".dummy");
-    FormatFactory::get().register_name<DummyFormat>("Dummy");
+    FormatFactory::get().add_format<DummyFormat>();
 
     DummyFormat dummy("", File::READ);
     auto format = FormatFactory::get().extension(".dummy")("", File::READ);
@@ -63,12 +59,12 @@ TEST_CASE("Geting registered format"){
         CHECK(std::string(e.what()) == "can not find a format named 'DUMMY'. Did you mean 'Dummy'?");
     }
 
-    FormatFactory::get().register_name<DummyFormat>("Dunny");
+    FormatFactory::get().add_format<DunnyFormat>();
     try {
         FormatFactory::get().name("Dully");
         CHECK(false);
     } catch (const FormatError& e) {
-        CHECK(std::string(e.what()) == "can not find a format named 'Dully'. Did you mean 'Dunny' or 'Dummy'?");
+        CHECK(std::string(e.what()) == "can not find a format named 'Dully'. Did you mean 'Dummy' or 'Dunny'?");
     }
 }
 


### PR DESCRIPTION
The goal of this PR is to allow (1) discovery of format names instead of needing to get back to the doc every time and (2) help with format name usage, specifically with typos.

The first commit implement suggestion like `not format named 'lammpsdata'. did you mean 'LAMMPS Data'?`. The following commits export format metadata for use by external tools.

This metadata is not part of the main API, and as such is not exported to C. If you need to use it from other languages than C++, please ask!