### PR TITLE
Matrix update

### DIFF
--- a/include/chemfiles/UnitCell.hpp
+++ b/include/chemfiles/UnitCell.hpp
@@ -62,7 +62,7 @@ public:
     /// @example{tests/doc/cell/cell-3.cpp}
     UnitCell(double a, double b, double c);
 
-    /// Construct an unit cell of side size `a`, `b`, `c`, and cell angles
+    /// Construct a unit cell of side size `a`, `b`, `c`, and cell angles
     /// `alpha`, `beta`, `gamma`.
     ///
     /// If all of `alpha`, `beta` and `gamma` are 90.0, then the cell is
@@ -70,6 +70,17 @@ public:
     ///
     /// @example{tests/doc/cell/cell-6.cpp}
     UnitCell(double a, double b, double c, double alpha, double beta, double gamma);
+
+    /// Construct a unit cell via from an upper triangular matrix.
+    ///
+    /// If a matrix of all zeros is given, then an infinite cell is 
+    /// created.
+    ///
+    /// If only the diagonal of the matrix is non-zero, then the cell is
+    /// `ORTHOROMBIC`. Else a `TRICLINIC` cell is created.
+    ///
+    /// @example{tests/doc/cell/matrix.cpp}
+    UnitCell(const Matrix3D& matrix);
 
     /// Get the cell matrix, defined as the upper triangular matrix
     ///

--- a/include/chemfiles/types.hpp
+++ b/include/chemfiles/types.hpp
@@ -83,6 +83,11 @@ inline bool operator!=(const Vector3D& lhs, const Vector3D& rhs) {
     return !(lhs == rhs);
 }
 
+/// Negate vector
+inline Vector3D operator-(const Vector3D& lhs) {
+    return {-lhs[0], -lhs[1], -lhs[2]};
+}
+
 /// Add two vectors
 inline Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs) {
     return {lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2]};
@@ -173,6 +178,57 @@ inline bool operator!=(const Matrix3D& lhs, const Matrix3D& rhs) {
     return !(lhs == rhs);
 }
 
