### PR TITLE
Rename Frame::guess_topology to Frame::guess_bonds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `Residue::set` and `Residue::get`.
 * The topology of residues is now automatically set using a lookup table for the
   PDB format.
+* `Frame::guess_topology` was renamed to `Frame::guess_bonds`.
 * The selection engine has been rewritten to add support for more complex
   selections:
     * it is now possible to use mathematical expressions in selections such as
@@ -37,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added `chfl_residue_get_property` and `chfl_residue_set_property` to provide
   access to residue properties.
+* `chfl_frame_guess_topology` was renamed to `chfl_frame_guess_bonds`.
 
 ## 0.8 (14 Dec 2017)
 

--- a/doc/src/capi/chfl_frame.rst
+++ b/doc/src/capi/chfl_frame.rst
@@ -39,7 +39,7 @@ Function manipulating ``CHFL_FRAME``
 
 .. doxygenfunction:: chfl_frame_set_step
 
-.. doxygenfunction:: chfl_frame_guess_topology
+.. doxygenfunction:: chfl_frame_guess_bonds
 
 .. doxygenfunction:: chfl_frame_distance
 

--- a/include/chemfiles/Frame.hpp
+++ b/include/chemfiles/Frame.hpp
@@ -231,8 +231,8 @@ public:
     ///
     /// @throw Error if the Van der Waals radius in unknown for a given atom.
     ///
-    /// @example{tests/doc/frame/guess_topology.cpp}
-    void guess_topology();
+    /// @example{tests/doc/frame/guess_bonds.cpp}
+    void guess_bonds();
 
     /// Remove all connectivity information in the frame's topology
     ///

--- a/include/chemfiles/capi/frame.h
+++ b/include/chemfiles/capi/frame.h
@@ -183,10 +183,10 @@ CHFL_EXPORT chfl_status chfl_frame_set_step(
 /// The bonds are guessed using a distance-based algorithm, and then angles and
 /// dihedrals are guessed from the bonds.
 ///
-/// @example{tests/capi/doc/chfl_frame/guess_topology.c}
+/// @example{tests/capi/doc/chfl_frame/guess_bonds.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn
 ///         about the error if the status code is not `CHFL_SUCCESS`.
-CHFL_EXPORT chfl_status chfl_frame_guess_topology(CHFL_FRAME* frame);
+CHFL_EXPORT chfl_status chfl_frame_guess_bonds(CHFL_FRAME* frame);
 
 /// Get the distance between the atoms at indexes `i` and `j` in the `frame`,
 /// accounting for periodic boundary conditions. The result is placed in

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -45,7 +45,7 @@ void Frame::add_velocities() {
     }
 }
 
-void Frame::guess_topology() {
+void Frame::guess_bonds() {
     topology_.clear_bonds();
     // This bond guessing algorithm comes from VMD
     auto cutoff = 0.833;

--- a/src/capi/frame.cpp
+++ b/src/capi/frame.cpp
@@ -150,10 +150,10 @@ extern "C" chfl_status chfl_frame_set_step(CHFL_FRAME* const frame, uint64_t ste
     )
 }
 
-extern "C" chfl_status chfl_frame_guess_topology(CHFL_FRAME* const frame) {
+extern "C" chfl_status chfl_frame_guess_bonds(CHFL_FRAME* const frame) {
     CHECK_POINTER(frame);
     CHFL_ERROR_CATCH(
-        frame->guess_topology();
+        frame->guess_bonds();
     )
 }
 

--- a/tests/capi/doc/chfl_frame/guess_bonds.c
+++ b/tests/capi/doc/chfl_frame/guess_bonds.c
@@ -22,7 +22,7 @@ int main() {
     assert(bonds == 0);
     chfl_topology_free(topology);
 
-    chfl_frame_guess_topology(frame);
+    chfl_frame_guess_bonds(frame);
 
     // Get a copie of the new topology
     topology = chfl_topology_from_frame(frame);

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -267,7 +267,7 @@ TEST_CASE("chfl_frame") {
         REQUIRE(frame);
         CHECK_STATUS(chfl_trajectory_read(trajectory, frame));
 
-        CHECK_STATUS(chfl_frame_guess_topology(frame));
+        CHECK_STATUS(chfl_frame_guess_bonds(frame));
         CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 

--- a/tests/doc/frame/guess_bonds.cpp
+++ b/tests/doc/frame/guess_bonds.cpp
@@ -16,7 +16,7 @@ TEST_CASE() {
 
     assert(frame.topology().bonds().size() == 0);
 
-    frame.guess_topology();
+    frame.guess_bonds();
     assert(frame.topology().bonds().size() == 1);
     // [example]
 }

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -111,7 +111,7 @@ TEST_CASE("Guess topology") {
         frame.add_atom(Atom("O"), {0, 0, 0});
         frame.add_atom(Atom("O"), {1.5, 0, 0});
         frame.add_atom(Atom("H"), {1.5, 1, 0});
-        frame.guess_topology();
+        frame.guess_bonds();
 
         auto bonds = std::vector<Bond>{{0, 1}, {1, 2}, {2, 3}};
         auto angles = std::vector<Angle>{{0, 1, 2}, {1, 2, 3}};
@@ -123,7 +123,7 @@ TEST_CASE("Guess topology") {
 
     SECTION("Methane file") {
         auto frame = Trajectory("data/xyz/methane.xyz").read();
-        frame.guess_topology();
+        frame.guess_bonds();
 
         auto topology = frame.topology();
         CHECK(topology.bonds() == (std::vector<Bond>{{0, 1}, {0, 2}, {0, 3}, {0, 4}}));
@@ -148,7 +148,7 @@ TEST_CASE("Guess topology") {
         frame.add_atom(Atom("H"), {0.2, 0.8, 0});
         frame.add_atom(Atom("H"), {-0.2, 0.8, 0});
 
-        frame.guess_topology();
+        frame.guess_bonds();
         CHECK(frame.topology().bonds() == (std::vector<Bond>{{0, 1}, {0, 2}}));
     }
 
@@ -159,7 +159,7 @@ TEST_CASE("Guess topology") {
         frame.add_atom(Atom("C"), {0.5, 0, 0});
         frame.add_atom(Atom("C"), {-0.5, 0, 0});
 
-        frame.guess_topology();
+        frame.guess_bonds();
         CHECK(frame.topology().bonds() == (std::vector<Bond>{{0, 1}, {0, 2}, {1, 2}}));
         CHECK(frame.topology().angles() == (std::vector<Angle>{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}}));
         CHECK(frame.topology().dihedrals() == (std::vector<Dihedral>{}));
@@ -173,7 +173,7 @@ TEST_CASE("Guess topology") {
         frame.add_atom(Atom("C"), {1.5, 1.5, 0});
         frame.add_atom(Atom("C"), {0, 1.5, 0});
 
-        frame.guess_topology();
+        frame.guess_bonds();
         CHECK(frame.topology().bonds() == (std::vector<Bond>{{0, 1}, {0, 3}, {1, 2}, {2, 3}}));
         CHECK(frame.topology().angles() == (std::vector<Angle>{{0, 1, 2}, {0, 3, 2}, {1, 0, 3}, {1, 2, 3}}));
         CHECK(frame.topology().dihedrals() == (std::vector<Dihedral>{{0, 1, 2, 3}, {1, 0, 3, 2}, {1, 2, 3, 0}, {2, 1, 0, 3}}));


### PR DESCRIPTION
It makes more sense, now that the topology contains more than just bonds.