### PR TITLE
Use a shared allocator for C API pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Next Release (current master)
 
 * Direct reading and writing of compressed files. gzip and lzma (.xz) formats
-  are supported. 
+  are supported.
 * GROMACS .gro files now supported through custom implementation.
 * Properties are now supported in the `Residue` class. They are accessed using
   `Residue::set` and `Residue::get`.
@@ -30,12 +30,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
       quotes (`name "45"`). This also allows for more exotic atomic names
       (`name "名"`).
 * There is only one constructor for the `Frame` class: `Frame(UnitCell cell =
-  UnitCell())`. The constructor taking a topology can be replaced with calls to 
+  UnitCell())`. The constructor taking a topology can be replaced with calls to
   `Frame::add_atom` and `Frame::add_bond`.
 
 ### Changes in supported formats
 
-* Added `MarcoMolecule Transmission Format (MMTF)` support, reading via mmtf-c.
+* Added `MarcoMolecule Transmission Format (MMTF)` support, reading via mmtf-cpp.
 * Added `Structure-Data File (SDF)` support, reading and writing.
 * Added `Cambridge Structure Search and Retrieval (CSSR)` support, reading and writing.
 
@@ -44,6 +44,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added `chfl_residue_get_property` and `chfl_residue_set_property` to provide
   access to residue properties.
 * `chfl_frame_guess_topology` was renamed to `chfl_frame_guess_bonds`.
+* Function accessing atoms/cell/residue/topology inside a frame/topology no
+  longer make a copy. This allows for direct reading and writing inside the
+  containing frame/topology.
 
 ## 0.8 (14 Dec 2017)
 

--- a/include/chemfiles/capi/atom.h
+++ b/include/chemfiles/capi/atom.h
@@ -29,9 +29,23 @@ CHFL_EXPORT CHFL_ATOM* chfl_atom(const char* name);
 ///         You can use `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom_copy(const CHFL_ATOM* atom);
 
-/// Get a copy of the atom at the given `index` from a `frame`
+/// Get access to the atom at the given `index` from a `frame`.
 ///
-/// The caller of this function should free the associated memory using
+/// Any modification to the atom will be reflected in the `frame`. The `frame`
+/// will be kept alive, even if `chfl_frame_free` is called, until
+/// `chfl_atom_free` is also called on the pointer returned by this function.
+///
+/// The pointer returned by this function points directly inside the frame, and
+/// will be invalidated if any of the following function is called on the
+/// frame:
+///
+/// - `chfl_frame_resize`
+/// - `chfl_frame_add_atom`
+/// - `chfl_frame_remove`
+/// - `chfl_frame_set_topology`
+///
+/// Calling any function on an invalidated pointer is undefined behavior.
+/// Even if the pointer if invalidated, it stills needs to be released with
 /// `chfl_atom_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/from_frame.c}
@@ -39,11 +53,25 @@ CHFL_EXPORT CHFL_ATOM* chfl_atom_copy(const CHFL_ATOM* atom);
 /// @return A pointer to the atom, or NULL in case of error or if `index` is
 ///         out of bounds. You can use `chfl_last_error` to learn about the
 ///         error.
-CHFL_EXPORT CHFL_ATOM* chfl_atom_from_frame(const CHFL_FRAME* frame, uint64_t index);
+CHFL_EXPORT CHFL_ATOM* chfl_atom_from_frame(CHFL_FRAME* frame, uint64_t index);
 
-/// Get a copy of the atom at the given `index` from a `topology`
+/// Get access to the atom at the given `index` from a `topology`
 ///
-/// The caller of this function should free the associated memory using
+/// Any modification to the atom will be reflected in the `topology`. The
+/// `topology` will be kept alive, even if `chfl_topology_free` is called,
+/// until `chfl_atom_free` is also called on the pointer returned by this
+/// function.
+///
+/// The pointer returned by this function points directly inside the topology,
+/// and will be invalidated if any of the following function is called on the
+/// topology:
+///
+/// - `chfl_topology_resize`
+/// - `chfl_topology_add_atom`
+/// - `chfl_topology_remove`
+///
+/// Calling any function on an invalidated pointer is undefined behavior.
+/// Even if the pointer if invalidated, it stills needs to be released with
 /// `chfl_atom_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/from_topology.c}
