### PR TITLE
Additional PDB fixes

### DIFF
--- a/doc/src/properties/atom.toml
+++ b/doc/src/properties/atom.toml
@@ -1,22 +1,3 @@
-[is_hetatm]
-type = "bool"
-
-PDB = """When reading, **is_hetatm** is set to ``true`` for atoms defined with a
-``HETATM`` record, and ``false`` for atoms defined with an ``ATOM`` record.
-When writing, **is_hetatm** is used to determine whether to emit an ``HETATM``
-or an ``ATOM`` record. If the property is not set, ``HETATM`` is used."""
-
-MMTF = """When reading, **is_hetatm** is set to ``false`` when the
-``composition_type`` for the group is related to peptide or nucleotide
-linkage. See the ``composition_type`` property for residues for more
-information. This property is ignored while writing."""
-
-mmCIF = """When reading, **is_hetatm** is set to ``true`` when
-``_atom_site.group_PDB`` is ``HETATM``, and ``false`` when it is ``ATOM``. When
-writing, **is_hetatm** is used to determine whether to use ``HETATM`` or
-``ATOM`` for ``_atom_site.group_PDB``. If the property is not set, ``ATOM`` is
-used."""
-
 [altloc]
 type = "string"
 

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -6,6 +6,7 @@ GRO = "The first line of a GRO file is used as the frame **name** when reading."
 SDF = "The first line of an SDF file is used as the frame **name** when reading."
 MOL2 = "The first line after ``@<TRIPOS>MOLECULE`` is used as the frame **name** when reading."
 MMTF = "The text in the ``title`` field is used as the frame **name** when reading."
+mmCIF = "The text in the ``_struct.title`` field is used as the frame **name** when reading."
 
 [classification]
 type = "string"
@@ -17,6 +18,7 @@ type = "string"
 
 PDB = "Four letter code for structures deposited in the PDB. Read from the ``HEADER`` record."
 MMTF = "Four letter code for structures deposited in the PDB. Read from the ``structuresId`` field."
+mmCIF = "Four letter code for structures deposited in the PDB. Read from the ``_entry.id`` field."
 
 [deposition_date]
 type = "string"

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -1,6 +1,22 @@
 [name]
 type = "string"
 
+PDB = "The text described by the ``TITLE `` record is used as the frame **name** when reading."
 GRO = "The first line of a GRO file is used as the frame **name** when reading."
 SDF = "The first line of an SDF file is used as the frame **name** when reading."
 MOL2 = "The first line after ``@<TRIPOS>MOLECULE`` is used as the frame **name** when reading."
+
+[classification]
+type = "string"
+
+PDB = "The classification of a structure assigned by the PDB. Read from the ``HEADER`` record."
+
+[pdb_idcode]
+type = "string"
+
+PDB = "Four letter code for structures deposited in the PDB. Read from the ``HEADER`` record."
+
+[deposition_date]
+type = "string"
+
+PDB = "Date (DD-MMM-YY format) of the deposition in the PDB. Read from the ``HEADER`` record."

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -5,6 +5,7 @@ PDB = "The text described by the ``TITLE `` record is used as the frame **name**
 GRO = "The first line of a GRO file is used as the frame **name** when reading."
 SDF = "The first line of an SDF file is used as the frame **name** when reading."
 MOL2 = "The first line after ``@<TRIPOS>MOLECULE`` is used as the frame **name** when reading."
+MMTF = "The text in the ``title`` field is used as the frame **name** when reading."
 
 [classification]
 type = "string"
@@ -15,8 +16,10 @@ PDB = "The classification of a structure assigned by the PDB. Read from the ``HE
 type = "string"
 
 PDB = "Four letter code for structures deposited in the PDB. Read from the ``HEADER`` record."
+MMTF = "Four letter code for structures deposited in the PDB. Read from the ``structuresId`` field."
 
 [deposition_date]
 type = "string"
 
 PDB = "Date (DD-MMM-YY format) of the deposition in the PDB. Read from the ``HEADER`` record."
+MMTF = "Date (YYYY-MM-DD format) of the deposition in the PDB. Read from the ``depositionDate`` field."