+/// Negate matrix
+inline Matrix3D operator-(const Matrix3D& lhs) {
+    Matrix3D res;
+    res[0][0] = -lhs[0][0];
+    res[1][0] = -lhs[1][0];
+    res[2][0] = -lhs[2][0];
+
+    res[0][1] = -lhs[0][1];
+    res[1][1] = -lhs[1][1];
+    res[2][1] = -lhs[2][1];
+
+    res[0][2] = -lhs[0][2];
+    res[1][2] = -lhs[1][2];
+    res[2][2] = -lhs[2][2];
+    return res;
+}
+
+/// Addition of two matrix
+inline Matrix3D operator+(const Matrix3D& lhs, const Matrix3D& rhs) {
+    Matrix3D res;
+    res[0][0] = lhs[0][0] + rhs[0][0];
+    res[1][0] = lhs[1][0] + rhs[1][0];
+    res[2][0] = lhs[2][0] + rhs[2][0];
+
+    res[0][1] = lhs[0][1] + rhs[0][1];
+    res[1][1] = lhs[1][1] + rhs[1][1];
+    res[2][1] = lhs[2][1] + rhs[2][1];
+
+    res[0][2] = lhs[0][2] + rhs[0][2];
+    res[1][2] = lhs[1][2] + rhs[1][2];
+    res[2][2] = lhs[2][2] + rhs[2][2];
+    return res;
+}
+
+/// Subtraction of two matrix
+inline Matrix3D operator-(const Matrix3D& lhs, const Matrix3D& rhs) {
+    Matrix3D res;
+    res[0][0] = lhs[0][0] - rhs[0][0];
+    res[1][0] = lhs[1][0] - rhs[1][0];
+    res[2][0] = lhs[2][0] - rhs[2][0];
+
+    res[0][1] = lhs[0][1] - rhs[0][1];
+    res[1][1] = lhs[1][1] - rhs[1][1];
+    res[2][1] = lhs[2][1] - rhs[2][1];
+
+    res[0][2] = lhs[0][2] - rhs[0][2];
+    res[1][2] = lhs[1][2] - rhs[1][2];
+    res[2][2] = lhs[2][2] - rhs[2][2];
+    return res;
+}
+
 /// Multiplication of a vector by a matrix
 inline Vector3D operator*(const Matrix3D& lhs, const Vector3D& rhs) {
     return {
@@ -196,6 +252,57 @@ inline Matrix3D operator*(const Matrix3D& lhs, const Matrix3D& rhs) {
     res[0][2] = lhs[0][0] * rhs[0][2] + lhs[0][1] * rhs[1][2] + lhs[0][2] * rhs[2][2];
     res[1][2] = lhs[1][0] * rhs[0][2] + lhs[1][1] * rhs[1][2] + lhs[1][2] * rhs[2][2];
     res[2][2] = lhs[2][0] * rhs[0][2] + lhs[2][1] * rhs[1][2] + lhs[2][2] * rhs[2][2];
+    return res;
+}
+
+/// Multiplication of a matrix and a scalar on the left
+inline Matrix3D operator*(const Matrix3D& lhs, double rhs) {
+    Matrix3D res;
+    res[0][0] = lhs[0][0] * rhs;
+    res[1][0] = lhs[1][0] * rhs;
+    res[2][0] = lhs[2][0] * rhs;
+
+    res[0][1] = lhs[0][1] * rhs;
+    res[1][1] = lhs[1][1] * rhs;
+    res[2][1] = lhs[2][1] * rhs;
+
+    res[0][2] = lhs[0][2] * rhs;
+    res[1][2] = lhs[1][2] * rhs;
+    res[2][2] = lhs[2][2] * rhs;
+    return res;
+}
+
+/// Multiplication of a matrix and a scalar on the right
+inline Matrix3D operator*(double lhs, const Matrix3D& rhs) {
+    Matrix3D res;
+    res[0][0] = rhs[0][0] * lhs;
+    res[1][0] = rhs[1][0] * lhs;
+    res[2][0] = rhs[2][0] * lhs;
+
+    res[0][1] = rhs[0][1] * lhs;
+    res[1][1] = rhs[1][1] * lhs;
+    res[2][1] = rhs[2][1] * lhs;
+
+    res[0][2] = rhs[0][2] * lhs;
+    res[1][2] = rhs[1][2] * lhs;
+    res[2][2] = rhs[2][2] * lhs;
+    return res;
+}
+
+/// Division of a matrix and a scalar
+inline Matrix3D operator/(const Matrix3D& lhs, double rhs) {
+    Matrix3D res;
+    res[0][0] = lhs[0][0] / rhs;
+    res[1][0] = lhs[1][0] / rhs;
+    res[2][0] = lhs[2][0] / rhs;
+
+    res[0][1] = lhs[0][1] / rhs;
+    res[1][1] = lhs[1][1] / rhs;
+    res[2][1] = lhs[2][1] / rhs;
+
+    res[0][2] = lhs[0][2] / rhs;
+    res[1][2] = lhs[1][2] / rhs;
+    res[2][2] = lhs[2][2] / rhs;
     return res;
 }
 

--- a/include/chemfiles/types.hpp
+++ b/include/chemfiles/types.hpp
@@ -50,6 +50,18 @@ public:
     ///
     /// @example{tests/doc/vector3d/norm.cpp}
     double norm() const;
+
+    /// Compound addition of two vectors
+    Vector3D& operator+=(const Vector3D& rhs);
+
+    /// Compound subtraction of two vectors
+    Vector3D& operator-=(const Vector3D& rhs);
+
+    /// Compound multiplication of a vector and a scalar
+    Vector3D& operator*=(double rhs);
+
+    /// Compound division of a vector by a scalar
+    Vector3D& operator/=(double rhs);
 };
 
 /// Compute the dot product of the vectors `lhs` and `rhs`.
@@ -113,6 +125,40 @@ inline Vector3D operator/(const Vector3D& lhs, double rhs) {
     return {lhs[0] / rhs, lhs[1] / rhs, lhs[2] / rhs};
 }
 
+// Compound operators:
+
+inline Vector3D& Vector3D::operator+=(const Vector3D& rhs) {
+    (*this)[0] += rhs[0];
+    (*this)[1] += rhs[1];
+    (*this)[2] += rhs[2];
+
+    return *this;
+}
+
+inline Vector3D& Vector3D::operator-=(const Vector3D& rhs) {
+    (*this)[0] -= rhs[0];
+    (*this)[1] -= rhs[1];
+    (*this)[2] -= rhs[2];
+
+    return *this;
+}
+
+inline Vector3D& Vector3D::operator*=(double rhs) {
+    (*this)[0] *= rhs;
+    (*this)[1] *= rhs;
+    (*this)[2] *= rhs;
+
+    return *this;
+}
+
+inline Vector3D& Vector3D::operator/=(double rhs) {
+    (*this)[0] /= rhs;
+    (*this)[1] /= rhs;
+    (*this)[2] /= rhs;
+
+    return *this;
+}
+
 // Vector3D needs to have a standard layout, equivalent to a `double[3]` array.
 // This means that the pointer return by `std::vector<Vector3D>::data` is
 // compatible with the `chfl_vector3d` type (`double[3]`).
@@ -164,6 +210,18 @@ public:
     /// @throw Error if the matrix is not inversible
     /// @example{tests/doc/matrix3d/invert.cpp}
     Matrix3D invert() const;
+
+    /// Compound addition of two matrices
+    Matrix3D& operator+=(const Matrix3D& rhs);
+
+    /// Compound subtraction of two matrices
+    Matrix3D& operator-=(const Matrix3D& rhs);
+
+    /// Compound multiplication of a matrix and a scalar
+    Matrix3D& operator*=(double rhs);
+
+    /// Compound division of a matrix by a scalar
+    Matrix3D& operator/=(double rhs);
 };
 
 /// Compare two matrix for equality using float equality on all components