@@ -51,7 +79,7 @@ CHFL_EXPORT CHFL_ATOM* chfl_atom_from_frame(const CHFL_FRAME* frame, uint64_t in
 ///         out of bounds. You can use `chfl_last_error` to learn about the
 ///         error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom_from_topology(
-    const CHFL_TOPOLOGY* topology, uint64_t index
+    CHFL_TOPOLOGY* topology, uint64_t index
 );
 
 /// Get the mass of an `atom`, in the double pointed to by `mass`.
@@ -204,7 +232,7 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_atom_get_property(
 ///
 /// @example{tests/capi/doc/chfl_atom/chfl_atom.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_atom_free(CHFL_ATOM* atom);
+CHFL_EXPORT chfl_status chfl_atom_free(const CHFL_ATOM* atom);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/cell.h
+++ b/include/chemfiles/capi/cell.h
@@ -51,15 +51,27 @@ CHFL_EXPORT CHFL_CELL* chfl_cell_triclinic(
     const chfl_vector3d lengths, const chfl_vector3d angles
 );
 
-/// Get a copy of the unit cell of a `frame`.
+/// Get access to the cell of a `frame`
 ///
-/// The caller of this function should free the associated memory using
+/// Any modification to the cell will be reflected in the `frame`. The
+/// `frame` will be kept alive, even if `chfl_frame_free` is called,
+/// until `chfl_cell_free` is also called on the pointer returned by this
+/// function.
+///
+/// The pointer returned by this function points directly inside the frame,
+/// and will be invalidated if any of the following function is called on the
+/// frame:
+///
+/// - `chfl_frame_set_cell`
+///
+/// Calling any function on an invalidated pointer is undefined behavior.
+/// Even if the pointer if invalidated, it stills needs to be released with
 /// `chfl_cell_free`.
 ///
 /// @example{tests/capi/doc/chfl_cell/from_frame.c}
 /// @return A pointer to the unit cell, or NULL in case of error.
 ///         You can use `chfl_last_error` to learn about the error.
-CHFL_EXPORT CHFL_CELL* chfl_cell_from_frame(const CHFL_FRAME* frame);
+CHFL_EXPORT CHFL_CELL* chfl_cell_from_frame(CHFL_FRAME* frame);
 
 /// Get a copy of a `cell`.
 ///
@@ -171,7 +183,7 @@ CHFL_EXPORT chfl_status chfl_cell_wrap(
 ///
 /// @example{tests/capi/doc/chfl_cell/chfl_cell.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_cell_free(CHFL_CELL* cell);
+CHFL_EXPORT chfl_status chfl_cell_free(const CHFL_CELL* cell);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/frame.h
+++ b/include/chemfiles/capi/frame.h
@@ -298,7 +298,7 @@ CHFL_EXPORT chfl_status chfl_frame_add_residue(
 ///
 /// @example{tests/capi/doc/chfl_frame/chfl_frame.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_frame_free(CHFL_FRAME* frame);
+CHFL_EXPORT chfl_status chfl_frame_free(const CHFL_FRAME* frame);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/property.h
+++ b/include/chemfiles/capi/property.h
@@ -128,7 +128,7 @@ CHFL_EXPORT chfl_status chfl_property_get_vector3d(
 ///
 /// @example{tests/capi/doc/chfl_property/bool.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_property_free(CHFL_PROPERTY* property);
+CHFL_EXPORT chfl_status chfl_property_free(const CHFL_PROPERTY* property);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/residue.h
+++ b/include/chemfiles/capi/residue.h
@@ -29,7 +29,7 @@ CHFL_EXPORT CHFL_RESIDUE* chfl_residue(const char* name);
 ///         You can use `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid);
 
-/// Get a copy of the residue at index `i` from a `topology`.
+/// Get access to the residue at index `i` in a `topology`.
 ///
 /// If `i` is bigger than the result of `chfl_topology_residues_count`, this
 /// function will return `NULL`.
@@ -37,29 +37,51 @@ CHFL_EXPORT CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid)
 /// The residue index in the topology is not always the same as the residue
 /// `id`.
 ///
-/// The caller of this function should free the allocated memory using
+/// The `topology` will be kept alive, even if `chfl_topology_free` is called,
+/// until `chfl_residue_free` is also called on the pointer returned by this
+/// function.
+///
+/// The pointer returned by this function points directly inside the topology,
+/// and will be invalidated if any of the following function is called on the
+/// topology:
+///
+/// - `chfl_topology_add_residue`
+///
+/// Calling any function on an invalidated pointer is undefined behavior.
+/// Even if the pointer if invalidated, it stills needs to be released with
 /// `chfl_residue_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/from_topology.c}
 /// @return A pointer to the residue, or NULL in case of error.
 ///         You can use `chfl_last_error` to learn about the error.
-CHFL_EXPORT CHFL_RESIDUE* chfl_residue_from_topology(
+CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_from_topology(
     const CHFL_TOPOLOGY* topology, uint64_t i
 );
 
-/// Get a copy of the residue containing the atom at index `i` in the
+/// Get access to the residue containing the atom at index `i` in the
 /// `topology`.
 ///
 /// This function will return `NULL` if the atom is not in a residue, or if the
 /// index `i` is bigger than `chfl_topology_atoms_count`.
 ///
-/// The caller of this function should free the allocated memory using
+/// The `topology` will be kept alive, even if `chfl_topology_free` is called,
+/// until `chfl_residue_free` is also called on the pointer returned by this
+/// function.
+///
+/// The pointer returned by this function points directly inside the topology,
+/// and will be invalidated if any of the following function is called on the
+/// topology:
+///
+/// - `chfl_topology_add_residue`
+///
+/// Calling any function on an invalidated pointer is undefined behavior.
+/// Even if the pointer if invalidated, it stills needs to be released with
 /// `chfl_residue_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/for_atom.c}
 /// @return A pointer to the residue, or NULL in case of error.
 ///         You can use `chfl_last_error` to learn about the error.
-CHFL_EXPORT CHFL_RESIDUE* chfl_residue_for_atom(
+CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_for_atom(
     const CHFL_TOPOLOGY* topology, uint64_t i
 );
 
@@ -170,7 +192,7 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_residue_get_property(
 ///
 /// @example{tests/capi/doc/chfl_residue/chfl_residue.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_residue_free(CHFL_RESIDUE* residue);
+CHFL_EXPORT chfl_status chfl_residue_free(const CHFL_RESIDUE* residue);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/selection.h
+++ b/include/chemfiles/capi/selection.h
@@ -102,7 +102,7 @@ CHFL_EXPORT chfl_status chfl_selection_matches(
 ///
 /// @example{tests/capi/doc/chfl_selection/chfl_selection.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_selection_free(CHFL_SELECTION* selection);
+CHFL_EXPORT chfl_status chfl_selection_free(const CHFL_SELECTION* selection);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/topology.h
+++ b/include/chemfiles/capi/topology.h
@@ -19,15 +19,19 @@ extern "C" {
 ///         You can use `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_TOPOLOGY* chfl_topology(void);
 
-/// Get a copy of the topology of a `frame`.
+/// Get access to the topology of a `frame`.
 ///
-/// The caller of this function should free the associated memory using
-/// `chfl_topology_free`.
+/// The `frame` will be kept alive, even if `chfl_frame_free` is called,
+/// until `chfl_topology_free` is also called on the pointer returned by this
+/// function.
+///
+/// If `chfl_frame_set_topology` is called, this pointer will point to the new
+/// topology.
 ///
 /// @example{tests/capi/doc/chfl_topology/from_frame.c}
 /// @return A pointer to the topology, or NULL in case of error.
 ///         You can use `chfl_last_error` to learn about the error.
-CHFL_EXPORT CHFL_TOPOLOGY* chfl_topology_from_frame(const CHFL_FRAME* frame);
+CHFL_EXPORT const CHFL_TOPOLOGY* chfl_topology_from_frame(const CHFL_FRAME* frame);
 
 /// Get a copy of a `topology`.
 ///
@@ -230,7 +234,7 @@ CHFL_EXPORT chfl_status chfl_topology_residues_linked(
 ///
 /// @example{tests/capi/doc/chfl_topology/chfl_topology.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_topology_free(CHFL_TOPOLOGY* topology);
+CHFL_EXPORT chfl_status chfl_topology_free(const CHFL_TOPOLOGY* topology);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/trajectory.h
+++ b/include/chemfiles/capi/trajectory.h
@@ -125,7 +125,7 @@ CHFL_EXPORT chfl_status chfl_trajectory_nsteps(
 ///
 /// @example{tests/capi/doc/chfl_trajectory/open.c}
 /// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_trajectory_close(CHFL_TRAJECTORY* trajectory);
+CHFL_EXPORT chfl_status chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/shared_allocator.hpp
+++ b/include/chemfiles/shared_allocator.hpp
@@ -1,0 +1,185 @@
+#ifndef CHFL_SHARED_ALLOCATOR_HPP
+#define CHFL_SHARED_ALLOCATOR_HPP
+
+#include <unordered_map>
+#include <functional>
+#include <cassert>
+#include <vector>
+#include <atomic>
+
+#include "chemfiles/ErrorFmt.hpp"
+
+/// An atomic counter, for reference counted pointers
+class atomic_count {
+public:
+    explicit atomic_count(long value): value_(static_cast<std::int_least32_t>(value)) {}
+    ~atomic_count() = default;
+
+    atomic_count(const atomic_count&) = delete;
+    atomic_count& operator=(const atomic_count&) = delete;
+
+    atomic_count(atomic_count&& other): value_(static_cast<std::int_least32_t>(other.load())) {
+        other.value_ = 0;
+    }
+
+    atomic_count& operator=(atomic_count&& other) {
+        value_ = static_cast<std::int_least32_t>(other.load());
+        other.value_ = 0;
+        return *this;
+    }
+
+    // Increase counter by one and return the resulting value
+    long increase() {
+        return value_.fetch_add(1, std::memory_order_acq_rel) + 1;
+    }
+
+    // Decrease the counter by one and return the resulting value
+    long decrease() {
+        return value_.fetch_sub(1, std::memory_order_acq_rel) - 1;
+    }
+
+    // Get the current counter value
+    long load() const {
+        return value_.load(std::memory_order_acquire);
+    }
+
+private:
+    std::atomic_int_least32_t value_;
+};
+
+
+/// An allocator with shared_ptr like semantics, working with raw pointers.
+///
+/// This is used in the C API to ensure that when taking pointers to
+/// atoms/residues/cell inside a frame/topology, the frame/topology is keept
+/// alive even if the user call chfl_xxx_free.
+class shared_allocator {
+public:
+    shared_allocator() = default;
+    shared_allocator(const shared_allocator&) = delete;
+    shared_allocator& operator=(const shared_allocator&) = delete;
+    shared_allocator(shared_allocator&&) = delete;
+    shared_allocator& operator=(shared_allocator&&) = delete;
+
+    /// Like std::make_shared: create a new shared pointer by constructing a
+    /// value of type T with the given arguments.
+    template<class T, typename ... Args>
+    static T* make_shared(Args&& ... args) {
+        auto ptr = new T{std::forward<Args>(args)...};
+        instance_.insert_new(ptr);
+        return ptr;
+    }
+
+    /// Like std::shared_ptr<U> aliasing contructor: element and ptr will share
+    /// the references count, and none will be freed while the other one is
+    /// alive.
+    ///
+    /// `ptr` must have been allocated with make_shared.
+    template<class T, class U>
+    static T* shared_ptr(U* ptr, T* element) {
+        instance_.insert_shared(ptr, element);
+        auto& count = instance_.count(ptr);
+        count.increase();
+        return element;
+    }
+
+    template<class T, class U>
+    static const T* shared_ptr(U* ptr, const T* element) {
+        return shared_ptr(ptr, const_cast<T*>(element));
+    }
+
+    /// Decrease the reference count of `ptr`, and delete it if needed.
+    static void free(const void* ptr) {
+        auto it = instance_.map_.find(ptr);
+        auto& count = instance_.counts_.at(it->second);
+        auto references = count.decrease();
+        if (references == 0) {
+            instance_.deleters_.at(it->second)();
+            instance_.unused_counts_.emplace_back(it->second);
+        } else if (references < 0) {
+            throw chemfiles::error(
+                "internal errpr: negative reference count for {}", ptr
+            );
+        }
+        instance_.map_.erase(it);
+    }
+
+private:
+    template<class T>
+    void insert_new(T* ptr) {
+        size_t id = get_unused_count();
+        counts_[id] = atomic_count(1);
+        deleters_[id] = [ptr](){ delete ptr; };
+        auto inserted = map_.emplace(ptr, id);
+        if (!inserted.second) {
+            throw chemfiles::error(
+                "internal error: pointer at {} is already managed by "
+                "shared_allocator", static_cast<void*>(ptr)
+            );
+        }
+    }
+
+    void insert_shared(const void* ptr, void* element) {
+        auto it = map_.find(ptr);
+        if (it == map_.end()) {
+            throw chemfiles::error(
+                "internal error: pointer at {} is not managed by "
+                "shared_allocator", ptr
+            );
+        }
+        auto inserted = map_.emplace(element, it->second);
+        if (!inserted.second) {
+            if (inserted.first->second == it->second) {
+                // We already have a shared pointer to this element, just
+                // increase the reference count
+                counts_.at(it->second).increase();
+            } else {
+                throw chemfiles::error(
+                    "internal error: pointer at {} is already managed by "
+                    "shared_allocator", ptr
+                );
+            }
+        }
+    }
+
+    atomic_count& count(const void* ptr) {
+        auto it = map_.find(ptr);
+        if (it != map_.end()) {
+            return counts_.at(it->second);
+        } else {
+            throw std::runtime_error("unknwon pointer");
+        }
+    }
+
+    size_t get_unused_count() {
+        assert(counts_.size() == deleters_.size());
+        if (!unused_counts_.empty()) {
+            // Get an existing one
+            size_t id = unused_counts_.back();
+            unused_counts_.pop_back();
+            return id;
+        } else {
+            // create a new one
+            size_t id = counts_.size();
+            counts_.emplace_back(0);
+            deleters_.emplace_back([](){ throw std::runtime_error("uninitialized deleter"); });
+            return id;
+        }
+    }
+
+    /// A map of pointer adresses -> indexes of reference count in counts_ and
+    /// deleter function in deleters_
+    std::unordered_map<const void*, size_t> map_;
+    /// References counts
+    std::vector<atomic_count> counts_;
+    /// Deleter functions
+    std::vector<std::function<void(void)>> deleters_;
+    /// unused indexes in counts_/deleters_ that can be re-used. This is set by
+    /// free and used by get_unused_count.
+    std::vector<size_t> unused_counts_;
+
+    /// Global instance of the allocator
+    static shared_allocator instance_;
+};
+
+#endif

--- a/src/capi/frame.cpp
+++ b/src/capi/frame.cpp
@@ -3,6 +3,7 @@
 
 #include "chemfiles/capi/frame.h"
 #include "chemfiles/capi.hpp"
+#include "chemfiles/shared_allocator.hpp"
 
 #include "chemfiles/Frame.hpp"
 #include "chemfiles/ErrorFmt.hpp"
@@ -11,7 +12,7 @@ using namespace chemfiles;
 extern "C" CHFL_FRAME* chfl_frame(void) {
     CHFL_FRAME* frame = nullptr;
     CHFL_ERROR_GOTO(
-        frame = new Frame();
+        frame = shared_allocator::make_shared<Frame>();
     )
     return frame;
 error:
@@ -22,7 +23,7 @@ error:
 extern "C" CHFL_FRAME* chfl_frame_copy(const CHFL_FRAME* const frame) {
     CHFL_FRAME* new_frame = nullptr;
     CHFL_ERROR_GOTO(
-        new_frame = new Frame(frame->clone());
+        new_frame = shared_allocator::make_shared<Frame>(frame->clone());
     )
     return new_frame;
 error:
@@ -73,9 +74,9 @@ extern "C" chfl_status chfl_frame_velocities(CHFL_FRAME* const frame, chfl_vecto
 }
 
 extern "C" chfl_status chfl_frame_add_atom(
-	CHFL_FRAME* const frame, 
-	const CHFL_ATOM* const atom, 
-	const chfl_vector3d position, 
+	CHFL_FRAME* const frame,
+	const CHFL_ATOM* const atom,
+	const chfl_vector3d position,
 	const chfl_vector3d velocity
 ) {
     CHECK_POINTER(frame);
@@ -242,7 +243,12 @@ extern "C" chfl_status chfl_frame_add_residue(CHFL_FRAME* const frame, const CHF
     )
 }
 
-extern "C" chfl_status chfl_frame_free(CHFL_FRAME* const frame) {
-    delete frame;
-    return CHFL_SUCCESS;
+extern "C" chfl_status chfl_frame_free(const CHFL_FRAME* const frame) {
+    CHFL_ERROR_CATCH(
+        if (frame == nullptr) {
+            return CHFL_SUCCESS;
+        } else {
+            shared_allocator::free(frame);
+        }
+    )
 }

--- a/src/capi/property.cpp
+++ b/src/capi/property.cpp
@@ -98,7 +98,7 @@ extern "C" chfl_status chfl_property_get_vector3d(const CHFL_PROPERTY* const pro
     )
 }
 
-extern "C" chfl_status chfl_property_free(CHFL_PROPERTY* property) {
+extern "C" chfl_status chfl_property_free(const CHFL_PROPERTY* property) {
     delete property;
     return CHFL_SUCCESS;
 }

--- a/src/capi/selection.cpp
+++ b/src/capi/selection.cpp
@@ -87,7 +87,7 @@ extern "C" chfl_status chfl_selection_matches(const CHFL_SELECTION* const select
     )
 }
 
-extern "C" chfl_status chfl_selection_free(CHFL_SELECTION* const selection) {
+extern "C" chfl_status chfl_selection_free(const CHFL_SELECTION* const selection) {
     delete selection;
     return CHFL_SUCCESS;
 }

--- a/src/capi/trajectory.cpp
+++ b/src/capi/trajectory.cpp
@@ -91,7 +91,7 @@ extern "C" chfl_status chfl_trajectory_nsteps(CHFL_TRAJECTORY* const trajectory,
     )
 }
 
-extern "C" chfl_status chfl_trajectory_close(CHFL_TRAJECTORY* trajectory) {
+extern "C" chfl_status chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory) {
     delete trajectory;
     return CHFL_SUCCESS;
 }

--- a/src/shared_allocator.cpp
+++ b/src/shared_allocator.cpp
@@ -1,0 +1,6 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+#include "chemfiles/shared_allocator.hpp"
+
+// define the global allocator instance
+shared_allocator shared_allocator::instance_;

--- a/tests/capi/doc/chfl_frame/guess_bonds.c
+++ b/tests/capi/doc/chfl_frame/guess_bonds.c
@@ -16,7 +16,7 @@ int main() {
     chfl_atom_free(Cl);
 
     // Check that the topology does not contain any bond
-    CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+    const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
     uint64_t bonds = 0;
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 0);

--- a/tests/capi/doc/chfl_residue/for_atom.c
+++ b/tests/capi/doc/chfl_residue/for_atom.c
@@ -10,7 +10,7 @@ int main() {
 
     // Build topology ...
 
-    CHFL_RESIDUE* residue = chfl_residue_for_atom(topology, 3);
+    const CHFL_RESIDUE* residue = chfl_residue_for_atom(topology, 3);
 
     if (residue == NULL) {
         /* handle error */

--- a/tests/capi/doc/chfl_residue/from_topology.c
+++ b/tests/capi/doc/chfl_residue/from_topology.c
@@ -10,7 +10,7 @@ int main() {
 
     // Build topology ...
 
-    CHFL_RESIDUE* residue = chfl_residue_from_topology(topology, 3);
+    const CHFL_RESIDUE* residue = chfl_residue_from_topology(topology, 3);
 
     if (residue == NULL) {
         /* handle error */

--- a/tests/capi/doc/chfl_topology/from_frame.c
+++ b/tests/capi/doc/chfl_topology/from_frame.c
@@ -7,7 +7,7 @@
 int main() {
     // [example]
     CHFL_FRAME* frame = chfl_frame();
-    CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+    const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
 
     if (topology == NULL) {
         /* handle error */

--- a/tests/capi/doc/chfl_topology/residues_linked.c
+++ b/tests/capi/doc/chfl_topology/residues_linked.c
@@ -11,8 +11,8 @@ int main() {
 
     // Build the topology ...
 
-    CHFL_RESIDUE* first = chfl_residue_from_topology(topology, 0);
-    CHFL_RESIDUE* second = chfl_residue_from_topology(topology, 1);
+    const CHFL_RESIDUE* first = chfl_residue_from_topology(topology, 0);
+    const CHFL_RESIDUE* second = chfl_residue_from_topology(topology, 1);
 
     bool linked = false;
     chfl_topology_residues_linked(topology, first, second, &linked);

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -215,21 +215,42 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_set_topology(frame, topology));
         CHECK_STATUS(chfl_topology_free(topology));
 
-        topology = chfl_topology_from_frame(frame);
-        REQUIRE(topology);
+        const CHFL_TOPOLOGY* check_topology = chfl_topology_from_frame(frame);
+        REQUIRE(check_topology);
 
         uint64_t natoms = 0;
-        CHECK_STATUS(chfl_topology_atoms_count(topology, &natoms));
+        CHECK_STATUS(chfl_topology_atoms_count(check_topology, &natoms));
         CHECK(natoms == 4);
 
-        CHFL_ATOM* atom = chfl_atom_from_topology(topology, 1);
-        REQUIRE(atom);
+        CHECK_STATUS(chfl_topology_free(check_topology));
+        CHECK_STATUS(chfl_frame_free(frame));
+    }
 
-        char name[32] = {0};
-        CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
-        CHECK(name == std::string("Ar"));
+    SECTION("Change topology") {
+        CHFL_FRAME* frame = chfl_frame();
+        REQUIRE(frame);
+        CHECK_STATUS(chfl_frame_resize(frame, 4));
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+        REQUIRE(topology);
+
+        uint64_t nbonds = 0;
+        CHECK_STATUS(chfl_topology_bonds_count(topology, &nbonds));
+        CHECK(nbonds == 0);
+
+        CHFL_TOPOLOGY* new_topology = chfl_topology();
+        REQUIRE(new_topology);
+        CHECK_STATUS(chfl_topology_resize(new_topology, 4));
+        CHECK_STATUS(chfl_topology_add_bond(new_topology, 1, 2));
+        CHECK_STATUS(chfl_topology_add_bond(new_topology, 3, 2));
+
+        CHECK_STATUS(chfl_frame_set_topology(frame, new_topology));
+        CHECK_STATUS(chfl_topology_free(new_topology));
+
+        // Topology changed
+        CHECK_STATUS(chfl_topology_bonds_count(topology, &nbonds));
+        CHECK(nbonds == 2);
+
         CHECK_STATUS(chfl_topology_free(topology));
         CHECK_STATUS(chfl_frame_free(frame));
     }
@@ -268,7 +289,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_trajectory_read(trajectory, frame));
 
         CHECK_STATUS(chfl_frame_guess_bonds(frame));
-        CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+        const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 
         uint64_t n = 0;
@@ -360,7 +381,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_add_bond(frame, 0, 2));
         CHECK_STATUS(chfl_frame_add_bond(frame, 0, 3));
 
-        CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+        const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 
         uint64_t n = 0;
@@ -410,7 +431,7 @@ TEST_CASE("chfl_frame") {
             CHECK_STATUS(chfl_residue_free(residue));
         }
 
-        CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+        const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 
         uint64_t count = 0;

--- a/tests/capi/residue.cpp
+++ b/tests/capi/residue.cpp
@@ -85,29 +85,29 @@ TEST_CASE("chfl_residue") {
         CHECK_STATUS(chfl_topology_residues_count(topology, &size));
         CHECK(size == 1);
 
-        residue = chfl_residue_from_topology(topology, 0);
-        REQUIRE(residue);
+        const CHFL_RESIDUE* checking_residue = chfl_residue_from_topology(topology, 0);
+        REQUIRE(checking_residue);
         uint64_t resid = 0;
-        CHECK_STATUS(chfl_residue_id(residue, &resid));
+        CHECK_STATUS(chfl_residue_id(checking_residue, &resid));
         CHECK(resid == 56);
-        CHECK_STATUS(chfl_residue_free(residue));
+        CHECK_STATUS(chfl_residue_free(checking_residue));
 
-        residue = chfl_residue_from_topology(topology, 10);
-        CHECK_FALSE(residue);
+        checking_residue = chfl_residue_from_topology(topology, 10);
+        CHECK_FALSE(checking_residue);
 
-        residue = chfl_residue_for_atom(topology, 2);
-        REQUIRE(residue);
+        checking_residue = chfl_residue_for_atom(topology, 2);
+        REQUIRE(checking_residue);
 
         resid = 0;
-        CHECK_STATUS(chfl_residue_id(residue, &resid));
+        CHECK_STATUS(chfl_residue_id(checking_residue, &resid));
         CHECK(resid == 56);
-        CHECK_STATUS(chfl_residue_free(residue));
+        CHECK_STATUS(chfl_residue_free(checking_residue));
 
-        residue = chfl_residue_for_atom(topology, 10);
-        CHECK_FALSE(residue);
+        checking_residue = chfl_residue_for_atom(topology, 10);
+        CHECK_FALSE(checking_residue);
 
         CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_residue_free(residue));
+        CHECK_STATUS(chfl_residue_free(checking_residue));
     }
 
     SECTION("Property") {

--- a/tests/capi/topology.cpp
+++ b/tests/capi/topology.cpp
@@ -174,12 +174,12 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_residues_count(topology, &count));
         CHECK(count == 3);
 
-        CHFL_RESIDUE* first = chfl_residue_for_atom(topology, 2);
-        CHFL_RESIDUE* second = chfl_residue_for_atom(topology, 0);
+        const CHFL_RESIDUE* first = chfl_residue_for_atom(topology, 2);
+        const CHFL_RESIDUE* second = chfl_residue_for_atom(topology, 0);
         REQUIRE(first);
         REQUIRE(second);
 
-        CHFL_RESIDUE* out_of_bounds = chfl_residue_for_atom(topology, 7);
+        const CHFL_RESIDUE* out_of_bounds = chfl_residue_for_atom(topology, 7);
         CHECK_FALSE(out_of_bounds);
 
         bool linked = true;

--- a/tests/capi/trajectory.cpp
+++ b/tests/capi/trajectory.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Read trajectory") {
 
         CHECK_STATUS(chfl_trajectory_read(trajectory, frame));
 
-        CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+        const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 
         uint64_t natoms = 0;
@@ -115,7 +115,7 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_topology_bonds_count(topology, &n));
         CHECK(n == 0);
 
-        CHFL_ATOM* atom = chfl_atom_from_topology(topology, 0);
+        const CHFL_ATOM* atom = chfl_atom_from_frame(frame, 0);
         REQUIRE(atom);
 
         char name[32];


### PR DESCRIPTION
This allow users of the C API to directly access data inside frames/topologies. This allow to remove a copy on read access, and two copies on write access.

The core of the code is in shared_allocator.hpp, a singleton class allowing to allocate/deallocate pointers with shared pointers semantics. Specifically, the aliasing constructor of `std::shared_ptr<t>`
(`std::shared_ptr<T>(std::shared_ptr<U>&, T*)`) is emulated by storing an atomic reference count for all allocated pointers.

`std::shared_ptr` itself was also considered, but the different solutions had various shortcomings:

- define `CHFL_ATOM` as `std::shared_ptr<Atom>`, and pass around `CHFL_ATOM*`, allocating shared pointers on the heap. This fails to encode const relations between pointers, for example accessing the topology of a frame.
- define `CHFL_ATOM` as `Atom`, and pass around `CHFL_ATOM*`. This works with respect to propagating const, and one can make a `std::shared_ptr<T>` from a `T*` with `std::enable_shared_from_this`. But this requires to allocate all values pointers as shared pointer, even when accessing data inside a frame. So every single atom would need to always be a shared_ptr.

Fix #87 