### PR TITLE
Use atomic properties in selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     * When using numbers as atomic names/types, they must now be inside double
       quotes (`name "45"`). This also allows for more exotic atomic names
       (`name "名"`).
+    * Atomic properties can be checked, using the `[property] == Ow` syntax for
+      string properties, `[property] == 2.3` for numeric properties and
+      `[property]` for boolean properties.
 * There is only one constructor for the `Frame` class: `Frame(UnitCell cell =
   UnitCell())`. The constructor taking a topology can be replaced with calls to
   `Frame::add_atom` and `Frame::add_bond`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Chemfiles will now read configuration from `.chemfiles.toml` or
   `chemfiles.toml` instead of `.chemfilesrc`
 * Added `Trajectory::path` to get the file path used to create a trajectory
+* Renamed `Property::get_kind` to `Property::kind`
 
 ### Changes in supported formats
 

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -57,7 +57,7 @@ breathe_projects = {
 breathe_default_project = "chemfiles"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = [os.path.join(ROOT, "templates")]
+templates_path = [os.path.join(ROOT, "..", "templates")]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
@@ -69,11 +69,15 @@ html_theme = 'bootstrap'
 html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 html_theme_options = {
-    'navbar_pagenav_name': "Content",
     'navbar_site_name': "Navigation",
+    'navbar_pagenav': False,
     'source_link_position': None,
     'bootswatch_theme': "flatly",
     'bootstrap_version': "3",
+}
+
+html_sidebars = {
+    '**': ['sidebar-toc.html', 'searchbox.html']
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/src/capi/chfl_atom.rst
+++ b/doc/src/capi/chfl_atom.rst
@@ -1,7 +1,7 @@
 .. _capi-atom:
 
-Function manipulating ``CHFL_ATOM``
------------------------------------
+``CHFL_ATOM``
+-------------
 
 .. doxygentypedef:: CHFL_ATOM
 

--- a/doc/src/capi/chfl_cell.rst
+++ b/doc/src/capi/chfl_cell.rst
@@ -1,7 +1,7 @@
 .. _capi-cell:
 
-Function manipulating ``CHFL_CELL``
------------------------------------
+``CHFL_CELL``
+-------------
 
 .. doxygentypedef:: CHFL_CELL
 

--- a/doc/src/capi/chfl_frame.rst
+++ b/doc/src/capi/chfl_frame.rst
@@ -1,7 +1,7 @@
 .. _capi-frame:
 
-Function manipulating ``CHFL_FRAME``
-------------------------------------
+``CHFL_FRAME``
+--------------
 
 .. doxygentypedef:: CHFL_FRAME
 

--- a/doc/src/capi/chfl_property.rst
+++ b/doc/src/capi/chfl_property.rst
@@ -1,7 +1,7 @@
 .. _capi-property:
 
-Function manipulating ``CHFL_PROPERTY``
----------------------------------------
+``CHFL_PROPERTY``
+-----------------
 
 .. doxygentypedef:: CHFL_PROPERTY
 

--- a/doc/src/capi/chfl_residue.rst
+++ b/doc/src/capi/chfl_residue.rst
@@ -1,7 +1,7 @@
 .. _capi-residue:
 
-Function manipulating ``CHFL_RESIDUE``
---------------------------------------
+``CHFL_RESIDUE``
+----------------
 
 .. doxygentypedef:: CHFL_RESIDUE
 

--- a/doc/src/capi/chfl_selection.rst
+++ b/doc/src/capi/chfl_selection.rst
@@ -1,7 +1,7 @@
 .. _capi-selection:
 
-Function manipulating ``CHFL_SELECTION``
-----------------------------------------
+``CHFL_SELECTION``
+------------------
 
 .. doxygentypedef:: CHFL_SELECTION
 

--- a/doc/src/capi/chfl_topology.rst
+++ b/doc/src/capi/chfl_topology.rst
@@ -1,7 +1,7 @@
 .. _capi-topology:
 
-Function manipulating ``CHFL_TOPOLOGY``
----------------------------------------
+``CHFL_TOPOLOGY``
+-----------------
 
 .. doxygentypedef:: CHFL_TOPOLOGY
 

--- a/doc/src/capi/chfl_trajectory.rst
+++ b/doc/src/capi/chfl_trajectory.rst
@@ -1,7 +1,7 @@
 .. _capi-trajectory:
 
-Function manipulating ``CHFL_TRAJECTORY``
------------------------------------------
+``CHFL_TRAJECTORY``
+-------------------
 
 .. doxygentypedef:: CHFL_TRAJECTORY
 

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -71,8 +71,8 @@ in our `Gitter chat room <https://gitter.im/chemfiles/chemfiles>`_.
 
 .. _classes-reference:
 
-Classes and functions reference
--------------------------------
+API reference
+-------------
 
 All the public classes (for the C++ interface) and functions (for the C
 interface) are extensively documented here.

--- a/doc/src/overview.rst
+++ b/doc/src/overview.rst
@@ -1,5 +1,5 @@
-Chemfiles classes overview
-===========================
+Overview
+========
 
 This figure represents how the basic classes of chemfiles are organised and how
 they interact together. The only classes a chemfiles user should worry about are

--- a/doc/src/selections.rst
+++ b/doc/src/selections.rst
@@ -75,6 +75,9 @@ Boolean selectors
 - ``is_improper(i, j, k, m)``: check if atoms i, j, k and m are bonded together
   to form a dihedral angle, *i.e.* that all of i, k, and m are bonded to j. If
   any of i, j, k or m refer to the same atom, this returns false;
+- ``[<property>]``: check if atoms have a boolean property named `'property'`
+  set, and that this property is true. This will return false if the property
+  is not set;
 
 For boolean selectors taking arguments, ``i/j/k/m`` can either be one of the
 atoms currently being matched (``#1 / #2 / #3 / #4``) or another selection
@@ -92,6 +95,9 @@ String properties
   depending on the actual data;
 - ``resname``: gives the residue name. If an atom is not in a residue, this
   return the empty string;
+- ``[<property>]``: gives the value of the string property named `'property'`
+  for the atom. This will return an empty string (`""`) if the property is not
+  set;
 
 Numeric properties
 ------------------
@@ -104,6 +110,8 @@ Most of the numeric properties only apply to a single atom:
 - ``vx``, ``vy`` and ``vz``: gives the atomic velocity in cartesian coordinates;
 - ``resid``: gives the atomic residue index. If an atom is not in a residue,
   this return -1;
+- ``[<property>]``: gives the value of the numeric property named `'property'`
+  for the atom. This will return 0 if the property is not set;
 
 But some properties apply to multiple atoms, and as such are only usable when
 selecting multiple atoms:

--- a/doc/templates/page.html
+++ b/doc/templates/page.html
@@ -8,8 +8,10 @@
     <p class="pull-right">
       <a href="#">Back to top</a>
     </p>
-    <p>
-        &copy; Copyright Guillaume Fraux and contributors.<br/>
+    <p class="pull-left">
+        &copy; Copyright Guillaume Fraux and contributors.
+    </p>
+    <p class="text-center">
         BSD licensed on <a href="https://github.com/chemfiles/chemfiles">Github</a>
     </p>
   </div>

--- a/doc/templates/sidebar-toc.html
+++ b/doc/templates/sidebar-toc.html
@@ -1,0 +1,1 @@
+{{ toctree(maxdepth=2|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool) }}

--- a/include/chemfiles/Property.hpp
+++ b/include/chemfiles/Property.hpp
@@ -21,7 +21,7 @@ namespace chemfiles {
 class CHFL_EXPORT Property final {
 public:
     /// Possible types holded by a property
-    enum kind {
+    enum Kind {
         BOOL = 0,
         DOUBLE = 1,
         STRING = 2,
@@ -132,7 +132,7 @@ public:
     /// Get the kind of property, *i.e.* the type of the holded value
     ///
     /// @example{tests/doc/property/get_kind.cpp}
-    kind get_kind() const {
+    Kind kind() const {
         return this->kind_;
     }
 
@@ -168,7 +168,7 @@ private:
     /// Get the kind name as a string
     std::string kind_as_string() const;
 
-    kind kind_;
+    Kind kind_;
     union {
         bool bool_;
         std::string string_;

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -89,6 +89,20 @@ public:
     bool is_match(const Frame& frame, const Match& match) const override;
 };
 
+/// Selection based on boolean properties
+class BoolProperty final: public Selector {
+public:
+    BoolProperty(std::string property, Variable argument):
+        property_(std::move(property)), argument_(argument) {}
+    std::string print(unsigned delta) const override;
+    bool is_match(const Frame& frame, const Match& match) const override;
+
+private:
+    std::string property_;
+    /// Which atom in the candidate match are we checking?
+    Variable argument_;
+};
+
 /// A sub-selection for use in boolean selectors
 class SubSelection {
 public:
@@ -196,6 +210,20 @@ private:
     bool equals_;
     /// Which atom in the candidate match are we checking?
     Variable argument_;
+};
+
+/// Selection based on string properties
+class StringProperty final: public StringSelector {
+public:
+    StringProperty(std::string property, std::string value, bool equals, Variable argument):
+        StringSelector(std::move(value), equals, argument),
+        property_(std::move(property)) {}
+
+    const std::string& value(const Frame& frame, size_t i) const override;
+    std::string name() const override;
+
+private:
+    std::string property_;
 };
 
 /// Select atoms using their type
@@ -479,6 +507,18 @@ private:
     /// Which atom in the candidate match are we checking?
     Variable argument_;
 };
+
+/// Select atoms using a given double property in the frame.
+class NumericProperty final: public NumericSelector {
+public:
+    NumericProperty(std::string property, Variable argument): NumericSelector(argument), property_(std::move(property)) {}
+    std::string name() const override;
+    double value(const Frame& frame, size_t i) const override;
+
+private:
+    std::string property_;
+};
+
 
 /// Select atoms using their index in the frame.
 class Index final: public NumericSelector {

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -455,17 +455,17 @@ private:
     Variable m_;
 };
 
-/// Abstract base class for numeric properties
-class NumericProperty: public MathExpr {
+/// Abstract base class for numeric selectors
+class NumericSelector: public MathExpr {
 public:
-    NumericProperty(Variable argument): argument_(argument) {}
-    ~NumericProperty() override = default;
+    NumericSelector(Variable argument): argument_(argument) {}
+    ~NumericSelector() override = default;
 
-    NumericProperty(NumericProperty&&) = default;
-    NumericProperty& operator=(NumericProperty&&) = default;
+    NumericSelector(NumericSelector&&) = default;
+    NumericSelector& operator=(NumericSelector&&) = default;
 
-    NumericProperty(const NumericProperty&) = delete;
-    NumericProperty& operator=(const NumericProperty&) = delete;
+    NumericSelector(const NumericSelector&) = delete;
+    NumericSelector& operator=(const NumericSelector&) = delete;
 
     double eval(const Frame& frame, const Match& match) const override final;
     optional<double> optimize() override final;
@@ -481,25 +481,25 @@ private:
 };
 
 /// Select atoms using their index in the frame.
-class Index final: public NumericProperty {
+class Index final: public NumericSelector {
 public:
-    Index(Variable argument): NumericProperty(argument) {}
+    Index(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
 };
 
 /// Select atoms using their residue id (residue number)
-class Resid final: public NumericProperty {
+class Resid final: public NumericSelector {
 public:
-    Resid(Variable argument): NumericProperty(argument) {}
+    Resid(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
 };
 
 /// Select atoms using their mass.
-class Mass final: public NumericProperty {
+class Mass final: public NumericSelector {
 public:
-    Mass(Variable argument): NumericProperty(argument) {}
+    Mass(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
 };
@@ -513,9 +513,9 @@ enum class Coordinate {
 /// Select atoms using their position in space. The selection can be created by
 /// `x <op> <val>`, `y <op> <val>` or `z <op> <val>`, depending on the component
 /// of the position to use.
-class Position final: public NumericProperty {
+class Position final: public NumericSelector {
 public:
-    Position(Variable argument, Coordinate coordinate): NumericProperty(argument), coordinate_(coordinate) {}
+    Position(Variable argument, Coordinate coordinate): NumericSelector(argument), coordinate_(coordinate) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
 private:
@@ -525,9 +525,9 @@ private:
 /// Select atoms using their velocity. The selection can be created by `vx <op>
 /// <val>`, `vy <op> <val>` or `vz <op> <val>`, depending on the component of
 /// the velocity to use.
-class Velocity final: public NumericProperty {
+class Velocity final: public NumericSelector {
 public:
-    Velocity(Variable argument, Coordinate coordinate): NumericProperty(argument), coordinate_(coordinate) {}
+    Velocity(Variable argument, Coordinate coordinate): NumericSelector(argument), coordinate_(coordinate) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
 private:

--- a/include/chemfiles/selections/lexer.hpp
+++ b/include/chemfiles/selections/lexer.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <cassert>
 
 #include <chemfiles/exports.hpp>
 #include <chemfiles/Error.hpp>
@@ -15,6 +16,9 @@ namespace chemfiles {
 namespace selections {
 
 using Variable = uint8_t;
+
+/// Check that a given string is a valid identifier
+bool is_ident(const std::string& string);
 
 /// A token in the selection stream
 class Token {
@@ -74,7 +78,10 @@ public:
     Token& operator=(Token&&) = default;
 
     /// Create an identifier token with `data` name
-    static Token ident(std::string data);
+    static Token ident(std::string data) {
+        assert(is_ident(data));
+        return Token(IDENT, std::move(data), 0.0, 0);
+    }
 
     /// Create a string with some `data` inside
     static Token string(std::string data) {

--- a/include/chemfiles/selections/lexer.hpp
+++ b/include/chemfiles/selections/lexer.hpp
@@ -25,10 +25,14 @@ class Token {
 public:
     /// Available token types
     enum Type {
-        /// Left parenthesis
+        /// Left parenthesis '('
         LPAREN,
-        /// Right parenthesis
+        /// Right parenthesis ')'
         RPAREN,
+        /// Left bracket '['
+        LBRACKET,
+        /// Right bracket ']'
+        RBRACKET,
         /// Comma
         COMMA,
         /// "==" token

--- a/include/chemfiles/selections/parser.hpp
+++ b/include/chemfiles/selections/parser.hpp
@@ -38,7 +38,6 @@ private:
     MathAst math_function(const std::string& name);
     // functions of atomic variables (distance(#1, #2), ...)
     MathAst math_var_function(const std::string& name);
-    MathAst math_property(const std::string& name);
 
     // Match multiple variables and the surrounding parenthesis
     std::vector<Variable> variables();

--- a/include/chemfiles/selections/parser.hpp
+++ b/include/chemfiles/selections/parser.hpp
@@ -30,6 +30,11 @@ private:
     Ast string_selector();
     Ast math_selector();
 
+    /// Parse Boolean and string properties, returning nullptr if none of these
+    /// can not be parsed, so that they can be parsed as a mathematical
+    /// expression later
+    Ast bool_or_string_property();
+
     MathAst math_sum();
     MathAst math_product();
     MathAst math_power();

--- a/src/capi/property.cpp
+++ b/src/capi/property.cpp
@@ -57,7 +57,7 @@ extern "C" chfl_status chfl_property_get_kind(const CHFL_PROPERTY* const propert
     CHECK_POINTER(property);
     CHECK_POINTER(kind);
     CHFL_ERROR_CATCH(
-        *kind = static_cast<chfl_property_kind>(property->get_kind());
+        *kind = static_cast<chfl_property_kind>(property->kind());
     )
 }
 

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -174,7 +174,7 @@ static std::string to_gro_index(uint64_t i) {
 }
 
 void GROFormat::write(const Frame& frame) {
-    if (frame.get("name") && frame.get("name")->get_kind() == Property::STRING) {
+    if (frame.get("name") && frame.get("name")->kind() == Property::STRING) {
         fmt::print(*file_, frame.get("name")->as_string() + "\n");
     } else {
         fmt::print(*file_, "GRO File produced by chemfiles\n");

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -226,7 +226,6 @@ void MMTFFormat::read(Frame& frame) {
 }
 
 void MMTFFormat::write(const Frame& frame) {
-    
     // Used to add bonds  bonds
     auto writeAtomLoc = static_cast<size_t>(structure_.numAtoms);
 
@@ -235,7 +234,7 @@ void MMTFFormat::write(const Frame& frame) {
 
     std::string prev_chainId;
     std::string prev_chainName;
-    const chemfiles::Residue* prev_residue = 0;
+    const chemfiles::Residue* prev_residue = nullptr;
 
     auto& topology = frame.topology();
     auto& positions = frame.positions();
@@ -266,13 +265,11 @@ void MMTFFormat::write(const Frame& frame) {
         std::string current_chainId;
         std::string current_chainName;
 
-        if (current_chainId_opt &&
-            current_chainId_opt->get_kind() == Property::STRING) {
+        if (current_chainId_opt && current_chainId_opt->kind() == Property::STRING) {
             current_chainId = current_chainId_opt->as_string();
         }
 
-        if (current_chainName_opt &&
-            current_chainName_opt->get_kind() == Property::STRING) {
+        if (current_chainName_opt && current_chainName_opt->kind() == Property::STRING) {
             current_chainName = current_chainName_opt->as_string();
         }
 

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -248,7 +248,7 @@ void MOL2Format::write(const Frame& frame) {
     fmt::print(*file_, "@<TRIPOS>MOLECULE\n");
 
     const auto& frame_name = frame.get("name");
-    if (frame_name && frame_name->get_kind() == Property::STRING) {
+    if (frame_name && frame_name->kind() == Property::STRING) {
         fmt::print(*file_, frame_name->as_string());
     }
     fmt::print(*file_, "\n");

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -461,7 +461,7 @@ void PDBFormat::write(const Frame& frame) {
         std::string atom_hetatm = "HETATM";
         auto is_hetatm = frame.topology()[i].get("is_hetatm");
         if (is_hetatm) {
-            if (is_hetatm->get_kind() == Property::BOOL) {
+            if (is_hetatm->kind() == Property::BOOL) {
                 if (is_hetatm->as_bool()) {
                     atom_hetatm = "HETATM";
                 } else {

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -230,7 +230,7 @@ void mmCIFFormat::read(Frame& frame) {
     auto line = file_->readline();
 
     size_t last_position = 0;
-    
+
     if (model_position != atom_site_map_.end()) {
         last_position = std::stoul(split(line, ' ')[model_position->second]);
     }
@@ -250,7 +250,7 @@ void mmCIFFormat::read(Frame& frame) {
         }
 
         size_t current_position = 0;
-        
+
         if (model_position != atom_site_map_.end()) {
             current_position = std::stoul(line_split[model_position->second]);
         }
@@ -270,7 +270,7 @@ void mmCIFFormat::read(Frame& frame) {
             line_split[label_alt_id->second] != ".") {
             atom.set("altloc", line_split[label_alt_id->second]);
         }
-        
+
         if (formal_charge != atom_site_map_.end()) {
             atom.set_charge(cif_to_double(line_split[formal_charge->second]));
         }
@@ -400,23 +400,20 @@ void mmCIFFormat::write(const Frame& frame) {
                 seq_id = "?";
             }
 
-            if (residue->get("chainid") &&
-                residue->get("chainid")->get_kind() == Property::STRING) {
+            if (residue->get("chainid") && residue->get("chainid")->kind() == Property::STRING) {
                 asymid = residue->get("chainid")->as_string();
             } else {
                 asymid = "?";
             }
 
-            if (residue->get("chainname") &&
-                residue->get("chainname")->get_kind() == Property::STRING) {
+            if (residue->get("chainname") && residue->get("chainname")->kind() == Property::STRING) {
                 auth_asymid = residue->get("chainname")->as_string();
             }
         }
 
         const auto& atom = frame[i];
 
-        if (atom.get("is_hetatm") &&
-            atom.get("is_hetatm")->get_kind() == Property::BOOL &&
+        if (atom.get("is_hetatm") && atom.get("is_hetatm")->kind() == Property::BOOL &&
             atom.get("is_hetatm")->as_bool()) {
             pdbgroup = "HETATM";
         }

--- a/src/selections/expr.cpp
+++ b/src/selections/expr.cpp
@@ -469,15 +469,15 @@ std::string OutOfPlane::print() const {
     return fmt::format("out_of_plane(#{}, #{}, #{}, #{})", i_ + 1, j_ + 1, k_ + 1, m_ + 1);
 }
 
-double NumericProperty::eval(const Frame& frame, const Match& match) const {
+double NumericSelector::eval(const Frame& frame, const Match& match) const {
     return this->value(frame, match[argument_]);
 }
 
-optional<double> NumericProperty::optimize() {
+optional<double> NumericSelector::optimize() {
     return nullopt;
 }
 
-std::string NumericProperty::print() const {
+std::string NumericSelector::print() const {
     return fmt::format("{}(#{})", name(), argument_ + 1);
 }
 

--- a/src/selections/expr.cpp
+++ b/src/selections/expr.cpp
@@ -6,6 +6,7 @@
 #include "chemfiles/ErrorFmt.hpp"
 
 #include "chemfiles/selections/expr.hpp"
+#include "chemfiles/selections/lexer.hpp"
 
 using namespace chemfiles;
 using namespace chemfiles::selections;
@@ -185,7 +186,11 @@ bool IsImproper::is_match(const Frame& frame, const Match& match) const {
 
 std::string StringSelector::print(unsigned /*unused*/) const {
     auto op = equals_ ? "==" : "!=";
-    return fmt::format("{}(#{}) {} {}", name(), argument_ + 1, op, value_);
+    if (is_ident(value_)) {
+        return fmt::format("{}(#{}) {} {}", name(), argument_ + 1, op, value_);
+    } else {
+        return fmt::format("{}(#{}) {} \"{}\"", name(), argument_ + 1, op, value_);
+    }
 }
 
 bool StringSelector::is_match(const Frame& frame, const Match& match) const {

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -55,6 +55,10 @@ std::string Token::as_str() const {
         return "(";
     case Token::RPAREN:
         return ")";
+    case Token::LBRACKET:
+        return "[";
+    case Token::RBRACKET:
+        return "]";
     case Token::COMMA:
         return ",";
     case Token::VARIABLE:
@@ -111,6 +115,12 @@ std::vector<Token> Tokenizer::tokenize() {
             continue;
         } else if (match(')')) {
             tokens.emplace_back(Token(Token::RPAREN));
+            continue;
+        } else if (match('[')) {
+            tokens.emplace_back(Token(Token::LBRACKET));
+            continue;
+        } else if (match(']')) {
+            tokens.emplace_back(Token(Token::RBRACKET));
             continue;
         } else if (match(',')) {
             tokens.emplace_back(Token(Token::COMMA));

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -32,13 +32,19 @@ static bool is_ident_component(char c) {
     return is_alpha(c) || is_digit(c) || c == '_';
 }
 
-Token Token::ident(std::string data) {
-    assert(!data.empty());
-    assert(is_alpha(data[0]));
-    for (auto c: data) {
-        assert(is_ident_component(c));
+bool chemfiles::selections::is_ident(const std::string& string) {
+    if (string.empty()) {
+        return false;
     }
-    return Token(IDENT, std::move(data), 0.0, 0);
+    if (!is_alpha(string[0])) {
+        return false;
+    }
+    for (auto c: string) {
+        if (!is_ident_component(c)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 std::string Token::as_str() const {

--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -226,17 +226,17 @@ Ast Parser::string_selector() {
             auto value = previous().string();
             return STRING_SELECTORS[name](std::move(value), true, var);
         } else {
-            throw selection_error("expected a value after '{} ==', found {}", name, peek().as_str());
+            throw selection_error("expected a string value after '{} ==', found {}", name, peek().as_str());
         }
     } else if (match(Token::NOT_EQUAL)) {
         if (match(Token::IDENT) || match(Token::STRING)) {
             auto value = previous().string();
             return STRING_SELECTORS[name](std::move(value), false, var);
         } else {
-            throw selection_error("expected a value after '{} !=', found {}", name, peek().as_str());
+            throw selection_error("expected a string value after '{} !=', found {}", name, peek().as_str());
         }
     } else {
-        throw selection_error("expected one of '!=', '==' or a value after {}, found {}", name, peek().as_str());
+        throw selection_error("expected one of '!=', '==' or a string value after {}, found {}", name, peek().as_str());
     }
 }
 

--- a/tests/doc/property/bool.cpp
+++ b/tests/doc/property/bool.cpp
@@ -11,7 +11,7 @@ TEST_CASE() {
     // [example]
     auto property = Property(false);
 
-    assert(property.get_kind() == Property::BOOL);
+    assert(property.kind() == Property::BOOL);
     assert(property.as_bool() == false);
     // [example]
 }

--- a/tests/doc/property/double.cpp
+++ b/tests/doc/property/double.cpp
@@ -11,15 +11,15 @@ TEST_CASE() {
     // [example]
     auto property = Property(45.2);
 
-    assert(property.get_kind() == Property::DOUBLE);
+    assert(property.kind() == Property::DOUBLE);
     assert(property.as_double() == 45.2);
 
     // Various overload convert integers to double
-    assert(Property(45).get_kind() == Property::DOUBLE);     // int
-    assert(Property(45l).get_kind() == Property::DOUBLE);    // long
-    assert(Property(45ll).get_kind() == Property::DOUBLE);   // long long
-    assert(Property(45u).get_kind() == Property::DOUBLE);    // unsigned
-    assert(Property(45ul).get_kind() == Property::DOUBLE);   // unsigned long
-    assert(Property(45ull).get_kind() == Property::DOUBLE);  // unsigned long long
+    assert(Property(45).kind() == Property::DOUBLE);     // int
+    assert(Property(45l).kind() == Property::DOUBLE);    // long
+    assert(Property(45ll).kind() == Property::DOUBLE);   // long long
+    assert(Property(45u).kind() == Property::DOUBLE);    // unsigned
+    assert(Property(45ul).kind() == Property::DOUBLE);   // unsigned long
+    assert(Property(45ull).kind() == Property::DOUBLE);  // unsigned long long
     // [example]
 }

--- a/tests/doc/property/get_kind.cpp
+++ b/tests/doc/property/get_kind.cpp
@@ -9,9 +9,9 @@ using namespace chemfiles;
 
 TEST_CASE() {
     // [example]
-    assert(Property(42).get_kind() == Property::DOUBLE);
-    assert(Property(false).get_kind() == Property::BOOL);
-    assert(Property("string").get_kind() == Property::STRING);
-    assert(Property(Vector3D(1, 2, 3)).get_kind() == Property::VECTOR3D);
+    assert(Property(42).kind() == Property::DOUBLE);
+    assert(Property(false).kind() == Property::BOOL);
+    assert(Property("string").kind() == Property::STRING);
+    assert(Property(Vector3D(1, 2, 3)).kind() == Property::VECTOR3D);
     // [example]
 }

--- a/tests/doc/property/string.cpp
+++ b/tests/doc/property/string.cpp
@@ -12,13 +12,13 @@ TEST_CASE() {
     // from a std::string
     auto property = Property(std::string("foo"));
 
-    assert(property.get_kind() == Property::STRING);
+    assert(property.kind() == Property::STRING);
     assert(property.as_string() == "foo");
 
     // from a const char*
     property = Property("bar");
 
-    assert(property.get_kind() == Property::STRING);
+    assert(property.kind() == Property::STRING);
     assert(property.as_string() == "bar");
     // [example]
 }

--- a/tests/doc/property/vector3d.cpp
+++ b/tests/doc/property/vector3d.cpp
@@ -11,7 +11,7 @@ TEST_CASE() {
     // [example]
     auto property = Property(Vector3D(11, 22, 33));
 
-    assert(property.get_kind() == Property::VECTOR3D);
+    assert(property.kind() == Property::VECTOR3D);
     assert(property.as_vector3d() == Vector3D(11, 22, 33));
     // [example]
 }

--- a/tests/property.cpp
+++ b/tests/property.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Property") {
         auto property = Property(false);
 
         CHECK(property.as_bool() == false);
-        CHECK(property.get_kind() == Property::BOOL);
+        CHECK(property.kind() == Property::BOOL);
         CHECK(property == Property(false));
 
         CHECK(property != Property(0));
@@ -26,7 +26,7 @@ TEST_CASE("Property") {
         auto property = Property(42.0);
 
         CHECK(property.as_double() == 42.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
 
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
@@ -34,49 +34,49 @@ TEST_CASE("Property") {
 
         property = Property(23.0f);
         CHECK(property.as_double() == 23.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(23);
         CHECK(property.as_double() == 23.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(24l);
         CHECK(property.as_double() == 24.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(25ll);
         CHECK(property.as_double() == 25.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(26u);
         CHECK(property.as_double() == 26.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(27ul);
         CHECK(property.as_double() == 27.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property(28ull);
         CHECK(property.as_double() == 28.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -84,7 +84,7 @@ TEST_CASE("Property") {
         short val_short = 29;
         property = Property(val_short);
         CHECK(property.as_double() == 29.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -92,7 +92,7 @@ TEST_CASE("Property") {
         char val_char = 30;
         property = Property(val_char);
         CHECK(property.as_double() == 30.0);
-        CHECK(property.get_kind() == Property::DOUBLE);
+        CHECK(property.kind() == Property::DOUBLE);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -102,14 +102,14 @@ TEST_CASE("Property") {
     SECTION("String") {
         auto property = Property(std::string("test"));
         CHECK(property.as_string() == "test");
-        CHECK(property.get_kind() == Property::STRING);
+        CHECK(property.kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
 
         property = Property("test-2");
         CHECK(property.as_string() == "test-2");
-        CHECK(property.get_kind() == Property::STRING);
+        CHECK(property.kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -117,7 +117,7 @@ TEST_CASE("Property") {
         char data[] = {'e', 'm', 'p', 't', 'y', '\0'};
         property = Property(data);
         CHECK(property.as_string() == "empty");
-        CHECK(property.get_kind() == Property::STRING);
+        CHECK(property.kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -125,7 +125,7 @@ TEST_CASE("Property") {
         char* val_char = data;
         property = Property(val_char);
         CHECK(property.as_string() == "empty");
-        CHECK(property.get_kind() == Property::STRING);
+        CHECK(property.kind() == Property::STRING);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);
         CHECK_THROWS_AS(property.as_vector3d(), PropertyError);
@@ -136,7 +136,7 @@ TEST_CASE("Property") {
         auto property = Property(Vector3D(0.0, 1.1, 2.2));
 
         CHECK(property.as_vector3d() == Vector3D(0.0, 1.1, 2.2));
-        CHECK(property.get_kind() == Property::VECTOR3D);
+        CHECK(property.kind() == Property::VECTOR3D);
         CHECK_THROWS_AS(property.as_bool(), PropertyError);
         CHECK_THROWS_AS(property.as_string(), PropertyError);
         CHECK_THROWS_AS(property.as_double(), PropertyError);

--- a/tests/selection.cpp
+++ b/tests/selection.cpp
@@ -388,6 +388,28 @@ TEST_CASE("Multiple selections") {
 
         CHECK_THROWS_AS(selection.list(frame), SelectionError);
     }
+
+    SECTION("Properties") {
+        auto selection = Selection("[numeric] == 3");
+        CHECK(selection.list(frame) == std::vector<size_t>{0ul});
+
+        selection = Selection("[bool] and all");
+        CHECK(selection.list(frame) == std::vector<size_t>{1ul});
+
+        // No distinction between missing value and false value
+        selection = Selection("not [bool]");
+        CHECK(selection.list(frame) == (std::vector<size_t>{0ul, 2ul, 3ul}));
+
+        selection = Selection("[string] == foo");
+        CHECK(selection.list(frame) == std::vector<size_t>{2ul});
+
+        // No distinction between missing value and false value
+        selection = Selection("[string] != foo");
+        CHECK(selection.list(frame) == (std::vector<size_t>{0ul, 1ul, 3ul}));
+
+        selection = Selection("[\"string space\"] == \"foo bar\"");
+        CHECK(selection.list(frame) == std::vector<size_t>{3ul});
+    }
 }
 
 Frame testing_frame() {
@@ -401,6 +423,13 @@ Frame testing_frame() {
     frame.add_bond(0, 1);
     frame.add_bond(1, 2);
     frame.add_bond(2, 3);
+
+    frame[0].set("numeric", 3);
+    frame[1].set("bool", true);
+    frame[2].set("bool", false);
+    frame[2].set("string", "foo");
+    frame[3].set("string", "bar");
+    frame[3].set("string space", "foo bar");
 
     auto residue = Residue("resime", 3);
     residue.add_atom(2);

--- a/tests/selections/lexer.cpp
+++ b/tests/selections/lexer.cpp
@@ -25,15 +25,17 @@ TEST_CASE("Tokens") {
         auto token = Token::ident("blabla");
         REQUIRE(token.type() == Token::IDENT);
         CHECK(token.ident() == "blabla");
-        CHECK(token.str() == "blabla");
+        CHECK(token.as_str() == "blabla");
 
         CHECK_THROWS_AS(token.number(), Error);
         CHECK_THROWS_AS(token.variable(), Error);
+    }
 
-        token = Token::raw_ident("blabla");
-        REQUIRE(token.type() == Token::RAW_IDENT);
-        CHECK(token.ident() == "blabla");
-        CHECK(token.str() == "\"blabla\"");
+    SECTION("Strings") {
+        auto token = Token::string("blabla");
+        REQUIRE(token.type() == Token::STRING);
+        CHECK(token.string() == "blabla");
+        CHECK(token.as_str() == "\"blabla\"");
 
         CHECK_THROWS_AS(token.number(), Error);
         CHECK_THROWS_AS(token.variable(), Error);
@@ -102,8 +104,8 @@ TEST_CASE("Lexing") {
         for (std::string id: {"\"\"", "\"id_3nt___\"", "\"and\"", "\"3.2\""}) {
             auto tokens = tokenize(id);
             CHECK(tokens.size() == 2);
-            CHECK(tokens[0].type() == Token::RAW_IDENT);
-            CHECK(tokens[0].ident() == id.substr(1, id.size() - 2));
+            CHECK(tokens[0].type() == Token::STRING);
+            CHECK(tokens[0].string() == id.substr(1, id.size() - 2));
             CHECK(tokens[1].type() == Token::END);
         }
     }

--- a/tests/selections/lexer.cpp
+++ b/tests/selections/lexer.cpp
@@ -4,6 +4,8 @@
 #include <catch.hpp>
 #include "chemfiles/selections/lexer.hpp"
 
+#include <iostream>
+
 using namespace chemfiles;
 using namespace chemfiles::selections;
 
@@ -150,6 +152,27 @@ TEST_CASE("Lexing") {
         CHECK(tokens[1].type() == Token::RPAREN);
     }
 
+    SECTION("Brackets") {
+        CHECK(tokenize("[")[0].type() == Token::LBRACKET);
+        CHECK(tokenize("]")[0].type() == Token::RBRACKET);
+
+        auto tokens = tokenize("[bagyu");
+        CHECK(tokens.size() == 3);
+        CHECK(tokens[0].type() == Token::LBRACKET);
+
+        tokens = tokenize("]qbisbszlh");
+        CHECK(tokens.size() == 3);
+        CHECK(tokens[0].type() == Token::RBRACKET);
+
+        tokens = tokenize("jsqsb[");
+        CHECK(tokens.size() == 3);
+        CHECK(tokens[1].type() == Token::LBRACKET);
+
+        tokens = tokenize("kjpqhiufn]");
+        CHECK(tokens.size() == 3);
+        CHECK(tokens[1].type() == Token::RBRACKET);
+    }
+
     SECTION("Operators") {
         CHECK(tokenize("and")[0].type() == Token::AND);
         CHECK(tokenize("or")[0].type() == Token::OR);
@@ -195,6 +218,18 @@ TEST_CASE("Lexing errors") {
         "_not_an_id",
         "3not_an_id",
         "§", // Not accepted characters
+        "`",
+        "!",
+        "&",
+        "|",
+        "@",
+        "#",
+        "~",
+        "{",
+        "}",
+        "_",
+        "\\",
+        "=",
         "è",
         "à",
         "ü",
@@ -202,12 +237,6 @@ TEST_CASE("Lexing errors") {
         "ζ",
         "Ｒ", // weird full width UTF-8 character
         "形",
-        "`",
-        "!",
-        "&",
-        "|",
-        "#",
-        "@",
         "# 9",
         "9.2.5",
     };

--- a/tests/selections/parser.cpp
+++ b/tests/selections/parser.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Parsing") {
         CHECK(parse("type goo")->print() == "type(#1) == goo");
         CHECK(parse("type(#3) goo")->print() == "type(#3) == goo");
         CHECK(parse("type != goo")->print() == "type(#1) != goo");
-        CHECK(parse("type == \"45\"")->print() == "type(#1) == 45");
+        CHECK(parse("type == \"45\"")->print() == "type(#1) == \"45\"");
 
         CHECK(parse("type goo")->print() == "type(#1) == goo");
         auto ast = "or -> type(#1) == goo\n   -> type(#1) == foo";
@@ -102,8 +102,8 @@ TEST_CASE("Parsing") {
         CHECK(parse("name goo")->print() == "name(#1) == goo");
         CHECK(parse("name(#3) goo")->print() == "name(#3) == goo");
         CHECK(parse("name != goo")->print() == "name(#1) != goo");
-        CHECK(parse("name \"45\"")->print() == "name(#1) == 45");
-        CHECK(parse("name \"名\"")->print() == "name(#1) == 名");
+        CHECK(parse("name \"45\"")->print() == "name(#1) == \"45\"");
+        CHECK(parse("name \"名\"")->print() == "name(#1) == \"名\"");
 
         CHECK(parse("name goo")->print() == "name(#1) == goo");
         auto ast = "or -> name(#1) == goo\n   -> name(#1) == foo";
@@ -136,7 +136,7 @@ TEST_CASE("Parsing") {
         CHECK(parse("resname goo")->print() == "resname(#1) == goo");
         CHECK(parse("resname(#3) goo")->print() == "resname(#3) == goo");
         CHECK(parse("resname != goo")->print() == "resname(#1) != goo");
-        CHECK(parse("resname \"45\"")->print() == "resname(#1) == 45");
+        CHECK(parse("resname \"45\"")->print() == "resname(#1) == \"45\"");
 
         CHECK(parse("resname goo")->print() == "resname(#1) == goo");
         auto ast = "or -> resname(#1) == goo\n   -> resname(#1) == foo";

--- a/tests/selections/parser.cpp
+++ b/tests/selections/parser.cpp
@@ -88,6 +88,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("type != goo")->print() == "type(#1) != goo");
         CHECK(parse("type == \"45\"")->print() == "type(#1) == 45");
 
+        CHECK(parse("type goo")->print() == "type(#1) == goo");
+        auto ast = "or -> type(#1) == goo\n   -> type(#1) == foo";
+        CHECK(parse("type goo foo")->print() == ast);
+
         CHECK_THROWS_AS(parse("type < bar"), SelectionError);
         CHECK_THROWS_AS(parse("type >= bar"), SelectionError);
     }
@@ -100,6 +104,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("name != goo")->print() == "name(#1) != goo");
         CHECK(parse("name \"45\"")->print() == "name(#1) == 45");
         CHECK(parse("name \"名\"")->print() == "name(#1) == 名");
+
+        CHECK(parse("name goo")->print() == "name(#1) == goo");
+        auto ast = "or -> name(#1) == goo\n   -> name(#1) == foo";
+        CHECK(parse("name goo foo")->print() == ast);
 
         CHECK_THROWS_AS(parse("name < bar"), SelectionError);
         CHECK_THROWS_AS(parse("name >= bar"), SelectionError);
@@ -115,6 +123,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("index != 12")->print() == "index(#1) != 12");
         CHECK(parse("index >= 42.3")->print() == "index(#1) >= 42.300000");
 
+        CHECK(parse("index 4")->print() == "index(#1) == 4");
+        auto ast = "or -> index(#1) == 4\n   -> index(#1) == 3";
+        CHECK(parse("index 4 3")->print() == ast);
+
         CHECK_THROWS_AS(parse("index == bar"), SelectionError);
     }
 
@@ -125,6 +137,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("resname(#3) goo")->print() == "resname(#3) == goo");
         CHECK(parse("resname != goo")->print() == "resname(#1) != goo");
         CHECK(parse("resname \"45\"")->print() == "resname(#1) == 45");
+
+        CHECK(parse("resname goo")->print() == "resname(#1) == goo");
+        auto ast = "or -> resname(#1) == goo\n   -> resname(#1) == foo";
+        CHECK(parse("resname goo foo")->print() == ast);
 
         CHECK_THROWS_AS(parse("resname < bar"), SelectionError);
         CHECK_THROWS_AS(parse("resname >= bar"), SelectionError);
@@ -140,6 +156,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("resid != 12")->print() == "resid(#1) != 12");
         CHECK(parse("resid >= 42.3")->print() == "resid(#1) >= 42.300000");
 
+        CHECK(parse("resid 4")->print() == "resid(#1) == 4");
+        auto ast = "or -> resid(#1) == 4\n   -> resid(#1) == 3";
+        CHECK(parse("resid 4 3")->print() == ast);
+
         CHECK_THROWS_AS(parse("resid == bar"), SelectionError);
     }
 
@@ -151,6 +171,10 @@ TEST_CASE("Parsing") {
 
         CHECK(parse("mass <= 42")->print() == "mass(#1) <= 42");
         CHECK(parse("mass != 12")->print() == "mass(#1) != 12");
+
+        CHECK(parse("mass 4")->print() == "mass(#1) == 4");
+        auto ast = "or -> mass(#1) == 4\n   -> mass(#1) == 3";
+        CHECK(parse("mass 4 3")->print() == ast);
 
         CHECK_THROWS_AS(parse("mass <= bar"), SelectionError);
     }
@@ -164,6 +188,10 @@ TEST_CASE("Parsing") {
         CHECK(parse("vx == 4")->print() == "vx(#1) == 4");
         CHECK(parse("vy < 4")->print() == "vy(#1) < 4");
         CHECK(parse("vz >= 4")->print() == "vz(#1) >= 4");
+
+        CHECK(parse("x 4")->print() == "x(#1) == 4");
+        auto ast = "or -> x(#1) == 4\n   -> x(#1) == 3";
+        CHECK(parse("x 4 3")->print() == ast);
 
         CHECK_THROWS_AS(parse("x <= bar"), SelectionError);
         CHECK_THROWS_AS(parse("vy > bar"), SelectionError);


### PR DESCRIPTION
This PR contains a bit of cleaning for the selection code (4 first commits) and then implement the use of properties in selections, as discussed in #178.

The syntax used is `[<property>]`, e.g. `[is_hetatm]`, `[chainid]`, etc. Properties with spaces are supported with quotes: `["why not?"]`

For multiple atoms, the variable part comes after the closing bracket `[chainid](#3)`.

Because there is no way to know whether we are parsing a property to be evaluated as a boolean, a string or a number, the parser try to find the one that matches by the context: if the property is followed by 'and' or 'or', then use it as a boolean. If it is followed by a string; `==` or `!=` and then a string, use it as a string. Else use it as a number. Then, during the selection evaluation, and error is thrown if a property with this name exist but has the wrong type.

Finally, missing properties are evaluated to `false` for boolean properties (which prevent making a difference between missing properties and properties set to false); to an empty string for string properties; and to NaN for numeric properties. `Vector3D` properties are not supported.

## Unresolved questions:

- [ ] What should the syntax be for variables? `[short](#3)` and `["long prop"](#3)` or `[short(#3)]` and `["long prop"(#3)]`
- [ ] Should missing numeric properties evaluate to 0 instead of NaN?

## TODO

- [x] Documentation
- [x] Changelog