### PR TITLE
Request compression in format argument

### DIFF
--- a/include/chemfiles/File.hpp
+++ b/include/chemfiles/File.hpp
@@ -28,20 +28,21 @@ public:
 
     virtual ~File() noexcept = default;
     File(File&&) = default;
-    File& operator=(File&&) = delete;
+    File& operator=(File&&) = default;
     File(File const&) = delete;
     File& operator=(File const&) = delete;
 
-    /// File name, i.e. complete path to this file on disk.
-    const std::string& filename() const { return filename_; }
-    /// File opening mode.
+    /// Get the file path used to open this file.
+    const std::string& path() const { return path_; }
+
+    /// Get the mode used to open this file.
     Mode mode() const { return mode_; }
 
 protected:
-    File(std::string path, Mode mode): filename_(std::move(path)), mode_(mode) {}
+    File(std::string path, Mode mode): path_(std::move(path)), mode_(mode) {}
 
 private:
-    const std::string filename_;
+    std::string path_;
     Mode mode_;
 };
 
@@ -54,7 +55,7 @@ private:
 class CHFL_EXPORT TextFile: public File, public std::iostream {
 public:
     /// Open the most adaptated text file class for the given `path` and `mode`
-    static std::unique_ptr<TextFile> create(const std::string& path, File::Mode mode);
+    static std::unique_ptr<TextFile> open(std::string path, File::Mode mode);
 
     /// Read a line from the file
     std::string readline();
@@ -68,7 +69,7 @@ public:
 protected:
     /// Initialize the TextFile at the given `path` and `mode`. All read and
     /// write operations will go through the provided `buffer`.
-    TextFile(const std::string& path, File::Mode mode, std::streambuf* buffer);
+    TextFile(std::string path, File::Mode mode, std::streambuf* buffer);
 
 private:
     void get_line(std::string& string);

--- a/include/chemfiles/File.hpp
+++ b/include/chemfiles/File.hpp
@@ -26,6 +26,16 @@ public:
         APPEND = 'a',
     };
 
+    /// Possible compression methods for opening a file
+    enum Compression {
+        /// Default method: plain text or binary formats
+        DEFAULT,
+        /// gzip compression
+        GZIP,
+        /// lzma compression (.xz)
+        LZMA,
+    };
+
     virtual ~File() noexcept = default;
     File(File&&) = default;
     File& operator=(File&&) = default;
@@ -38,12 +48,17 @@ public:
     /// Get the mode used to open this file.
     Mode mode() const { return mode_; }
 
+    /// Get the compression used to open this file.
+    Compression compression() const { return compression_; }
+
 protected:
-    File(std::string path, Mode mode): path_(std::move(path)), mode_(mode) {}
+    File(std::string path, Mode mode, Compression compression):
+        path_(std::move(path)), mode_(mode), compression_(compression) {}
 
 private:
     std::string path_;
     Mode mode_;
+    Compression compression_;
 };
 
 /// Abstract base class representing a text file. This class is inteded to be
