### PR TITLE
Fix mutliple bugs in shared allocator

### DIFF
--- a/src/shared_allocator.cpp
+++ b/src/shared_allocator.cpp
@@ -1,6 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 #include "chemfiles/shared_allocator.hpp"
+using namespace chemfiles;
 
 // define the global allocator instance
-chemfiles::shared_allocator chemfiles::shared_allocator::instance_;
+mutex<shared_allocator> shared_allocator::instance_;

--- a/src/shared_allocator.cpp
+++ b/src/shared_allocator.cpp
@@ -3,4 +3,4 @@
 #include "chemfiles/shared_allocator.hpp"
 
 // define the global allocator instance
-shared_allocator shared_allocator::instance_;
+chemfiles::shared_allocator chemfiles::shared_allocator::instance_;

--- a/tests/capi/doc/chfl_frame/guess_bonds.c
+++ b/tests/capi/doc/chfl_frame/guess_bonds.c
@@ -24,7 +24,7 @@ int main() {
 
     chfl_frame_guess_bonds(frame);
 
-    // Get a copie of the new topology
+    // Get the new topology
     topology = chfl_topology_from_frame(frame);
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 1);

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -268,6 +268,14 @@ TEST_CASE("chfl_frame") {
         CHECK(name == std::string(""));
         CHECK_STATUS(chfl_atom_free(atom));
 
+        // Get the same atom twice
+        CHFL_ATOM* first = chfl_atom_from_frame(frame, 1);
+        CHFL_ATOM* second = chfl_atom_from_frame(frame, 1);
+        REQUIRE(first);
+        REQUIRE(second);
+        CHECK_STATUS(chfl_atom_free(first));
+        CHECK_STATUS(chfl_atom_free(second));
+
         // Out of bounds access
         atom = chfl_atom_from_frame(frame, 10000);
         CHECK_FALSE(atom);


### PR DESCRIPTION
Some of these appear when using chemfiles from multiple threads at once, which is the case by default of Rust tests. 