### PR TITLE
Additional MMTF support

### DIFF
--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -8,6 +8,9 @@
 #include "chemfiles/ErrorFmt.hpp"
 #include "chemfiles/Frame.hpp"
 
+#include "chemfiles/files/GzFile.hpp"
+#include "chemfiles/files/XzFile.hpp"
+
 using namespace chemfiles;
 
 template<> FormatInfo chemfiles::format_information<MMTFFormat>() {
@@ -16,9 +19,34 @@ template<> FormatInfo chemfiles::format_information<MMTFFormat>() {
     );
 }
 
+static std::string extension(const std::string& filename) {
+    auto idx = filename.rfind('.');
+    if (idx != std::string::npos) {
+        return filename.substr(idx);
+    } else {
+        return "";
+    }
+}
+
 MMTFFormat::MMTFFormat(const std::string& path, File::Mode mode) {
+    auto ext = extension(path);
+
     if (mode == File::READ) {
-        mmtf::decodeFromFile(structure_, path);
+        if (ext == ".gz") {
+            gzstreambuf gz_buff;
+            gz_buff.open(path, "rb");
+            std::stringstream buffer;
+            buffer << &gz_buff;
+            mmtf::decodeFromBuffer(structure_, buffer.str().data(), buffer.str().size());
+        } else if (ext == ".xz") {
+            xzstreambuf xz_buff;
+            xz_buff.open(path, "rb");
+            std::stringstream buffer;
+            buffer << &xz_buff;
+            mmtf::decodeFromBuffer(structure_, buffer.str().data(), buffer.str().size());
+        } else { // Just in case the user specified MMTF without a proper extension
+            mmtf::decodeFromFile(structure_, path);
+        }
         if (!structure_.hasConsistentData()) {
             throw format_error("Issue with: {}. Please ensure it is valid MMTF", path);
         }
@@ -79,11 +107,11 @@ void MMTFFormat::read(Frame& frame) {
         // A group is like a residue or other molecule in a PDB file.
         for (size_t k = 0; k < chainGroupCount; k++) {
             auto groupType = static_cast<size_t>(structure_.groupTypeList[groupIndex_]);
-            auto group = structure_.groupList[groupType];
+            const auto& group = structure_.groupList[groupType];
 
             auto groupId = static_cast<size_t>(structure_.groupIdList[groupIndex_]);
             auto residue = Residue(group.groupName, groupId);
-            // TODO: Use group.chemCompType to assign linkage
+            residue.set("composition_type", group.chemCompType);
 
             // Save the offset before we go changing it
             size_t atomOffset = atomIndex_ - atomSkip_;
@@ -97,6 +125,7 @@ void MMTFFormat::read(Frame& frame) {
                     structure_.yCoordList[atomIndex_],
                     structure_.zCoordList[atomIndex_]
                 );
+                atom.set("is_hetatm", mmtf::is_hetatm(group.chemCompType.c_str()));
                 frame.add_atom(atom, position);
                 residue.add_atom(atomIndex_ - atomSkip_);
                 atomIndex_++;
@@ -164,8 +193,10 @@ void MMTFFormat::read(Frame& frame) {
             continue;
         }
 
-        // TODO: Use Chemical linkage to store the type of bond here
-        frame.add_bond(atom1 - atomSkip_, atom2 - atomSkip_);
+        size_t atom_idx1 = atom1 - atomSkip_;
+        size_t atom_idx2 = atom2 - atomSkip_;
+
+        frame.add_bond(atom_idx1, atom_idx2);
     }
 
     atomSkip_ = atomIndex_;

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -120,6 +120,7 @@ void MMTFFormat::read(Frame& frame) {
             for (size_t l = 0; l < groupSize; l++) {
                 auto atom = Atom(group.atomNameList[l]);
                 atom.set_type(group.elementList[l]);
+                atom.set_charge(group.formalChargeList[l]);
                 auto position = Vector3D(
                     structure_.xCoordList[atomIndex_],
                     structure_.yCoordList[atomIndex_],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "39f397156e1a769004b25e728c71472cb2260441")
+set(TESTS_DATA_GIT "97baf3479de931b889a750b4eb18ca596799bd79")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=0f0c5d7dd19d5353810958397d530df54443902f
+        EXPECTED_HASH SHA1=a1e990158f35b981133af9a5b391f2d0ab8bee87
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -130,4 +130,29 @@ TEST_CASE("Read files in MMTF format") {
         auto frame3= file.read();
     }
 
+    SECTION("GZ Files") {
+        Trajectory file("data/mmtf/1J8K.mmtf.gz");
+
+        auto frame = file.read_step(13);
+        CHECK(frame.size() == 1402);
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(-5.106, 16.212, 4.562), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(5.601, -22.571, -16.631), 1e-3));
+        const auto& topo = frame.topology();
+        CHECK(topo.are_linked(topo.residue(0), topo.residue(1)));
+        CHECK(!topo.are_linked(topo.residue(0), topo.residue(2)));
+    }
+
+    SECTION("XZ Files") {
+        Trajectory file("data/mmtf/1J8K.mmtf.xz");
+
+        auto frame = file.read_step(13);
+        CHECK(frame.size() == 1402);
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(-5.106, 16.212, 4.562), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(5.601, -22.571, -16.631), 1e-3));
+        const auto& topo = frame.topology();
+        CHECK(topo.are_linked(topo.residue(0), topo.residue(1)));
+        CHECK(!topo.are_linked(topo.residue(0), topo.residue(2)));
+    }
 }

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -40,6 +40,8 @@ TEST_CASE("Read files in MMTF format") {
         auto residue = *frame.topology().residue_for_atom(4557);
         CHECK(residue.size() == 43);
         CHECK(residue.name() == "HEM");
+        CHECK(residue.get("composition_type")->as_string() == "NON-POLYMER");
+        CHECK(frame[4557].get("is_hetatm")->as_bool()); // Should be a hetatm
 
         // Nitrogen-Iron Bond
         CHECK(frame.topology().bond_order(4557, 4556) == Bond::SINGLE);
@@ -96,6 +98,7 @@ TEST_CASE("Read files in MMTF format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(-5.106, 16.212, 4.562), 1e-3));
         CHECK(approx_eq(positions[1401], Vector3D(5.601, -22.571, -16.631), 1e-3));
+        CHECK(!frame[0].get("is_hetatm")->as_bool());
 
         const auto& topo = frame.topology();
         CHECK(topo.are_linked(topo.residue(0), topo.residue(1)));
@@ -110,6 +113,7 @@ TEST_CASE("Read files in MMTF format") {
         const auto& topo2 = frame.topology();
         CHECK(topo2.are_linked(topo.residue(0), topo2.residue(1)));
         CHECK(!topo2.are_linked(topo.residue(0), topo2.residue(2)));
+        CHECK(topo.residue(0).get("composition_type")->as_string() == "L-PEPTIDE LINKING");
     }
 
     SECTION("Successive steps") {


### PR DESCRIPTION
I've added a few new features to the MMTF format. They are:

- Ability to read from GZ and XZ files.
- Now we save the formal charge of atoms in a given residue.
- Biologic assemblies identified in the MMTF file are saved as residue properties.