--- a/doc/src/properties/residue.toml
+++ b/doc/src/properties/residue.toml
@@ -1,3 +1,23 @@
+[is_standard_pdb]
+type = "bool"
+
+PDB = """When reading, **is_standard_pdb** is set to ``true`` for residues 
+defined with a ``ATOM`` record, and ``false`` for atoms defined with an
+``HETATM`` record. When writing, **is_standard_pdb** is used to determine
+whether to emit an ``HETATM`` or an ``ATOM`` record. If the property is not set,
+``HETATM`` is used."""
+
+MMTF = """When reading, **is_standard_pdb** is set to ``false`` when the
+``composition_type`` for the group is related to peptide or nucleotide
+linkage. See the ``composition_type`` property for residues for more
+information. This property is ignored while writing."""
+
+mmCIF = """When reading, **is_standard_pdb** is set to ``true`` when
+``_atom_site.group_PDB`` is ``ATOM``, ``false`` when it is ``HETATM``, and is
+unset in the absense of this field. When writing, **is_standard_pdb** is used
+to determine whether to use ``ATOM`` or ``HETATM`` for ``_atom_site.group_PDB``.
+If the property is not set, ``HETATM`` is used."""
+
 [chainname]
 type = "string"
 

--- a/doc/src/properties/residue.toml
+++ b/doc/src/properties/residue.toml
@@ -90,3 +90,20 @@ residue. This code is stored as a single character in the PDB file after the
 residue id. If this character is a space character, the property is not set. On
 writing, this character is stored with the ``ATOM`` or ``HETATM`` record. If the
 property is not set, a space character is used."""
+
+[secondary_structure]
+type = "string"
+
+PDB = """On reading, the **secondary_structure** is assigned via ``HELIX``,
+``SHEET``, and ``TURN`` records. If a residue is listed in a ``SHEET`` record,
+then the **secondary_structure** is set to ``extended``. Similarly, the ``TURN``
+record will set residues as ``turn``. The ``HELIX`` record is more complex as
+the `PDB` standard allows for multiple types of helicies include ``alpha``,
+``pi``, and ``3-10`` helicies. This property is not used for writing."""
+
+MMTF = """On reading, the **secondary_structure** is assigned via the
+``secStructList`` field in the ``MMTF`` standard. The values assigned match the
+descriptions by the *Define Secondary Strucutre of Proteins (DSSP)* algorithm.
+Examples include ``extended``, ``alpha helix``, ``pi helix``, ``turn`` and
+``coil``. This property is not set for undefined secondary structures and is not
+used for writing.

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -5,6 +5,7 @@
 #define CHEMFILES_FORMAT_PDB_HPP
 
 #include <map>
+#include <vector>
 
 #include "chemfiles/Format.hpp"
 #include "chemfiles/File.hpp"
@@ -53,6 +54,9 @@ private:
     std::vector<std::streampos> steps_positions_;
     /// Number of models written/read to the file.
     size_t models_;
+    /// List of all atom offsets. This maybe pushed in read_ATOM or if a TER
+    /// record is found. It is reset every time a frame is read.
+    std::vector<size_t> atom_offsets_;
     /// Did we wrote a frame to the file? This is used to check wheter we need
     /// to write a final `END` record in the destructor
     bool written_ = false;

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <vector>
+#include <tuple>
 
 #include "chemfiles/Format.hpp"
 #include "chemfiles/File.hpp"
@@ -42,13 +43,14 @@ private:
     void read_CRYST1(Frame& frame, const std::string& line);
     // Read ATOM and HETATM records
     void read_ATOM(Frame& frame, const std::string& line, bool is_hetatm);
-
+    // Read HELIX records
+    void read_HELIX(const std::string& line);
     // Read CONECT record
     void read_CONECT(Frame& frame, const std::string& line);
 
     std::unique_ptr<TextFile> file_;
