### PR TITLE
Use sscanf when reading free form text formats

### DIFF
--- a/src/Selection.cpp
+++ b/src/Selection.cpp
@@ -54,16 +54,16 @@ static Context get_context(const std::string& string, std::string& selection) {
 static unsigned max_variable(Context context) {
     switch (context) {
     case Context::ATOM:
-        return 1;
+        return 0;
     case Context::PAIR:
     case Context::BOND:
-        return 2;
+        return 1;
     case Context::ANGLE:
     case Context::THREE:
-        return 3;
+        return 2;
     case Context::DIHEDRAL:
     case Context::FOUR:
-        return 4;
+        return 3;
     }
     unreachable();
 }

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -268,17 +268,16 @@ void PDBFormat::read_CONECT(Frame& frame, const std::string& line) {
 }
 
 void PDBFormat::link_standard_residue_bonds(Frame& frame) {
-
     bool link_previous_peptide = false;
     bool link_previous_nucleic = false;
     size_t previous_residue_id = 0;
     size_t previous_carboxylic_id = 0;
 
     for (auto& res : residues_) {
-
         const auto& residue_table = PDB_CONNECTIVITY_INFORMATION.find(res.second.name());
-        if (residue_table == PDB_CONNECTIVITY_INFORMATION.end())
+        if (residue_table == PDB_CONNECTIVITY_INFORMATION.end()) {
             continue;
+        }
 
         std::map<std::string, size_t> atom_name_to_index;
         for (const auto& atom : res.second) {
@@ -439,10 +438,8 @@ void PDBFormat::write(const Frame& frame) {
         }
     }
 
+    auto& positions = frame.positions();
     for (size_t i = 0; i < frame.size(); i++) {
-        auto& name = frame.topology()[i].name();
-        auto& type = frame.topology()[i].type();
-        auto& pos = frame.positions()[i];
 
         std::string atom_hetatm = "HETATM";
         auto is_hetatm = frame.topology()[i].get("is_hetatm");
@@ -498,8 +495,7 @@ void PDBFormat::write(const Frame& frame) {
             } else {
                 chainid = "X";
             }
-        }
-        else {
+        } else {
             resname = "XXX";
             chainid = "X";
             auto value = max_resid++;
@@ -511,20 +507,17 @@ void PDBFormat::write(const Frame& frame) {
         }
 
         assert(resname.length() <= 3);
+        auto& pos = positions[i];
         check_values_size(pos, 8, "atomic position");
 
-        // Print all atoms as HETATM, because there is no way we can know if we
-        // are handling a biomolecule or not.
-        //
-        // We ignore the 'altLoc' and 'iCode' fields, as we do not
-        // know them.
+        // We ignore the 'altLoc' and 'iCode' fields, as we do not know them.
         //
         // 'chainID' is set to be 'X', and if there is no residue information
-        // 'resSeq' to be the atomic number.
+        // 'resSeq' is set to be the atomic number.
         fmt::print(
             *file_,
             "{: <6}{: >5} {: <4s} {:3} {:1}{: >4s}    {:8.3f}{:8.3f}{:8.3f}{:6.2f}{:6.2f}          {: >2s}\n",
-            atom_hetatm, to_pdb_index(i), name, resname, chainid, resid, pos[0], pos[1], pos[2], 1.0, 0.0, type
+            atom_hetatm, to_pdb_index(i), frame[i].name(), resname, chainid, resid, pos[0], pos[1], pos[2], 1.0, 0.0, frame[i].type()
         );
     }
 

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -43,7 +43,7 @@ std::string Token::str() const {
     case Token::COMMA:
         return ",";
     case Token::VARIABLE:
-        return "#" + std::to_string(variable_);
+        return "#" + std::to_string(variable_ + 1);
     case Token::EQUAL:
         return "==";
     case Token::NOT_EQUAL:
@@ -174,8 +174,10 @@ Token Tokenizer::variable() {
     }
     if (data > UINT8_MAX) {
         throw selection_error("variable index #{} is too big for uint8_t", data);
+    } else if (data == 0) {
+        throw selection_error("invalid variable index #0");
     }
-    return Token::variable(static_cast<uint8_t>(data));
+    return Token::variable(static_cast<uint8_t>(data - 1));
 }
 
 Token Tokenizer::raw_ident() {

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -399,7 +399,7 @@ Variable Parser::variable() {
     Variable var = 0;
     if (match(Token::LPAREN)) {
         if (match(Token::VARIABLE)) {
-            var = previous().variable() - 1;
+            var = previous().variable();
         } else {
             throw selection_error("expected variable in parenthesis, got {}", peek().str());
         }
@@ -418,14 +418,14 @@ std::vector<Variable> Parser::variables() {
     }
 
     if (match(Token::VARIABLE)) {
-        vars.push_back(previous().variable() - 1);
+        vars.push_back(previous().variable());
     } else {
         throw selection_error("expected variable in parenthesis, got {}", peek().str());
     }
 
     while (match(Token::COMMA)) {
         if (match(Token::VARIABLE)) {
-            vars.push_back(previous().variable() - 1);
+            vars.push_back(previous().variable());
         } else {
             throw selection_error("expected variable in parenthesis, got {}", peek().str());
         }
@@ -446,7 +446,7 @@ std::vector<SubSelection> Parser::sub_selection() {
     }
 
     if (match(Token::VARIABLE)) {
-        vars.push_back(previous().variable() - 1);
+        vars.push_back(previous().variable());
     } else {
         // HACK: We can not (yet) build a selection directly from AST, because
         // we need to validate the variables and get the context. So we eat all
@@ -463,7 +463,7 @@ std::vector<SubSelection> Parser::sub_selection() {
 
     while (match(Token::COMMA)) {
         if (match(Token::VARIABLE)) {
-            vars.push_back(previous().variable() - 1);
+            vars.push_back(previous().variable());
         } else {
             auto before = current_;
             auto _ast = expression();

--- a/tests/formats/tinker.cpp
+++ b/tests/formats/tinker.cpp
@@ -1,5 +1,6 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
+
 #include <fstream>
 
 #include "catch.hpp"
@@ -73,20 +74,21 @@ TEST_CASE("Read files in Tinker XYZ format using Molfile") {
 TEST_CASE("Write files in Tinker XYZ format") {
     auto tmpfile = NamedTempPath(".arc");
     const auto expected_content =
-    "4 written by the chemfiles library\n"
-    "0 0 0 90 90 90\n"
-    "1 A 1 2 3 1 2 3\n"
-    "2 A 1 2 3 1 1\n"
-    "3 B 1 2 3 2 1\n"
-    "4 B 1 2 3 3\n"
-    "6 written by the chemfiles library\n"
-    "22 33 44 90 90 90\n"
-    "1 A 4 5 6 1 2 3\n"
-    "2 A 4 5 6 1 1\n"
-    "3 B 4 5 6 2 1\n"
-    "4 B 4 5 6 3\n"
-    "5 E 4 5 6 4\n"
-    "6 F 4 5 6 5\n";
+R"(4 written by the chemfiles library
+0 0 0 90 90 90
+1 A 1 2 3 1 2 3
+2 A 1 2 3 1 1
+3 B 1 2 3 2 1
+4 B 1 2 3 3
+6 written by the chemfiles library
+22 33 44 90 90 90
+1 A 4 5 6 1 2 3
+2 A 4 5 6 1 1
+3 B 4 5 6 2 1
+4 B 4 5 6 3
+5 E 4 5 6 4
+6 F 4 5 6 5
+)";
 
     auto topology = Topology();
     topology.add_atom(Atom("A"));

--- a/tests/formats/xyz.cpp
+++ b/tests/formats/xyz.cpp
@@ -1,7 +1,6 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
-#include <streambuf>
 #include <fstream>
 
 #include "catch.hpp"
@@ -107,20 +106,21 @@ TEST_CASE("Errors in XYZ format") {
 TEST_CASE("Write files in XYZ format") {
     auto tmpfile = NamedTempPath(".xyz");
     const auto expected_content =
-    "4\n"
-    "Written by the chemfiles library\n"
-    "A 1 2 3\n"
-    "B 1 2 3\n"
-    "C 1 2 3\n"
-    "D 1 2 3\n"
-    "6\n"
-    "Written by the chemfiles library\n"
-    "A 4 5 6\n"
-    "B 4 5 6\n"
-    "C 4 5 6\n"
-    "D 4 5 6\n"
-    "E 4 5 6\n"
-    "F 4 5 6\n";
+R"(4
+Written by the chemfiles library
+A 1 2 3
+B 1 2 3
+C 1 2 3
+D 1 2 3
+6
+Written by the chemfiles library
+A 4 5 6
+B 4 5 6
+C 4 5 6
+D 4 5 6
+E 4 5 6
+F 4 5 6
+)";
 
     auto topology = Topology();
     topology.add_atom(Atom("A","O"));

--- a/tests/selections/lexer.cpp
+++ b/tests/selections/lexer.cpp
@@ -78,6 +78,18 @@ TEST_CASE("Lexing") {
         CHECK(tokens[8].type() == Token::END);
     }
 
+    SECTION("variables") {
+        auto tokens = tokenize("#2 #78");
+        CHECK(tokens.size() == 3);
+        CHECK(tokens[0].type() == Token::VARIABLE);
+        CHECK(tokens[0].variable() == 1);
+        CHECK(tokens[1].type() == Token::VARIABLE);
+        CHECK(tokens[1].variable() == 77);
+        CHECK(tokens[2].type() == Token::END);
+
+        CHECK_THROWS_AS(tokenize("#0"), SelectionError);
+    }
+
     SECTION("Identifiers") {
         for (auto& id: {"ident", "id_3nt___", "iD_3BFAMC8T3Vt___"}) {
             auto tokens = tokenize(id);


### PR DESCRIPTION
Instead of relying on stringstreams, which are way slower.

On my system, this speeds up the following code from 0.38s to 0.27s

```cpp
#include <chemfiles.hpp>
using namespace chemfiles;

int main() {
    auto trajectory = Trajectory("tests/data/xyz/water.xyz");
    for (size_t i = 0; i<trajectory.nsteps(); i++) {
        auto frame = trajectory.read_step(i);
    }
    for (size_t i = 0; i<trajectory.nsteps(); i++) {
        auto frame = trajectory.read_step(i);
    }
    for (size_t i = 0; i<trajectory.nsteps(); i++) {
        auto frame = trajectory.read_step(i);
    }
    for (size_t i = 0; i<trajectory.nsteps(); i++) {
        auto frame = trajectory.read_step(i);
    }
}
```