### PR TITLE
Set Sphinx version to avoid bug in 1.8.0

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx >1.6.1
+sphinx==1.7.9
 breathe >4.7
 sphinx_bootstrap_theme


### PR DESCRIPTION
Sphinx v1.8.0 launched today around noon. Apparently, there is a bug in this version that causes the documentation build for Chemfiles to fail. I am forcing the Sphinx version to be set at 1.7.9.

Note: I have not submitted a bug upstream, but we should consider doing so.