@@ -54,8 +69,9 @@ private:
 /// the user of the class to the current state.
 class CHFL_EXPORT TextFile: public File, public std::iostream {
 public:
-    /// Open the most adaptated text file class for the given `path` and `mode`
-    static std::unique_ptr<TextFile> open(std::string path, File::Mode mode);
+    /// Open the file at the given `path` with the requested `mode` and
+    /// `compression` method using the most adapted child class of `TextFile`.
+    static std::unique_ptr<TextFile> open(std::string path, File::Mode mode, File::Compression compression);
 
     /// Read a line from the file
     std::string readline();
@@ -67,9 +83,10 @@ public:
     bool eof();
 
 protected:
-    /// Initialize the TextFile at the given `path` and `mode`. All read and
-    /// write operations will go through the provided `buffer`.
-    TextFile(std::string path, File::Mode mode, std::streambuf* buffer);
+    /// Initialize the TextFile at the given `path` and `mode`, with the
+    /// specified 'compression' method. All read and write operations will go
+    /// through the provided `buffer`.
+    TextFile(std::string path, File::Mode mode, File::Compression compression, std::streambuf* buffer);
 
 private:
     void get_line(std::string& string);

--- a/include/chemfiles/FormatFactory.hpp
+++ b/include/chemfiles/FormatFactory.hpp
@@ -16,7 +16,7 @@
 
 namespace chemfiles {
 
-using format_creator_t = std::function<std::unique_ptr<Format>(std::string path, File::Mode mode)>;
+using format_creator_t = std::function<std::unique_ptr<Format>(std::string path, File::Mode mode, File::Compression compression)>;
 
 /// This class allow to register Format with names and file extensions
 class CHFL_EXPORT FormatFactory final {
@@ -46,8 +46,8 @@ public:
     template<class Format>
     void add_format() {
         auto info = format_information<Format>();
-        register_format(info, [](const std::string& path, File::Mode mode) {
-            return std::unique_ptr<Format>(new Format(path, mode));  // NOLINT no make_unique in C++11
+        register_format(info, [](const std::string& path, File::Mode mode, File::Compression compression) {
+            return std::unique_ptr<Format>(new Format(path, mode, compression));  // NOLINT no make_unique in C++11
         });
     }
 

--- a/include/chemfiles/FormatFactory.hpp
+++ b/include/chemfiles/FormatFactory.hpp
@@ -16,7 +16,7 @@
 
 namespace chemfiles {
 
-using format_creator_t = std::function<std::unique_ptr<Format>(const std::string& path, File::Mode mode)>;
+using format_creator_t = std::function<std::unique_ptr<Format>(std::string path, File::Mode mode)>;
 
 /// This class allow to register Format with names and file extensions
 class CHFL_EXPORT FormatFactory final {

--- a/include/chemfiles/Trajectory.hpp
+++ b/include/chemfiles/Trajectory.hpp
@@ -21,14 +21,23 @@ class CHFL_EXPORT Trajectory final {
 public:
     /// Open a file, automatically gessing the file format from the extension.
     ///
-    /// The format can either be guessed from the extention (".xyz" is XYZ,
-    /// ".gro" is GROMACS, *etc.*), or specified as the third parameter. The
-    /// format names are given in the corresponding [documentation
-    /// section][formats]
+    /// The `format` parameter should be a string formatted as `"<format>"`,
+    /// `"<format>/<compression>"` or `"/<compression>"`. `<format>` should be
+    /// the format name (see the corresponding [documentation section][formats]
+    /// for the names) or an empty string. `<compression>` should be `GZ` for
+    /// gzip files, or `XZ` for lzma/.xz files. If `<compression>` is present,
+    /// it will determine which compression method is used to read/write the
+    /// file. For example, `format = "XYZ"` will force usage of XYZ format
+    /// regardless of the file extension; `format = "XYZ / GZ"` will
+    /// additionally use gzip compression; and `format = "/ GZ"` will use the
+    /// gzip compression, and the file extension to guess the format. 
     ///
-    /// If the file path ends with either `.gz` or `.xz` and no `format` is
-    /// given; the file will be treated as a compressed file and the next
-    /// extension is used to guess the format.
+    /// If the `<format>` is an empty string, the file extension will be used
+    /// to guess the format. If `<compression>` is NOT presentand the file path
+    /// ends with either `.gz` or `.xz` the file will be treated as a
+    /// compressed file and the next extension is used to guess the format. For
+    /// example `Trajectory("file.xyz.gz")` will open the file for reading
+    /// using the XYZ format and the gzip compression method.
     ///
     /// @example{tests/doc/trajectory/trajectory.cpp}
     ///

--- a/include/chemfiles/files/GzFile.hpp
+++ b/include/chemfiles/files/GzFile.hpp
@@ -20,7 +20,7 @@ public:
     ~gzstreambuf() override;
 
     /// Open the file at `path` with the given `mode`. The mode will be passed
-    /// down to gzopen. 
+    /// down to gzopen.
     void open(const std::string& path, const std::string& mode);
 
     int_type underflow() override;
@@ -44,8 +44,8 @@ private:
 /// A gziped text file
 class GzFile final: public TextFile {
 public:
-    /// Open the file with the given `filename` using the specified `mode`
-    GzFile(const std::string& filename, File::Mode mode);
+    /// Open the file at the given `path` using the specified `mode`
+    GzFile(std::string path, File::Mode mode);
 
 private:
     gzstreambuf buffer_;

--- a/include/chemfiles/files/NcFile.hpp
+++ b/include/chemfiles/files/NcFile.hpp
@@ -92,7 +92,7 @@ namespace nc {
 /// The template functions are manually specialized for float and char data types.
 class NcFile final: public File {
 public:
-    NcFile(const std::string& filename, File::Mode mode);
+    NcFile(std::string path, File::Mode mode);
     ~NcFile() noexcept override;
     NcFile(NcFile&&) = default;
     NcFile& operator=(NcFile&&) = delete;

--- a/include/chemfiles/files/PlainFile.hpp
+++ b/include/chemfiles/files/PlainFile.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 class PlainFile final: public TextFile {
 public:
     /// Open a text file with name `filename` and mode `mode`.
-    PlainFile(const std::string& filename, File::Mode mode);
+    PlainFile(std::string path, File::Mode mode);
 
 private:
     std::filebuf buffer_;

--- a/include/chemfiles/files/TNGFile.hpp
+++ b/include/chemfiles/files/TNGFile.hpp
@@ -13,7 +13,7 @@ namespace chemfiles {
 /// destruction of the file as needed.
 class TNGFile final: public File {
 public:
-    TNGFile(std::string filename, File::Mode mode);
+    TNGFile(std::string path, File::Mode mode);
     ~TNGFile() noexcept override;
     TNGFile(TNGFile&&) = default;
     TNGFile& operator=(TNGFile&&) = delete;

--- a/include/chemfiles/files/XzFile.hpp
+++ b/include/chemfiles/files/XzFile.hpp
@@ -67,8 +67,8 @@ private:
 /// A xz-compressed text file
 class XzFile final: public TextFile {
 public:
-    /// Open the file with the given `filename` using the specified `mode`
-    XzFile(const std::string& filename, File::Mode mode);
+    /// Open the file at the given `path` using the specified `mode`
+    XzFile(std::string path, File::Mode mode);
 
 private:
     xzstreambuf buffer_;

--- a/include/chemfiles/formats/AmberNetCDF.hpp
+++ b/include/chemfiles/formats/AmberNetCDF.hpp
@@ -19,7 +19,7 @@ class Topology;
 /// [NetCDF]: http://ambermd.org/netcdf/nctraj.xhtml
 class AmberNetCDFFormat final: public Format {
 public:
-    AmberNetCDFFormat(std::string path, File::Mode mode);
+    AmberNetCDFFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/AmberNetCDF.hpp
+++ b/include/chemfiles/formats/AmberNetCDF.hpp
@@ -19,7 +19,7 @@ class Topology;
 /// [NetCDF]: http://ambermd.org/netcdf/nctraj.xhtml
 class AmberNetCDFFormat final: public Format {
 public:
-    AmberNetCDFFormat(const std::string& path, File::Mode mode);
+    AmberNetCDFFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/CSSR.hpp
+++ b/include/chemfiles/formats/CSSR.hpp
@@ -15,7 +15,7 @@ namespace chemfiles {
 /// [CSSR]: http://www.chem.cmu.edu/courses/09-560/docs/msi/modenv/D_Files.html#944777
 class CSSRFormat final: public Format {
 public:
-    CSSRFormat(const std::string& path, File::Mode mode);
+    CSSRFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/CSSR.hpp
+++ b/include/chemfiles/formats/CSSR.hpp
@@ -15,7 +15,7 @@ namespace chemfiles {
 /// [CSSR]: http://www.chem.cmu.edu/courses/09-560/docs/msi/modenv/D_Files.html#944777
 class CSSRFormat final: public Format {
 public:
-    CSSRFormat(std::string path, File::Mode mode);
+    CSSRFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/GRO.hpp
+++ b/include/chemfiles/formats/GRO.hpp
@@ -17,7 +17,7 @@ namespace chemfiles {
 /// [GRO]: http://manual.gromacs.org/current/online/gro.html
 class GROFormat final: public Format {
 public:
-    GROFormat(const std::string& path, File::Mode mode);
+    GROFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/GRO.hpp
+++ b/include/chemfiles/formats/GRO.hpp
@@ -17,7 +17,7 @@ namespace chemfiles {
 /// [GRO]: http://manual.gromacs.org/current/online/gro.html
 class GROFormat final: public Format {
 public:
-    GROFormat(std::string path, File::Mode mode);
+    GROFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -127,7 +127,7 @@ private:
 /// [LAMMPS Data]: http://lammps.sandia.gov/doc/read_data.html
 class LAMMPSDataFormat final: public Format {
 public:
-    LAMMPSDataFormat(const std::string& path, File::Mode mode);
+    LAMMPSDataFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -127,7 +127,7 @@ private:
 /// [LAMMPS Data]: http://lammps.sandia.gov/doc/read_data.html
 class LAMMPSDataFormat final: public Format {
 public:
-    LAMMPSDataFormat(std::string path, File::Mode mode);
+    LAMMPSDataFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/MMTF.hpp
+++ b/include/chemfiles/formats/MMTF.hpp
@@ -19,7 +19,7 @@ namespace chemfiles {
 /// [MMTF]: https://mmtf.rcsb.org/
 class MMTFFormat final: public Format {
 public:
-    MMTFFormat(std::string path, File::Mode mode);
+    MMTFFormat(std::string path, File::Mode mode, File::Compression compression);
 
     ~MMTFFormat() = default;
     MMTFFormat(const MMTFFormat&) = delete;

--- a/include/chemfiles/formats/MMTF.hpp
+++ b/include/chemfiles/formats/MMTF.hpp
@@ -19,7 +19,7 @@ namespace chemfiles {
 /// [MMTF]: https://mmtf.rcsb.org/
 class MMTFFormat final: public Format {
 public:
-    MMTFFormat(const std::string& path, File::Mode mode);
+    MMTFFormat(std::string path, File::Mode mode);
 
     ~MMTFFormat() = default;
     MMTFFormat(const MMTFFormat&) = delete;

--- a/include/chemfiles/formats/MOL2.hpp
+++ b/include/chemfiles/formats/MOL2.hpp
@@ -20,7 +20,7 @@ namespace chemfiles {
 /// [MOL2]:
 class MOL2Format final: public Format {
 public:
-    MOL2Format(std::string path, File::Mode mode);
+    MOL2Format(std::string path, File::Mode mode, File::Compression compression);
 
     MOL2Format(const MOL2Format&) = delete;
     MOL2Format& operator=(const MOL2Format&) = delete;

--- a/include/chemfiles/formats/MOL2.hpp
+++ b/include/chemfiles/formats/MOL2.hpp
@@ -17,10 +17,10 @@ namespace chemfiles {
 /// For multi-frame trajectories, we follow the convention of VMD to use multiple
 /// `END` records, separating the steps.
 ///
-/// [MOL2]: 
+/// [MOL2]:
 class MOL2Format final: public Format {
 public:
-    MOL2Format(const std::string& path, File::Mode mode);
+    MOL2Format(std::string path, File::Mode mode);
 
     MOL2Format(const MOL2Format&) = delete;
     MOL2Format& operator=(const MOL2Format&) = delete;

--- a/include/chemfiles/formats/Molfile.hpp
+++ b/include/chemfiles/formats/Molfile.hpp
@@ -55,7 +55,7 @@ struct MolfilePluginData final {
 template <MolfileFormat F>
 class Molfile final: public Format {
 public:
-    Molfile(const std::string& path, File::Mode mode);
+    Molfile(std::string path, File::Mode mode);
     ~Molfile() noexcept override;
     Molfile(const Molfile&) = delete;
     Molfile& operator=(const Molfile&) = delete;

--- a/include/chemfiles/formats/Molfile.hpp
+++ b/include/chemfiles/formats/Molfile.hpp
@@ -55,7 +55,7 @@ struct MolfilePluginData final {
 template <MolfileFormat F>
 class Molfile final: public Format {
 public:
-    Molfile(std::string path, File::Mode mode);
+    Molfile(std::string path, File::Mode mode, File::Compression compression);
     ~Molfile() noexcept override;
     Molfile(const Molfile&) = delete;
     Molfile& operator=(const Molfile&) = delete;

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -20,7 +20,7 @@ namespace chemfiles {
 /// [PDB]: ftp://ftp.wwpdb.org/pub/pdb/doc/format_descriptions/Format_v33_A4.pdf
 class PDBFormat final: public Format {
 public:
-    PDBFormat(std::string path, File::Mode mode);
+    PDBFormat(std::string path, File::Mode mode, File::Compression compression);
 
     ~PDBFormat() noexcept override;
     PDBFormat(const PDBFormat&) = delete;

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -20,7 +20,7 @@ namespace chemfiles {
 /// [PDB]: ftp://ftp.wwpdb.org/pub/pdb/doc/format_descriptions/Format_v33_A4.pdf
 class PDBFormat final: public Format {
 public:
-    PDBFormat(const std::string& path, File::Mode mode);
+    PDBFormat(std::string path, File::Mode mode);
 
     ~PDBFormat() noexcept override;
     PDBFormat(const PDBFormat&) = delete;

--- a/include/chemfiles/formats/SDF.hpp
+++ b/include/chemfiles/formats/SDF.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [SDF]: http://accelrys.com/products/collaborative-science/biovia-draw/ctfile-no-fee.html
 class SDFFormat final: public Format {
 public:
-    SDFFormat(std::string path, File::Mode mode);
+    SDFFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/SDF.hpp
+++ b/include/chemfiles/formats/SDF.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [SDF]: http://accelrys.com/products/collaborative-science/biovia-draw/ctfile-no-fee.html
 class SDFFormat final: public Format {
 public:
-    SDFFormat(const std::string& path, File::Mode mode);
+    SDFFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/TNG.hpp
+++ b/include/chemfiles/formats/TNG.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [TNG]: http://dx.doi.org/10.1007/s00894-010-0948-5
 class TNGFormat final: public Format {
 public:
-    TNGFormat(const std::string& path, File::Mode mode);
+    TNGFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/TNG.hpp
+++ b/include/chemfiles/formats/TNG.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [TNG]: http://dx.doi.org/10.1007/s00894-010-0948-5
 class TNGFormat final: public Format {
 public:
-    TNGFormat(std::string path, File::Mode mode);
+    TNGFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/Tinker.hpp
+++ b/include/chemfiles/formats/Tinker.hpp
@@ -19,7 +19,7 @@ namespace chemfiles {
 /// extension, which is used for the standard XYZ format.
 class TinkerFormat final: public Format {
 public:
-    TinkerFormat(std::string path, File::Mode mode);
+    TinkerFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/Tinker.hpp
+++ b/include/chemfiles/formats/Tinker.hpp
@@ -19,7 +19,7 @@ namespace chemfiles {
 /// extension, which is used for the standard XYZ format.
 class TinkerFormat final: public Format {
 public:
-    TinkerFormat(const std::string& path, File::Mode mode);
+    TinkerFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/XYZ.hpp
+++ b/include/chemfiles/formats/XYZ.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [XYZ]: http://openbabel.org/wiki/XYZ
 class XYZFormat final: public Format {
 public:
-    XYZFormat(const std::string& path, File::Mode mode);
+    XYZFormat(std::string path, File::Mode mode);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/include/chemfiles/formats/XYZ.hpp
+++ b/include/chemfiles/formats/XYZ.hpp
@@ -14,7 +14,7 @@ namespace chemfiles {
 /// [XYZ]: http://openbabel.org/wiki/XYZ
 class XYZFormat final: public Format {
 public:
-    XYZFormat(std::string path, File::Mode mode);
+    XYZFormat(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;

--- a/src/files/GzFile.cpp
+++ b/src/files/GzFile.cpp
@@ -110,7 +110,7 @@ std::streampos gzstreambuf::seekoff(std::streamoff offset, std::ios_base::seekdi
 
 
 GzFile::GzFile(std::string path, File::Mode mode)
-    : TextFile(std::move(path), mode, &buffer_), buffer_() {
+    : TextFile(std::move(path), mode, File::GZIP, &buffer_), buffer_() {
 
     std::string openmode = "";
     switch (mode) {

--- a/src/files/GzFile.cpp
+++ b/src/files/GzFile.cpp
@@ -109,8 +109,8 @@ std::streampos gzstreambuf::seekoff(std::streamoff offset, std::ios_base::seekdi
 }
 
 
-GzFile::GzFile(const std::string& filename, File::Mode mode)
-    : TextFile(filename, mode, &buffer_), buffer_() {
+GzFile::GzFile(std::string path, File::Mode mode)
+    : TextFile(std::move(path), mode, &buffer_), buffer_() {
 
     std::string openmode = "";
     switch (mode) {
@@ -124,8 +124,8 @@ GzFile::GzFile(const std::string& filename, File::Mode mode)
         throw file_error("appending (open mode 'a') is not supported with gziped files");
     }
 
-    buffer_.open(filename, openmode);
+    buffer_.open(this->path(), openmode);
     if (!buffer_.is_open()) {
-        throw file_error("could not open the file at {}", filename);
+        throw file_error("could not open the file at {}", this->path());
     }
 }

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -95,26 +95,26 @@ void nc::NcChar::add(const std::vector<std::string>& data) {
     }
 }
 
-NcFile::NcFile(const std::string& filename, File::Mode mode)
-    : File(filename, mode), nc_mode_(DATA) {
+NcFile::NcFile(std::string path, File::Mode mode)
+    : File(std::move(path), mode), nc_mode_(DATA) {
     auto status = NC_NOERR;
 
     switch (mode) {
     case File::READ:
-        status = nc_open(filename.c_str(), NC_NOWRITE, &file_id_);
+        status = nc_open(this->path().c_str(), NC_NOWRITE, &file_id_);
         break;
     case File::APPEND:
-        status = nc_open(filename.c_str(), NC_WRITE, &file_id_);
+        status = nc_open(this->path().c_str(), NC_WRITE, &file_id_);
         break;
     case File::WRITE:
-        status = nc_create(filename.c_str(), NC_64BIT_OFFSET | NC_CLASSIC_MODEL, &file_id_);
+        status = nc_create(this->path().c_str(), NC_64BIT_OFFSET | NC_CLASSIC_MODEL, &file_id_);
         // Put the file in DATA mode. This can only fail for bad id, which we
         // check later.
         nc_enddef(file_id_);
         break;
     }
 
-    nc::check(status, "could not open the file '{}'", filename);
+    nc::check(status, "could not open the file '{}'", this->path());
 }
 
 NcFile::~NcFile() noexcept {

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -96,7 +96,7 @@ void nc::NcChar::add(const std::vector<std::string>& data) {
 }
 
 NcFile::NcFile(std::string path, File::Mode mode)
-    : File(std::move(path), mode), nc_mode_(DATA) {
+    : File(std::move(path), mode, File::DEFAULT), nc_mode_(DATA) {
     auto status = NC_NOERR;
 
     switch (mode) {

--- a/src/files/PlainFile.cpp
+++ b/src/files/PlainFile.cpp
@@ -8,7 +8,7 @@
 using namespace chemfiles;
 
 PlainFile::PlainFile(std::string path, File::Mode mode)
-    : TextFile(std::move(path), mode, &buffer_), buffer_() {
+    : TextFile(std::move(path), mode, File::DEFAULT, &buffer_), buffer_() {
     // We need to use binary mode when opening the file because we are storing
     // positions in the files relative to line ending positions. Using text
     // mode make the MSVC runtime convert lines ending and then all the values

--- a/src/files/PlainFile.cpp
+++ b/src/files/PlainFile.cpp
@@ -7,8 +7,8 @@
 #include "chemfiles/ErrorFmt.hpp"
 using namespace chemfiles;
 
-PlainFile::PlainFile(const std::string& filename, File::Mode mode)
-    : TextFile(filename, mode, &buffer_), buffer_() {
+PlainFile::PlainFile(std::string path, File::Mode mode)
+    : TextFile(std::move(path), mode, &buffer_), buffer_() {
     // We need to use binary mode when opening the file because we are storing
     // positions in the files relative to line ending positions. Using text
     // mode make the MSVC runtime convert lines ending and then all the values
@@ -30,8 +30,8 @@ PlainFile::PlainFile(const std::string& filename, File::Mode mode)
         break;
     }
 
-    buffer_.open(filename, openmode);
+    buffer_.open(this->path(), openmode);
     if (!buffer_.is_open()) {
-        throw file_error("could not open the file at {}", filename);
+        throw file_error("could not open the file at {}", this->path());
     }
 }

--- a/src/files/TNGFile.cpp
+++ b/src/files/TNGFile.cpp
@@ -11,7 +11,7 @@ using namespace chemfiles;
 #define STRING(x) STRING_0(x)
 #define CHECK(x) check_tng_error((x), (STRING(x)))
 
-TNGFile::TNGFile(std::string path, File::Mode mode): File(std::move(path), mode), handle_(nullptr) {
+TNGFile::TNGFile(std::string path, File::Mode mode): File(std::move(path), mode, File::DEFAULT), handle_(nullptr) {
     CHECK(tng_util_trajectory_open(this->path().c_str(), mode, &handle_));
 
     if (mode == File::READ) {

--- a/src/files/TNGFile.cpp
+++ b/src/files/TNGFile.cpp
@@ -11,8 +11,8 @@ using namespace chemfiles;
 #define STRING(x) STRING_0(x)
 #define CHECK(x) check_tng_error((x), (STRING(x)))
 
-TNGFile::TNGFile(std::string filename, File::Mode mode): File(std::move(filename), mode), handle_(nullptr) {
-    CHECK(tng_util_trajectory_open(this->filename().c_str(), mode, &handle_));
+TNGFile::TNGFile(std::string path, File::Mode mode): File(std::move(path), mode), handle_(nullptr) {
+    CHECK(tng_util_trajectory_open(this->path().c_str(), mode, &handle_));
 
     if (mode == File::READ) {
         CHECK(tng_file_headers_read(handle_, TNG_USE_HASH));

--- a/src/files/XzFile.cpp
+++ b/src/files/XzFile.cpp
@@ -376,16 +376,16 @@ bool xzstreambuf::is_open() const {
     return file_ != nullptr && !::ferror(file_);
 }
 
-XzFile::XzFile(const std::string& filename, File::Mode mode): TextFile(filename, mode, &buffer_), buffer_() {
+XzFile::XzFile(std::string path, File::Mode mode): TextFile(std::move(path), mode, &buffer_), buffer_() {
     if (mode == File::READ) {
-        buffer_.open(filename, "rb");
+        buffer_.open(this->path(), "rb");
     } else if (mode == File::WRITE) {
-        buffer_.open(filename, "wb");
+        buffer_.open(this->path(), "wb");
     } else if (mode == File::APPEND) {
         throw file_error("appending (open mode 'a') is not supported with xz files");
     }
 
     if (!buffer_.is_open()) {
-        throw file_error("could not open the file at {}", filename);
+        throw file_error("could not open the file at {}", this->path());
     }
 }

--- a/src/files/XzFile.cpp
+++ b/src/files/XzFile.cpp
@@ -376,7 +376,7 @@ bool xzstreambuf::is_open() const {
     return file_ != nullptr && !::ferror(file_);
 }
 
-XzFile::XzFile(std::string path, File::Mode mode): TextFile(std::move(path), mode, &buffer_), buffer_() {
+XzFile::XzFile(std::string path, File::Mode mode): TextFile(std::move(path), mode, File::LZMA, &buffer_), buffer_() {
     if (mode == File::READ) {
         buffer_.open(this->path(), "rb");
     } else if (mode == File::WRITE) {

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -51,13 +51,16 @@ static bool is_valid(const NcFile& file_, size_t natoms) {
     return true;
 }
 
-AmberNetCDFFormat::AmberNetCDFFormat(std::string path, File::Mode mode)
+AmberNetCDFFormat::AmberNetCDFFormat(std::string path, File::Mode mode, File::Compression compression)
     : file_(std::move(path), mode), step_(0), validated_(false) {
     if (file_.mode() == File::READ || file_.mode() == File::APPEND) {
         if (!is_valid(file_, static_cast<size_t>(-1))) {
             throw format_error("invalid AMBER NetCDF file at '{}'", file_.path());
         }
         validated_ = true;
+    }
+    if (compression != File::DEFAULT) {
+        throw format_error("compression is not supported with NetCDF format");
     }
 }
 

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -51,11 +51,11 @@ static bool is_valid(const NcFile& file_, size_t natoms) {
     return true;
 }
 
-AmberNetCDFFormat::AmberNetCDFFormat(const std::string& path, File::Mode mode)
-    : file_(path, mode), step_(0), validated_(false) {
+AmberNetCDFFormat::AmberNetCDFFormat(std::string path, File::Mode mode)
+    : file_(std::move(path), mode), step_(0), validated_(false) {
     if (file_.mode() == File::READ || file_.mode() == File::APPEND) {
         if (!is_valid(file_, static_cast<size_t>(-1))) {
-            throw format_error("invalid AMBER NetCDF file at '{}'", file_.filename());
+            throw format_error("invalid AMBER NetCDF file at '{}'", file_.path());
         }
         validated_ = true;
     }

--- a/src/formats/CSSR.cpp
+++ b/src/formats/CSSR.cpp
@@ -27,8 +27,8 @@ template<> FormatInfo chemfiles::format_information<CSSRFormat>() {
 }
 
 
-CSSRFormat::CSSRFormat(std::string path, File::Mode mode)
-    : file_(TextFile::open(std::move(path), mode))
+CSSRFormat::CSSRFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(TextFile::open(std::move(path), mode, compression))
 {
     if (mode == File::APPEND) {
         throw format_error("append mode ('a') is not supported with CSSR format");

--- a/src/formats/CSSR.cpp
+++ b/src/formats/CSSR.cpp
@@ -27,8 +27,8 @@ template<> FormatInfo chemfiles::format_information<CSSRFormat>() {
 }
 
 
-CSSRFormat::CSSRFormat(const std::string& path, File::Mode mode)
-    : file_(TextFile::create(path, mode))
+CSSRFormat::CSSRFormat(std::string path, File::Mode mode)
+    : file_(TextFile::open(std::move(path), mode))
 {
     if (mode == File::APPEND) {
         throw format_error("append mode ('a') is not supported with CSSR format");

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -28,8 +28,8 @@ static void check_values_size(const Vector3D& values, unsigned width, const std:
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-GROFormat::GROFormat(const std::string& path, File::Mode mode)
-    : file_(TextFile::create(path, mode))
+GROFormat::GROFormat(std::string path, File::Mode mode)
+    : file_(TextFile::open(std::move(path), mode))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();
@@ -311,7 +311,7 @@ bool forward(TextFile& file) {
 
     if (natoms < 0) {
         throw format_error(
-            "number of atoms can not be negative in '{}'", file.filename()
+            "number of atoms can not be negative in '{}'", file.path()
         );
     }
 
@@ -320,7 +320,7 @@ bool forward(TextFile& file) {
     } catch (const FileError&) {
         // We could not read the lines from the file
         throw format_error(
-            "not enough lines in '{}' for GRO format", file.filename()
+            "not enough lines in '{}' for GRO format", file.path()
         );
     }
     return true;

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -28,8 +28,8 @@ static void check_values_size(const Vector3D& values, unsigned width, const std:
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-GROFormat::GROFormat(std::string path, File::Mode mode)
-    : file_(TextFile::open(std::move(path), mode))
+GROFormat::GROFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(TextFile::open(std::move(path), mode, compression))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -249,8 +249,8 @@ static bool is_unused_header(const std::string& line);
 /// in a size_t
 static size_t checked_cast(long long int value);
 
-LAMMPSDataFormat::LAMMPSDataFormat(const std::string& path, File::Mode mode):
-    current_section_(HEADER), file_(TextFile::create(path, mode)), style_("full") {}
+LAMMPSDataFormat::LAMMPSDataFormat(std::string path, File::Mode mode):
+    current_section_(HEADER), file_(TextFile::open(std::move(path), mode)), style_("full") {}
 
 size_t LAMMPSDataFormat::nsteps() {
     return 1;

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -249,8 +249,8 @@ static bool is_unused_header(const std::string& line);
 /// in a size_t
 static size_t checked_cast(long long int value);
 
-LAMMPSDataFormat::LAMMPSDataFormat(std::string path, File::Mode mode):
-    current_section_(HEADER), file_(TextFile::open(std::move(path), mode)), style_("full") {}
+LAMMPSDataFormat::LAMMPSDataFormat(std::string path, File::Mode mode, File::Compression compression):
+    current_section_(HEADER), file_(TextFile::open(std::move(path), mode, compression)), style_("full") {}
 
 size_t LAMMPSDataFormat::nsteps() {
     return 1;

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -28,7 +28,7 @@ static std::string extension(const std::string& filename) {
     }
 }
 
-MMTFFormat::MMTFFormat(const std::string& path, File::Mode mode) {
+MMTFFormat::MMTFFormat(std::string path, File::Mode mode) {
     auto ext = extension(path);
 
     if (mode == File::READ) {
@@ -104,14 +104,14 @@ void MMTFFormat::read(Frame& frame) {
     for (size_t j = 0; j < modelChainCount; j++) {
         auto chainGroupCount = static_cast<size_t>(structure_.groupsPerChain[chainIndex_]);
 
-        // Unfortunetly we must loop through the assembly lists to find which one our
-        // current chain belongs to. Forunetly, these lists are fairly short in the 
-        // vast majority of cases.
+        // Unfortunetly we must loop through the assembly lists to find which
+        // one our current chain belongs to. Forunetly, these lists are fairly
+        // short in the vast majority of cases.
         std::string current_assembly;
         for (const auto& assembly : structure_.bioAssemblyList) {
             for (const auto& transform : assembly.transformList) {
                 for (auto id : transform.chainIndexList) {
-                    if (id == chainIndex_) {
+                    if (static_cast<size_t>(id) == chainIndex_) {
                         current_assembly += "bio";
                         current_assembly += assembly.name;
                     }

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -19,26 +19,15 @@ template<> FormatInfo chemfiles::format_information<MMTFFormat>() {
     );
 }
 
-static std::string extension(const std::string& filename) {
-    auto idx = filename.rfind('.');
-    if (idx != std::string::npos) {
-        return filename.substr(idx);
-    } else {
-        return "";
-    }
-}
-
-MMTFFormat::MMTFFormat(std::string path, File::Mode mode) {
-    auto ext = extension(path);
-
+MMTFFormat::MMTFFormat(std::string path, File::Mode mode, File::Compression compression) {
     if (mode == File::READ) {
-        if (ext == ".gz") {
+        if (compression == File::GZIP) {
             gzstreambuf gz_buff;
             gz_buff.open(path, "rb");
             std::stringstream buffer;
             buffer << &gz_buff;
             mmtf::decodeFromBuffer(structure_, buffer.str().data(), buffer.str().size());
-        } else if (ext == ".xz") {
+        } else if (compression == File::LZMA) {
             xzstreambuf xz_buff;
             xz_buff.open(path, "rb");
             std::stringstream buffer;

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -25,8 +25,8 @@ static std::streampos read_until(TextFile& file, const std::string& tag);
 /// contain one more step or -1 if it does not.
 static std::streampos forward(TextFile& file);
 
-MOL2Format::MOL2Format(const std::string& path, File::Mode mode)
-  : file_(TextFile::create(path, mode)) {
+MOL2Format::MOL2Format(std::string path, File::Mode mode)
+  : file_(TextFile::open(std::move(path), mode)) {
     while (!file_->eof()) {
         auto position = forward(*file_);
         if (position == std::streampos(-1)) {
@@ -213,7 +213,7 @@ std::streampos forward(TextFile& file) {
 
             if (natoms < 0) {
                 throw format_error(
-                    "number of atoms can not be negative in '{}'", file.filename()
+                    "number of atoms can not be negative in '{}'", file.path()
                 );
             }
 
@@ -226,7 +226,7 @@ std::streampos forward(TextFile& file) {
 
             if (nbonds < 0) {
                 throw format_error(
-                    "number of bonds can not be negative in '{}'", file.filename()
+                    "number of bonds can not be negative in '{}'", file.path()
                 );
             }
 

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -25,8 +25,8 @@ static std::streampos read_until(TextFile& file, const std::string& tag);
 /// contain one more step or -1 if it does not.
 static std::streampos forward(TextFile& file);
 
-MOL2Format::MOL2Format(std::string path, File::Mode mode)
-  : file_(TextFile::open(std::move(path), mode)) {
+MOL2Format::MOL2Format(std::string path, File::Mode mode, File::Compression compression)
+  : file_(TextFile::open(std::move(path), mode, compression)) {
     while (!file_->eof()) {
         auto position = forward(*file_);
         if (position == std::streampos(-1)) {

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -63,11 +63,17 @@ static int molfiles_to_chemfiles_warning(int level, const char* message) {
 /******************************************************************************/
 
 template <MolfileFormat F>
-Molfile<F>::Molfile(std::string path, File::Mode mode)
+Molfile<F>::Molfile(std::string path, File::Mode mode, File::Compression compression)
     : path_(std::move(path)), plugin_handle_(nullptr), data_(nullptr), natoms_(0) {
     if (mode != File::READ) {
         throw format_error(
             "molfiles based format {} is only available in read mode", plugin_data_.format()
+        );
+    }
+
+    if (compression != File::DEFAULT) {
+        throw format_error(
+            "molfiles based format {} do not support compression", plugin_data_.format()
         );
     }
 

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -63,8 +63,8 @@ static int molfiles_to_chemfiles_warning(int level, const char* message) {
 /******************************************************************************/
 
 template <MolfileFormat F>
-Molfile<F>::Molfile(const std::string& path, File::Mode mode)
-    : path_(path), plugin_handle_(nullptr), data_(nullptr), natoms_(0) {
+Molfile<F>::Molfile(std::string path, File::Mode mode)
+    : path_(std::move(path)), plugin_handle_(nullptr), data_(nullptr), natoms_(0) {
     if (mode != File::READ) {
         throw format_error(
             "molfiles based format {} is only available in read mode", plugin_data_.format()
@@ -98,12 +98,12 @@ Molfile<F>::Molfile(const std::string& path, File::Mode mode)
     }
 
     data_ = plugin_handle_->open_file_read(
-        path.c_str(), plugin_handle_->name, &natoms_
+        path_.c_str(), plugin_handle_->name, &natoms_
     );
 
     if (!data_) {
         throw format_error(
-            "could not open the file at '{}' with {} plugin", path, plugin_data_.format()
+            "could not open the file at '{}' with {} plugin", path_, plugin_data_.format()
         );
     }
 

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -54,8 +54,8 @@ enum class Record {
 // Get the record type for a line.
 static Record get_record(const std::string& line);
 
-PDBFormat::PDBFormat(const std::string& path, File::Mode mode)
-  : file_(TextFile::create(path, mode)), models_(0) {
+PDBFormat::PDBFormat(std::string path, File::Mode mode)
+  : file_(TextFile::open(std::move(path), mode)), models_(0) {
     while (!file_->eof()) {
         auto position = file_->tellg();
         if (!file_ || position == std::streampos(-1)) {
@@ -165,7 +165,7 @@ void PDBFormat::read_CRYST1(Frame& frame, const std::string& line) {
         if (space_group != "P 1" && space_group != "P1") {
             warning(
                 "Space group which is not P1 ({}) ignored in '{}'",
-                space_group, file_->filename()
+                space_group, file_->path()
             );
         }
     }

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -54,8 +54,8 @@ enum class Record {
 // Get the record type for a line.
 static Record get_record(const std::string& line);
 
-PDBFormat::PDBFormat(std::string path, File::Mode mode)
-  : file_(TextFile::open(std::move(path), mode)), models_(0) {
+PDBFormat::PDBFormat(std::string path, File::Mode mode, File::Compression compression)
+  : file_(TextFile::open(std::move(path), mode, compression)), models_(0) {
     while (!file_->eof()) {
         auto position = file_->tellg();
         if (!file_ || position == std::streampos(-1)) {

--- a/src/formats/SDF.cpp
+++ b/src/formats/SDF.cpp
@@ -27,8 +27,8 @@ template<> FormatInfo chemfiles::format_information<SDFFormat>() {
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-SDFFormat::SDFFormat(std::string path, File::Mode mode)
-    : file_(TextFile::open(std::move(path), mode))
+SDFFormat::SDFFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(TextFile::open(std::move(path), mode, compression))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();

--- a/src/formats/SDF.cpp
+++ b/src/formats/SDF.cpp
@@ -27,8 +27,8 @@ template<> FormatInfo chemfiles::format_information<SDFFormat>() {
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-SDFFormat::SDFFormat(const std::string& path, File::Mode mode)
-    : file_(TextFile::create(path, mode))
+SDFFormat::SDFFormat(std::string path, File::Mode mode)
+    : file_(TextFile::open(std::move(path), mode))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();
@@ -278,7 +278,7 @@ bool forward(TextFile& file) {
 
     if (natoms < 0 || nbonds < 0) {
         throw format_error(
-            "number of atoms and bonds can not be negative in '{}'", file.filename()
+            "number of atoms and bonds can not be negative in '{}'", file.path()
         );
     }
 
@@ -287,7 +287,7 @@ bool forward(TextFile& file) {
     } catch (const FileError&) {
         // We could not read the lines from the file
         throw format_error(
-            "not enough lines in '{}' for SDF format", file.filename()
+            "not enough lines in '{}' for SDF format", file.path()
         );
     }
 

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -41,7 +41,7 @@ private:
 #define STRING(x) STRING_0(x)
 #define CHECK(x) check_tng_error((x), (STRING(x)))
 
-TNGFormat::TNGFormat(const std::string& path, File::Mode mode): tng_(path, mode) {}
+TNGFormat::TNGFormat(std::string path, File::Mode mode): tng_(std::move(path), mode) {}
 
 size_t TNGFormat::nsteps() {
     int64_t n_frames = 0;

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -41,7 +41,11 @@ private:
 #define STRING(x) STRING_0(x)
 #define CHECK(x) check_tng_error((x), (STRING(x)))
 
-TNGFormat::TNGFormat(std::string path, File::Mode mode): tng_(std::move(path), mode) {}
+TNGFormat::TNGFormat(std::string path, File::Mode mode, File::Compression compression): tng_(std::move(path), mode) {
+    if (compression != File::DEFAULT) {
+        throw format_error("TNG format do not support compression");
+    }
+}
 
 size_t TNGFormat::nsteps() {
     int64_t n_frames = 0;

--- a/src/formats/Tinker.cpp
+++ b/src/formats/Tinker.cpp
@@ -26,8 +26,8 @@ template<> FormatInfo chemfiles::format_information<TinkerFormat>() {
 static bool forward(TextFile& file);
 static bool is_unit_cell_line(const std::string& line);
 
-TinkerFormat::TinkerFormat(std::string path, File::Mode mode)
-    : file_(TextFile::open(std::move(path), mode))
+TinkerFormat::TinkerFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(TextFile::open(std::move(path), mode, compression))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();

--- a/src/formats/Tinker.cpp
+++ b/src/formats/Tinker.cpp
@@ -26,8 +26,8 @@ template<> FormatInfo chemfiles::format_information<TinkerFormat>() {
 static bool forward(TextFile& file);
 static bool is_unit_cell_line(const std::string& line);
 
-TinkerFormat::TinkerFormat(const std::string& path, File::Mode mode)
-    : file_(TextFile::create(path, mode))
+TinkerFormat::TinkerFormat(std::string path, File::Mode mode)
+    : file_(TextFile::open(std::move(path), mode))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();
@@ -58,7 +58,7 @@ void TinkerFormat::read(Frame& frame) {
         scan(line, "%zu", &natoms);
     } catch (const FileError& e) {
         throw format_error(
-            "can not read number of atoms in {}: {}", file_->filename(), e.what()
+            "can not read number of atoms in {}: {}", file_->path(), e.what()
         );
     }
 
@@ -81,7 +81,7 @@ void TinkerFormat::read(Frame& frame) {
 
     } catch (const FileError& e) {
         throw format_error(
-            "can not read atomic data in {}: {}", file_->filename(), e.what()
+            "can not read atomic data in {}: {}", file_->path(), e.what()
         );
     }
 
@@ -184,7 +184,7 @@ bool forward(TextFile& file) {
 
     if (natoms < 0) {
         throw format_error(
-            "number of atoms can not be negative in '{}'", file.filename()
+            "number of atoms can not be negative in '{}'", file.path()
         );
     }
 
@@ -203,7 +203,7 @@ bool forward(TextFile& file) {
     } catch (const FileError&) {
         // We could not read the lines from the file
         throw format_error(
-            "not enough lines in '{}' for Tinker XYZ format", file.filename()
+            "not enough lines in '{}' for Tinker XYZ format", file.path()
         );
     }
     return true;

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -26,8 +26,8 @@ template<> FormatInfo chemfiles::format_information<XYZFormat>() {
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-XYZFormat::XYZFormat(const std::string& path, File::Mode mode)
-    : file_(TextFile::create(path, mode))
+XYZFormat::XYZFormat(std::string path, File::Mode mode)
+    : file_(TextFile::open(std::move(path), mode))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();
@@ -112,7 +112,7 @@ bool forward(TextFile& file) {
 
     if (natoms < 0) {
         throw format_error(
-            "number of atoms can not be negative in '{}'", file.filename()
+            "number of atoms can not be negative in '{}'", file.path()
         );
     }
 
@@ -121,7 +121,7 @@ bool forward(TextFile& file) {
     } catch (const FileError& e) {
         // We could not read the lines from the file
         throw format_error(
-            "not enough lines for XYZ format: {}", file.filename(), e.what()
+            "not enough lines for XYZ format: {}", file.path(), e.what()
         );
     }
     return true;

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -26,8 +26,8 @@ template<> FormatInfo chemfiles::format_information<XYZFormat>() {
 /// not contain one more step.
 static bool forward(TextFile& file);
 
-XYZFormat::XYZFormat(std::string path, File::Mode mode)
-    : file_(TextFile::open(std::move(path), mode))
+XYZFormat::XYZFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(TextFile::open(std::move(path), mode, compression))
 {
     while (!file_->eof()) {
         auto position = file_->tellg();

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -14,12 +14,12 @@
 using namespace chemfiles;
 
 struct DummyFormat: public Format {
-    DummyFormat(const std::string&, File::Mode) {}
+    DummyFormat(const std::string&, File::Mode, File::Compression) {}
     size_t nsteps() override {return 42;}
 };
 
 struct DunnyFormat: public Format {
-    DunnyFormat(const std::string&, File::Mode) {}
+    DunnyFormat(const std::string&, File::Mode, File::Compression) {}
     size_t nsteps() override {return 0;}
 };
 
@@ -36,10 +36,10 @@ namespace chemfiles {
 TEST_CASE("Geting registered format"){
     FormatFactory::get().add_format<DummyFormat>();
 
-    DummyFormat dummy("", File::READ);
-    auto format = FormatFactory::get().extension(".dummy")("", File::READ);
+    DummyFormat dummy("", File::READ, File::DEFAULT);
+    auto format = FormatFactory::get().extension(".dummy")("", File::READ, File::DEFAULT);
     CHECK(typeid(dummy) == typeid(*format));
-    format = FormatFactory::get().name("Dummy")("", File::READ);
+    format = FormatFactory::get().name("Dummy")("", File::READ, File::DEFAULT);
     CHECK(typeid(dummy) == typeid(*format));
 
     CHECK_THROWS_AS(FormatFactory::get().name("UNKOWN"), FormatError);


### PR DESCRIPTION
This PR allow to request using GzFile/XzFile from the format parameter of trajectory, as `<format>/ GZ` or `<format>/XZ`, where `<format>` can be empty.

Ref #71 