-    /// Map of residues, indexed by residue id.
-    std::map<size_t, Residue> residues_;
+    /// Map of residues, indexed by residue id and chainid.
+    std::map<std::pair<char, size_t>, Residue> residues_;
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekg` them instead of reading the whole step.
     std::vector<std::streampos> steps_positions_;
@@ -60,6 +62,8 @@ private:
     /// Did we wrote a frame to the file? This is used to check wheter we need
     /// to write a final `END` record in the destructor
     bool written_ = false;
+    /// Store secondary structure information
+    std::vector<std::tuple<char, size_t, size_t, std::string>> secinfo_;
 };
 
 template<> FormatInfo format_information<PDBFormat>();

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -43,8 +43,11 @@ private:
     void read_CRYST1(Frame& frame, const std::string& line);
     // Read ATOM and HETATM records
     void read_ATOM(Frame& frame, const std::string& line, bool is_hetatm);
-    // Read HELIX records
+    // Read secondary structure records. All push secinfo_ vector if line is valid
     void read_HELIX(const std::string& line);
+    // reads SHEET and TURN records. i1 and i2 are the indicies of the chain ids
+    void read_secondary(const std::string& line, size_t i1, size_t i2,
+                        const std::string& sec);
     // Read CONECT record
     void read_CONECT(Frame& frame, const std::string& line);
 
@@ -62,7 +65,8 @@ private:
     /// Did we wrote a frame to the file? This is used to check wheter we need
     /// to write a final `END` record in the destructor
     bool written_ = false;
-    /// Store secondary structure information
+    /// Store secondary structure information. First field is the chainid,
+    /// followed by the first and last residue id in the secondary structure.
     std::vector<std::tuple<char, size_t, size_t, std::string>> secinfo_;
 };
 

--- a/include/chemfiles/formats/mmCIF.hpp
+++ b/include/chemfiles/formats/mmCIF.hpp
@@ -42,6 +42,9 @@ private:
     size_t models_;
     /// Number of atoms written to the file.
     size_t atoms_;
+    /// Frame properties need to be stored
+    std::string name_;
+    std::string pdb_idcode_;
 };
 
 template<> FormatInfo format_information<mmCIFFormat>();

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -190,6 +190,8 @@ void MMTFFormat::read(Frame& frame) {
             }
 
             if (groupIndex_ < structure_.secStructList.size()) {
+                // We use the raw values here to directly match the MMTF spec
+                // See https://github.com/rcsb/mmtf/blob/master/spec.md#secstructlist
                 switch(structure_.secStructList[groupIndex_]) {
                     case 0:
                         residue.set("secondary_structure", "pi helix");

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -189,6 +189,37 @@ void MMTFFormat::read(Frame& frame) {
                 );
             }
 
+            if (groupIndex_ < structure_.secStructList.size()) {
+                switch(structure_.secStructList[groupIndex_]) {
+                    case 0:
+                        residue.set("secondary_structure", "pi helix");
+                        break;
+                    case 1:
+                        residue.set("secondary_structure", "bend");
+                        break;
+                    case 2:
+                        residue.set("secondary_structure", "alpha helix");
+                        break;
+                    case 3:
+                        residue.set("secondary_structure", "extended");
+                        break;
+                    case 4:
+                        residue.set("secondary_structure", "3-10 helix");
+                        break;
+                    case 5:
+                        residue.set("secondary_structure", "bridge");
+                        break;
+                    case 6:
+                        residue.set("secondary_structure", "turn");
+                        break;
+                    case 7:
+                        residue.set("secondary_structure", "coil");
+                        break;
+                    default:
+                        break;
+                }
+            }
+
             // If the name of the current assembly is defined in the MMTF file.
             // Bioassemblies are optional, however.
             if (!current_assembly.empty()) {

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -131,6 +131,7 @@ void MMTFFormat::read(Frame& frame) {
             auto groupId = static_cast<size_t>(structure_.groupIdList[groupIndex_]);
             auto residue = Residue(group.groupName, groupId);
             residue.set("composition_type", group.chemCompType);
+            residue.set("is_standard_pdb", !mmtf::is_hetatm(group.chemCompType.c_str()));
 
             // Save the offset before we go changing it
             size_t atomOffset = atomIndex_ - atomSkip_;
@@ -153,7 +154,6 @@ void MMTFFormat::read(Frame& frame) {
                     structure_.yCoordList[atomIndex_],
                     structure_.zCoordList[atomIndex_]
                 );
-                atom.set("is_hetatm", mmtf::is_hetatm(group.chemCompType.c_str()));
                 frame.add_atom(atom, position);
                 residue.add_atom(atomIndex_ - atomSkip_);
                 atomIndex_++;

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -92,6 +92,18 @@ void MMTFFormat::read(Frame& frame) {
         ));
     }
 
+    if (!mmtf::isDefaultValue(structure_.title)) {
+        frame.set("name", structure_.title);
+    }
+
+    if (!mmtf::isDefaultValue(structure_.structureId)) {
+        frame.set("pdb_idcode", structure_.structureId);
+    }
+
+    if (!mmtf::isDefaultValue(structure_.depositionDate)) {
+        frame.set("deposition_date", structure_.depositionDate);
+    }
+
     auto modelChainCount = static_cast<size_t>(structure_.chainsPerModel[modelIndex_]);
     for (size_t j = 0; j < modelChainCount; j++) {
         auto chainGroupCount = static_cast<size_t>(structure_.groupsPerChain[chainIndex_]);

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -272,6 +272,7 @@ void PDBFormat::read_CONECT(Frame& frame, const std::string& line) {
             auto lower = std::lower_bound(atom_offsets_.begin(),
                                           atom_offsets_.end(), pdb_atom_id);
             pdb_atom_id -= static_cast<size_t>(lower - atom_offsets_.begin());
+            pdb_atom_id -= atom_offsets_.front();
             return pdb_atom_id;
         } catch (std::invalid_argument&) {
             throw format_error("could not read atomic number in '{}'", line);

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -70,6 +70,11 @@ PDBFormat::PDBFormat(std::string path, File::Mode mode, File::Compression compre
         }
     }
     file_->rewind();
+
+    // Needed in case there's no end records 
+    if (steps_positions_.empty()) {
+        steps_positions_.push_back(file_->tellg());
+    }
 }
 
 size_t PDBFormat::nsteps() {

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -209,15 +209,19 @@ void PDBFormat::read_ATOM(Frame& frame, const std::string& line,
         );
     }
 
-    if (atom_offsets_.size() == 0) {
+    if (atom_offsets_.empty()) {
         try {
-            auto initial_offset = std::stoul(line.substr(6,5));
-            if (initial_offset == 0) {
-                throw format_error("0 is not a valid atom id.");
+            auto initial_offset = std::stol(line.substr(6,5));
+            // We need to handle negative numbers ourselves: https://ideone.com/RdINqa
+            if (initial_offset <= 0) {
+                warning("{} is too small, assuming id is '1'", initial_offset);
+                atom_offsets_.push_back(0);
+            } else {
+                atom_offsets_.push_back(static_cast<size_t>(initial_offset) - 1);
             }
-            atom_offsets_.push_back(initial_offset - 1);
         } catch(std::invalid_argument&) {
-            throw format_error("{} is not a valid atom id.", line.substr(6,5));
+            warning("{} is not a valid atom id, assuming '1'", line.substr(6,5));
+			atom_offsets_.push_back(0);
         }
     }
 

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -99,8 +99,8 @@ mmCIFFormat::mmCIFFormat(std::string path, File::Mode mode, File::Compression co
 
         if (line_split[0] == "_struct.title") {
             auto temp_name = trim(line.substr(13));
-            std::copy(temp_name.begin() + 1, temp_name.end() - 1,
-                std::back_inserter(name_));
+            name_ = temp_name.size() > 2 ?
+                    temp_name.substr(1, temp_name.size() - 2) : "";
         }
 
         if (in_loop && line_split[0].find("_atom_site") != std::string::npos) {
@@ -202,11 +202,11 @@ void mmCIFFormat::read(Frame& frame) {
     frame.resize(0);
     residues_.clear();
 
-    if (name_.size()) {
+    if (name_ != "") {
         frame.set("name", name_);
     }
 
-    if (pdb_idcode_.size()) {
+    if (pdb_idcode_ != "") {
         frame.set("pdb_idcode", pdb_idcode_);
     }
 

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -1,8 +1,6 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
-#include <algorithm>
-
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "29c49929cd4937027072237e06ed6771391b31bb")
+set(TESTS_DATA_GIT "943cdbd7217e0b327647da3740de6dba67af440d")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=c8ef0c21ee59f91efdfcbb459ba3d46fc87c88e6
+        EXPECTED_HASH SHA1=90fcb8bfed69fbed5968419515a6b46a741813a7
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "943cdbd7217e0b327647da3740de6dba67af440d")
+set(TESTS_DATA_GIT "dee3659fad8106611a9fd0f0a5ee4596f7fb869d")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=90fcb8bfed69fbed5968419515a6b46a741813a7
+        EXPECTED_HASH SHA1=4e89a1782a93544c76cd32acd3f9f4401bcdf8fe
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/mmcif.cpp
+++ b/tests/formats/mmcif.cpp
@@ -133,6 +133,10 @@ TEST_CASE("Read files in mmCIF format") {
         Trajectory file("data/cif/1j8k.cif", 'r', "mmCIF");
         auto frame = file.read();
 
+        CHECK(frame.get("name")->as_string() ==
+              "NMR STRUCTURE OF THE FIBRONECTIN EDA DOMAIN, NMR, 20 STRUCTURES");
+        CHECK(frame.get("pdb_idcode")->as_string() == "1J8K");
+
         size_t count = 1;
         while (!file.done()) {
             frame = file.read();

--- a/tests/formats/mmcif.cpp
+++ b/tests/formats/mmcif.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Read files in mmCIF format") {
         auto residue = *frame.topology().residue_for_atom(4557);
         CHECK(residue.size() == 43);
         CHECK(residue.name() == "HEM");
-        CHECK(frame[4557].get("is_hetatm")->as_bool()); // Should be a hetatm
+        CHECK(residue.get("is_standard_pdb")->as_bool() == false);
 
         // Check residue connectivity
         const auto& topo = frame.topology();
@@ -119,7 +119,7 @@ TEST_CASE("Read files in mmCIF format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(-5.106, 16.212, 4.562), 1e-3));
         CHECK(approx_eq(positions[1401], Vector3D(5.601, -22.571, -16.631), 1e-3));
-        CHECK(!frame[0].get("is_hetatm")->as_bool());
+        CHECK(frame.topology().residue(0).get("is_standard_pdb")->as_bool());
 
         // Rewind
         frame = file.read_step(1);
@@ -191,11 +191,11 @@ TEST_CASE("Write mmCIF file") {
     "HETATM 1     A  A    .   . .    .    1.000    2.000    3.000 0 . 1\n"
     "ATOM   2     B  B    . foo ?    2    1.000    2.000    3.000 0 . 1\n"
     "ATOM   3     C  C    . foo ?    2    1.000    2.000    3.000 0 . 1\n"
-    "ATOM   4     D  D    . bar G    ?    1.000    2.000    3.000 0 A 1\n"
+    "HETATM 4     D  D    . bar G    ?    1.000    2.000    3.000 0 A 1\n"
     "HETATM 5     A  A    .   . .    .    4.000    5.000    6.000 0 . 2\n"
     "ATOM   6     B  B    . foo ?    2    1.000    2.000    3.000 0 . 2\n"
     "ATOM   7     C  C    . foo ?    2    1.000    2.000    3.000 0 . 2\n"
-    "ATOM   8     D  D    . bar G    ?    1.000    2.000    3.000 0 A 2\n";
+    "HETATM 8     D  D    . bar G    ?    1.000    2.000    3.000 0 A 2\n";
 
 
     auto frame = Frame(UnitCell(22));
@@ -204,11 +204,10 @@ TEST_CASE("Write mmCIF file") {
     frame.add_atom(Atom("C"), {1, 2, 3});
     frame.add_atom(Atom("D"), {1, 2, 3});
 
-    frame[0].set("is_hetatm", true);
-
     auto res = Residue("foo",2);
     res.add_atom(1);
     res.add_atom(2);
+    res.set("is_standard_pdb", true);
     frame.add_residue(std::move(res));
 
     res = Residue("bar");

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(residue.size() == 43);
         CHECK(residue.name() == "HEM");
         CHECK(residue.get("composition_type")->as_string() == "NON-POLYMER");
-        CHECK(frame[4557].get("is_hetatm")->as_bool()); // Should be a hetatm
+        CHECK(!residue.get("is_standard_pdb")->as_bool()); // Should be a hetatm
 
         // Nitrogen-Iron Bond
         CHECK(frame.topology().bond_order(4557, 4556) == Bond::SINGLE);
@@ -105,11 +105,13 @@ TEST_CASE("Read files in MMTF format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(-5.106, 16.212, 4.562), 1e-3));
         CHECK(approx_eq(positions[1401], Vector3D(5.601, -22.571, -16.631), 1e-3));
-        CHECK(!frame[0].get("is_hetatm")->as_bool());
 
         const auto& topo = frame.topology();
         CHECK(topo.are_linked(topo.residue(0), topo.residue(1)));
         CHECK(!topo.are_linked(topo.residue(0), topo.residue(2)));
+        CHECK(topo.residue(0).get("is_standard_pdb")->as_bool());
+        CHECK(topo.residue(1).get("is_standard_pdb")->as_bool());
+        CHECK(topo.residue(2).get("is_standard_pdb")->as_bool());
 
         frame = file.read_step(1);
         CHECK(frame.size() == 1402);

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -14,6 +14,13 @@ TEST_CASE("Read files in MMTF format") {
         Trajectory file("data/mmtf/4HHB.mmtf");
         Frame frame = file.read();
 
+        // Check frame properties
+        CHECK(frame.get("name")->as_string() ==
+              "THE CRYSTAL STRUCTURE OF HUMAN DEOXYHAEMOGLOBIN AT 1.74 "
+              "ANGSTROMS RESOLUTION");
+        CHECK(frame.get("deposition_date")->as_string() == "1984-03-07");
+        CHECK(frame.get("pdb_idcode")->as_string() == "4HHB");
+
         // If comparing to the RCSB-PDB file,
         // remember that TER increases the number of atoms
         CHECK(frame.size() == 4779);

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -49,6 +49,7 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(residue.name() == "HEM");
         CHECK(residue.get("composition_type")->as_string() == "NON-POLYMER");
         CHECK(!residue.get("is_standard_pdb")->as_bool()); // Should be a hetatm
+        CHECK(residue.get("secondary_structure") == nullopt);
 
         // Nitrogen-Iron Bond
         CHECK(frame.topology().bond_order(4557, 4556) == Bond::SINGLE);
@@ -95,6 +96,13 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(water_res2.get("chainid")->as_string() == "L");
         CHECK(water_res2.get("chainname")->as_string() == "B");
         CHECK(water_res2.get("chainindex")->as_double() == 11 );
+
+        // Check the secondary structure
+        CHECK(topo.residue(05).get("secondary_structure")->as_string() == "alpha helix");
+        CHECK(topo.residue(18).get("secondary_structure")->as_string() == "turn");
+        CHECK(topo.residue(36).get("secondary_structure")->as_string() == "3-10 helix");
+        CHECK(topo.residue(45).get("secondary_structure")->as_string() == "bend");
+        CHECK(topo.residue(143).get("secondary_structure")->as_string() == "coil");
     }
 
     SECTION("Skip steps") {
@@ -123,6 +131,9 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(topo2.are_linked(topo.residue(0), topo2.residue(1)));
         CHECK(!topo2.are_linked(topo.residue(0), topo2.residue(2)));
         CHECK(topo.residue(0).get("composition_type")->as_string() == "L-PEPTIDE LINKING");
+
+        // Check secondary structure
+        CHECK(topo.residue(10).get("secondary_structure")->as_string() == "extended");
     }
 
     SECTION("Successive steps") {

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -214,7 +214,8 @@ TEST_CASE("Read files in PDB format") {
 TEST_CASE("Problematic PDB files") {
     auto file = Trajectory("data/pdb/bad/atomid.pdb");
     CHECK(file.nsteps() == 1);
-    CHECK_THROWS(file.read());
+    auto frame = file.read();
+    CHECK(frame.size() == 2);
 }
 
 TEST_CASE("Write files in PDB format") {

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -128,6 +128,18 @@ TEST_CASE("Read files in PDB format") {
         }
     }
 
+    SECTION("Handle multiple TER records") {
+        Trajectory file("data/pdb/4hhb.pdb");
+        auto frame = file.read();
+
+        CHECK(frame[4556].name() == "ND");
+        CHECK(frame[4557].name() == "FE");
+        CHECK(frame.topology().bond_order(4556, 4557) == 0);
+
+        // The original behavior stored this, it is incorrect
+        CHECK_THROWS(frame.topology().bond_order(4561, 4560));
+    }
+
     SECTION("Handle multiple END records") {
         Trajectory file("data/pdb/end-endmdl.pdb");
         CHECK(file.nsteps() == 2);

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -140,6 +140,17 @@ TEST_CASE("Read files in PDB format") {
         CHECK_THROWS(frame.topology().bond_order(4561, 4560));
     }
 
+    SECTION("Handle odd PDB numbering") {
+        Trajectory file("data/pdb/odd-start.pdb");
+        auto frame = file.read();
+
+        CHECK(frame.size() == 20);
+        CHECK(frame[0].name() == "C1");
+        CHECK(frame[19].name() == "C18");
+        CHECK(frame.topology().bond_order(0, 1) == 0);
+        CHECK(frame.topology().bond_order(19, 13) == 0);
+    }
+
     SECTION("Handle multiple END records") {
         Trajectory file("data/pdb/end-endmdl.pdb");
         CHECK(file.nsteps() == 2);

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -155,6 +155,11 @@ TEST_CASE("Read files in PDB format") {
 
         // The original behavior stored this, it is incorrect
         CHECK_THROWS(frame.topology().bond_order(4561, 4560));
+
+        // Check secondary structure
+        auto& topo = frame.topology();
+        CHECK(topo.residue(05).get("secondary_structure")->as_string() == "alpha helix");
+        CHECK(topo.residue(36).get("secondary_structure")->as_string() == "alpha helix");
     }
 
     SECTION("Handle odd PDB numbering") {

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -211,6 +211,12 @@ TEST_CASE("Read files in PDB format") {
     }
 }
 
+TEST_CASE("Problematic PDB files") {
+    auto file = Trajectory("data/pdb/bad/atomid.pdb");
+    CHECK(file.nsteps() == 1);
+    CHECK_THROWS(file.read());
+}
+
 TEST_CASE("Write files in PDB format") {
     auto tmpfile = NamedTempPath(".pdb");
     const auto EXPECTED_CONTENT =

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -91,6 +91,24 @@ TEST_CASE("Read files in PDB format") {
         Frame frame = file.read();
     }
 
+    SECTION("Read frame properties") {
+        Trajectory file1("data/pdb/2hkb.pdb");
+        auto frame = file1.read();
+        CHECK(frame.get("classification")->as_string() == "DNA");
+        CHECK(frame.get("deposition_date")->as_string() == "03-JUL-06");
+        CHECK(frame.get("pdb_idcode")->as_string() == "2HKB");
+        CHECK(frame.get("name")->as_string() ==
+              "NMR STRUCTURE OF THE B-DNA DODECAMER CTCGGCGCCATC");
+
+        Trajectory file2("data/pdb/4hhb.pdb");
+        frame = file2.read();
+        CHECK(frame.get("classification")->as_string() == "OXYGEN TRANSPORT");
+        CHECK(frame.get("deposition_date")->as_string() == "07-MAR-84");
+        CHECK(frame.get("pdb_idcode")->as_string() == "4HHB");
+        CHECK(frame.get("name")->as_string() ==
+              "THE CRYSTAL STRUCTURE OF HUMAN DEOXYHAEMOGLOBIN AT 1.74 ANGSTROMS RESOLUTION");
+    }
+
     SECTION("Read residue information") {
         Trajectory file("data/pdb/water.pdb");
         Frame frame = file.read();


### PR DESCRIPTION
The purpose of this PR is a few fold:
 - [X] Fix issue #207 
 - [x] Fix issue #210
 - [x] Add secondary structure information stored in PDB/MMTF files.
 - [x] Read frame properties from PDB files, like `HEADER`, `TITLE`, etc.
 - [x] Add corresponding properties from mmCIF and MMTF where applicable.