@@ -195,7 +253,7 @@ inline Matrix3D operator-(const Matrix3D& lhs) {
     return res;
 }
 
-/// Addition of two matrix
+/// Addition of two matrices
 inline Matrix3D operator+(const Matrix3D& lhs, const Matrix3D& rhs) {
     Matrix3D res;
     res[0][0] = lhs[0][0] + rhs[0][0];
@@ -212,7 +270,7 @@ inline Matrix3D operator+(const Matrix3D& lhs, const Matrix3D& rhs) {
     return res;
 }
 
-/// Subtraction of two matrix
+/// Subtraction of two matrices
 inline Matrix3D operator-(const Matrix3D& lhs, const Matrix3D& rhs) {
     Matrix3D res;
     res[0][0] = lhs[0][0] - rhs[0][0];
@@ -238,7 +296,7 @@ inline Vector3D operator*(const Matrix3D& lhs, const Vector3D& rhs) {
     };
 }
 
-/// Multiplication of two matrix
+/// Multiplication of two matrices
 inline Matrix3D operator*(const Matrix3D& lhs, const Matrix3D& rhs) {
     Matrix3D res;
     res[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0];
@@ -327,6 +385,70 @@ inline Matrix3D Matrix3D::invert() const {
     res[2][1] = ((*this)[2][0] * (*this)[0][1] - (*this)[0][0] * (*this)[2][1]) * invdet;
     res[2][2] = ((*this)[0][0] * (*this)[1][1] - (*this)[1][0] * (*this)[0][1]) * invdet;
     return res;
+}
+
+inline Matrix3D& Matrix3D::operator+=(const Matrix3D& rhs) {
+    (*this)[0][0] += rhs[0][0];
+    (*this)[1][0] += rhs[1][0];
+    (*this)[2][0] += rhs[2][0];
+
+    (*this)[0][1] += rhs[0][1];
+    (*this)[1][1] += rhs[1][1];
+    (*this)[2][1] += rhs[2][1];
+
+    (*this)[0][2] += rhs[0][2];
+    (*this)[1][2] += rhs[1][2];
+    (*this)[2][2] += rhs[2][2];
+
+    return *this;
+}
+
+inline Matrix3D& Matrix3D::operator-=(const Matrix3D& rhs) {
+    (*this)[0][0] -= rhs[0][0];
+    (*this)[1][0] -= rhs[1][0];
+    (*this)[2][0] -= rhs[2][0];
+
+    (*this)[0][1] -= rhs[0][1];
+    (*this)[1][1] -= rhs[1][1];
+    (*this)[2][1] -= rhs[2][1];
+
+    (*this)[0][2] -= rhs[0][2];
+    (*this)[1][2] -= rhs[1][2];
+    (*this)[2][2] -= rhs[2][2];
+
+    return *this;
+}
+
+inline Matrix3D& Matrix3D::operator*=(double rhs) {
+    (*this)[0][0] *= rhs;
+    (*this)[1][0] *= rhs;
+    (*this)[2][0] *= rhs;
+
+    (*this)[0][1] *= rhs;
+    (*this)[1][1] *= rhs;
+    (*this)[2][1] *= rhs;
+
+    (*this)[0][2] *= rhs;
+    (*this)[1][2] *= rhs;
+    (*this)[2][2] *= rhs;
+
+    return *this;
+}
+
+inline Matrix3D& Matrix3D::operator/=(double rhs) {
+    (*this)[0][0] /= rhs;
+    (*this)[1][0] /= rhs;
+    (*this)[2][0] /= rhs;
+
+    (*this)[0][1] /= rhs;
+    (*this)[1][1] /= rhs;
+    (*this)[2][1] /= rhs;
+
+    (*this)[0][2] /= rhs;
+    (*this)[1][2] /= rhs;
+    (*this)[2][2] /= rhs;
+
+    return *this;
 }
 
 } // namespace chemfiles

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -46,6 +46,55 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(triclinic.beta() == 80);
         CHECK(triclinic.gamma() == 120);
         CHECK(approx_eq(triclinic.volume(), 1119.9375925598192, 1e-12));
+
+        auto zero_matrix = Matrix3D();
+        UnitCell infinite2(zero_matrix);
+        CHECK(infinite2 == infinite);
+
+        auto ortho_matrix = Matrix3D(10, 11, 12);
+        UnitCell ortho3(ortho_matrix);
+        CHECK(ortho3.shape() == UnitCell::ORTHORHOMBIC);
+        CHECK(ortho3.a() == 10);
+        CHECK(ortho3.b() == 11);
+        CHECK(ortho3.c() == 12);
+        CHECK(ortho3.alpha() == 90);
+        CHECK(ortho3.beta() == 90);
+        CHECK(ortho3.gamma() == 90);
+        CHECK(ortho3.volume() == 10*11*12);
+
+        // These need to be approximate due to acos used in this constructor
+        UnitCell triclinic2(triclinic.matrix());
+        CHECK(triclinic2.shape() == UnitCell::TRICLINIC);
+        CHECK(approx_eq(triclinic2.a(), 10.0, 1e-12));
+        CHECK(approx_eq(triclinic2.b(), 11.0, 1e-12));
+        CHECK(approx_eq(triclinic2.c(), 12.0, 1e-12));
+        CHECK(approx_eq(triclinic2.alpha(), 90.0, 1e-12));
+        CHECK(approx_eq(triclinic2.beta(), 80.0, 1e-12));
+        CHECK(approx_eq(triclinic2.gamma(), 120.0, 1e-12));
+        CHECK(approx_eq(triclinic2.volume(), 1119.9375925598192, 1e-12));
+
+        auto wrong_matrix = Matrix3D(
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            7.0, 8.0, 9.0
+        );
+
+        CHECK_THROWS_AS(UnitCell(wrong_matrix), Error);
+
+        auto triclinic_matrix = Matrix3D(
+            26.2553,  0.0000, -4.4843,
+             0.0000, 11.3176,  0.0000,
+             0.0000,  0.0000,  11.011
+        );
+
+        UnitCell triclinic3(triclinic_matrix);
+        CHECK(triclinic3.shape() == UnitCell::TRICLINIC);
+        CHECK(approx_eq(triclinic3.a(), 26.2553, 1e-4));
+        CHECK(approx_eq(triclinic3.b(), 11.3176, 1e-4));
+        CHECK(approx_eq(triclinic3.c(), 11.8892, 1e-4));
+        CHECK(approx_eq(triclinic3.alpha(), 90.0, 1e-4));
+        CHECK(approx_eq(triclinic3.beta(), 112.159, 1e-4));
+        CHECK(approx_eq(triclinic3.gamma(), 90.0, 1e-4));
     }
 
     SECTION("Operators") {

--- a/tests/doc/cell/matrix.cpp
+++ b/tests/doc/cell/matrix.cpp
@@ -23,5 +23,16 @@ TEST_CASE() {
     assert(matrix[1][0] == 0);
     assert(matrix[2][0] == 0);
     assert(matrix[2][1] == 0);
+
+    auto cell2 = UnitCell(matrix);
+
+    assert(cell2.a() == 11);
+    assert(cell2.b() == 22);
+    assert(cell2.c() == 33);
+
+    assert(cell2.alpha() == 90);
+    assert(cell2.beta()  == 90);
+    assert(cell2.gamma() == 90);
+
     // [example]
 }

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -18,6 +18,8 @@ TEST_CASE("Vector3d"){
     CHECK((u / 2.0) == Vector3D(0.5, 0.5, 0.5));
 
     CHECK((v * 4.75) == (4.75 * v));
+
+    CHECK((-v) == Vector3D(21.0, -15.0, -23.5));
 }
 
 TEST_CASE("Geometry"){
@@ -54,6 +56,86 @@ TEST_CASE("Matrix3"){
                 }
             }
         }
+    }
+
+    SECTION("Negate Matrix") {
+        auto A = Matrix3D(
+            2, 4, 9,
+            1, -67, 8,
+            9, 78.9, 65
+        );
+
+        auto B = Matrix3D(
+            -2, -4, -9,
+            -1, 67, -8,
+            -9, -78.9, -65
+        );
+
+        CHECK(A == (-B));
+        CHECK(B == (-A));
+    }
+
+    SECTION("Matrix-Matrix Addition") {
+        auto A = Matrix3D(
+            2, 4, 9,
+            1, -67, 8,
+            9, 78.9, 65
+        );
+        auto Z = Matrix3D();
+        CHECK((A + Z) == A);
+        CHECK((Z + A) == A);
+        CHECK((A - Z) == A);
+        CHECK((Z - A) == (-A));
+
+        auto C = Matrix3D(
+            2, 4, 9,
+            1, -6, 8,
+            -3, 9, 5
+        );
+
+        auto D = Matrix3D(
+            4, 8, 18,
+            2, -73, 16,
+            6, 87.9, 70
+        );
+
+        auto E = Matrix3D(
+            0, 0, 0,
+            0, -61, 0,
+            12, 69.9, 60
+        );
+
+        CHECK((A + C) == D);
+        CHECK((C + A) == D);
+        CHECK((A - C) == E);
+        CHECK((C - A) == (-E));
+    }
+
+    SECTION("Matrix-Scalar Multiplication and Division") {
+        auto A = Matrix3D(
+            2, 4, 9,
+            1, -67, 8,
+            9, 78.9, 65
+        );
+        CHECK(A * 1 == A);
+        CHECK(1 * A == A);
+        CHECK(A / 1 == A);
+
+        auto C = Matrix3D(
+            4, 8, 18,
+            2, -134, 16,
+            18, 157.8, 130
+        );
+
+        auto D = Matrix3D(
+            1, 2, 4.5,
+            0.5, -33.5, 4,
+            4.5, 39.45, 32.5
+        );
+
+        CHECK(A * 2 == C);
+        CHECK(2 * A == C);
+        CHECK(A / 2 == D);
     }
 
     SECTION("Matrix-Matrix Multiplications") {

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -20,6 +20,18 @@ TEST_CASE("Vector3d"){
     CHECK((v * 4.75) == (4.75 * v));
 
     CHECK((-v) == Vector3D(21.0, -15.0, -23.5));
+
+    CHECK((v += u) == Vector3D(-20.0, 16.0, 24.5));
+    CHECK(v == Vector3D(-20.0, 16.0, 24.5));
+
+    CHECK((v -= u) ==  Vector3D(-21.0, 15.0, 23.5));
+    CHECK(v ==  Vector3D(-21.0, 15.0, 23.5));
+
+    CHECK((u *= 3) == Vector3D(3.0, 3.0, 3.0));
+    CHECK(u == Vector3D(3.0, 3.0, 3.0));
+
+    CHECK((u /= 3) == Vector3D(1.0, 1.0, 1.0));
+    CHECK(u == Vector3D(1.0, 1.0, 1.0));
 }
 
 TEST_CASE("Geometry"){
@@ -109,6 +121,11 @@ TEST_CASE("Matrix3"){
         CHECK((C + A) == D);
         CHECK((A - C) == E);
         CHECK((C - A) == (-E));
+
+        CHECK((A += C) == D);
+        CHECK(A == D);
+        CHECK((A -= (C + C)) == E);
+        CHECK(A == E);
     }
 
     SECTION("Matrix-Scalar Multiplication and Division") {
@@ -136,6 +153,11 @@ TEST_CASE("Matrix3"){
         CHECK(A * 2 == C);
         CHECK(2 * A == C);
         CHECK(A / 2 == D);
+
+        CHECK((A *= 2) == C);
+        CHECK(A == C);
+        CHECK((A /= 4) == D);
+        CHECK(A == D);
     }
 
     SECTION("Matrix-Matrix Multiplications") {


### PR DESCRIPTION
I decided not to implement `Matrix3D operator*=(Matrix3D)` as this requires a copy of the matrix to be made and I feel compound assignment operators should be free of coping. Other than that, I feel this closes #162.