### PR TITLE
Improve residue id handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ script:
   # Run various additional checks
   - ./scripts/ci/check-capi-docs.py
   - ./scripts/ci/check-public-headers.py
+  - ./scripts/ci/lint-code.py
   # Build docs
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -22,7 +22,7 @@ struct atom_data final {
     double mass = std::numeric_limits<double>::quiet_NaN();
     size_t index = 0;
     size_t type = 0;
-    size_t molid = static_cast<size_t>(-1);
+    size_t molid = 0;
 };
 
 /// Possible LAMMPS atom style
@@ -44,7 +44,7 @@ private:
 public:
     atom_style(const std::string& name);
     /// Read a single line with this atom style
-    atom_data read_line(const std::string& line) const;
+    atom_data read_line(const std::string& line, size_t index) const;
 };
 
 // atom types are defined by the type string and the mass of the atom

--- a/scripts/ci/lint-code.py
+++ b/scripts/ci/lint-code.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+"""
+This script check for some functions we don't want to use because they are
+better wrappers in chemfiles
+"""
+import os
+import sys
+from glob import glob
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ERRORS = 0
+
+FUNCTIONS = {
+    'stof': 'parse<double>',
+    'stod': 'parse<double>',
+    'stold': 'parse<double>',
+    'stoi': 'parse<long long>',
+    'stol': 'parse<long long>',
+    'stoll': 'parse<long long>',
+    'stoul': 'parse<size_t>',
+    'stoull': 'parse<size_t>',
+}
+
+
+def error(message):
+    global ERRORS
+    ERRORS += 1
+    print(message)
+
+
+def check_code(path):
+    with open(path) as fd:
+        for i, line in enumerate(fd):
+            for bad, replacement in FUNCTIONS.items():
+                if bad in line:
+                    error("Please replace '{}' by '{}' at {}:{}".format(
+                        bad, replacement, os.path.relpath(path), i
+                    ))
+
+
+if __name__ == '__main__':
+    for file in glob(os.path.join(ROOT, "include", "chemfiles", "*.hpp")):
+        if file.endswith("utils.hpp"):
+            continue
+        check_code(file)
+
+    for file in glob(os.path.join(ROOT, "include", "chemfiles", "*", "*.hpp")):
+        check_code(file)
+
+    for file in glob(os.path.join(ROOT, "src", "*.cpp")):
+        check_code(file)
+
+    for file in glob(os.path.join(ROOT, "src", "*", "*.cpp")):
+        check_code(file)
+
+    if ERRORS != 0:
+        sys.exit(1)

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -54,18 +54,13 @@ void GROFormat::read_step(const size_t step, Frame& frame) {
 }
 
 void GROFormat::read(Frame& frame) {
-    long count = 0;
+    size_t natoms = 0;
     try {
         frame.set("name", (file_->readline())); // GRO comment line;
-        count = std::stol(file_->readline());
-    } catch (const std::exception& e) {
+        natoms = parse<size_t>(file_->readline());
+    } catch (const Error& e) {
         throw format_error("can not read next step as GRO: {}", e.what());
     }
-
-    if (count < 0) {
-        throw format_error("the number of atoms can not be negative in GRO format");
-    }
-    auto natoms = static_cast<size_t>(count);
 
     residues_.clear();
     frame.add_velocities();
@@ -80,74 +75,72 @@ void GROFormat::read(Frame& frame) {
             );
         }
 
-        auto resid = std::stoul(line.substr(0,5));
-
-        std::string resname = line.substr(5, 5);
-
-        std::string atomname= line.substr(10,5);
+        size_t resid = SIZE_MAX;
+        try {
+            resid = parse<size_t>(line.substr(0, 5));
+        } catch (const Error&) {
+            // Invalid residue, we'll skip it
+        }
+        auto resname = trim(line.substr(5, 5));
+        auto name = trim(line.substr(10, 5));
 
         // GRO files store atoms in NM, we need to convert to Angstroms
-        auto x = string2double(line.substr(20,8)) * 10;
-        auto y = string2double(line.substr(28,8)) * 10;
-        auto z = string2double(line.substr(36,8)) * 10;
+        auto x = parse<double>(line.substr(20, 8)) * 10;
+        auto y = parse<double>(line.substr(28, 8)) * 10;
+        auto z = parse<double>(line.substr(36, 8)) * 10;
 
         if (line.length() >= 68) {
-            auto vx = string2double(line.substr(44,8)) * 10;
-            auto vy = string2double(line.substr(52,8)) * 10;
-            auto vz = string2double(line.substr(60,8)) * 10;
+            auto vx = parse<double>(line.substr(44, 8)) * 10;
+            auto vy = parse<double>(line.substr(52, 8)) * 10;
+            auto vz = parse<double>(line.substr(60, 8)) * 10;
 
-            frame.add_atom(Atom(trim(atomname)),
+            frame.add_atom(Atom(name),
                 Vector3D(x, y, z),
                 Vector3D(vx, vy, vz)
             );
         } else {
-            frame.add_atom(Atom(trim(atomname)),
+            frame.add_atom(Atom(name),
                 Vector3D(x, y, z)
             );
         }
 
-        auto cf_atomid = frame.size() - 1;
-        try {
+        if (resid != SIZE_MAX) {
             if (residues_.find(resid) == residues_.end()) {
-                Residue residue(trim(resname), resid);
-                residue.add_atom(cf_atomid);
+                Residue residue(resname, resid);
+                residue.add_atom(frame.size() - 1);
 
                 residues_.insert({resid, residue});
             } else {
                 // Just add this atom to the residue
-                residues_.at(resid).add_atom(cf_atomid);
+                residues_.at(resid).add_atom(frame.size() - 1);
             }
-        } catch (std::invalid_argument&) {
-            // No residue information
         }
-
     }
 
     std::string box = file_->readline();
     auto box_values = split(box, ' ');
 
     if (box_values.size() == 3) {
-
-        auto a = string2double(box_values[0]) * 10;
-        auto b = string2double(box_values[1]) * 10;
-        auto c = string2double(box_values[2]) * 10;
+        auto a = parse<double>(box_values[0]) * 10;
+        auto b = parse<double>(box_values[1]) * 10;
+        auto c = parse<double>(box_values[2]) * 10;
 
         auto cell = UnitCell(a, b, c);
         frame.set_cell(cell);
     } else if (box_values.size() == 9) {
-        auto v1_x = string2double(box_values[0]) * 10;
-        auto v2_y = string2double(box_values[1]) * 10;
-        auto v3_z = string2double(box_values[2]) * 10;
+        auto v1_x = parse<double>(box_values[0]) * 10;
+        auto v2_y = parse<double>(box_values[1]) * 10;
+        auto v3_z = parse<double>(box_values[2]) * 10;
 
-        assert(string2double(box_values[3]) == 0);
-        assert(string2double(box_values[4]) == 0);
+        assert(parse<double>(box_values[3]) == 0);
+        assert(parse<double>(box_values[4]) == 0);
 
-        auto v2_x = string2double(box_values[5]) * 10;
+        auto v2_x = parse<double>(box_values[5]) * 10;
 
-        assert(string2double(box_values[6]) == 0);
+        assert(parse<double>(box_values[6]) == 0);
 
-        auto v3_x = string2double(box_values[7]) * 10;
-        auto v3_y = string2double(box_values[8]) * 10;
+        auto v3_x = parse<double>(box_values[7]) * 10;
+        auto v3_y = parse<double>(box_values[8]) * 10;
 
         auto H = Matrix3D(
             v1_x, v2_x, v3_x,
@@ -165,7 +158,7 @@ void GROFormat::read(Frame& frame) {
 }
 
 static std::string to_gro_index(uint64_t i) {
-    if (i + 1 >= 100000) {
+    if (i >= 99999) {
         warning("Too many atoms for GRO format, removing atomic id");
         return "*****";
     } else {
@@ -178,20 +171,20 @@ void GROFormat::write(const Frame& frame) {
     fmt::print(*file_, "{: >5d}\n", frame.size());
 
     // Only use numbers bigger than the biggest residue id as "resSeq" for
-    // atoms without associated residue.
-    uint64_t max_resid = 0;
+    // atoms without associated residue, and start generated residue id at
+    // 1
+    uint64_t max_resid = 1;
     for (const auto& residue: frame.topology().residues()) {
         auto resid = residue.id();
         if (resid && resid.value() > max_resid) {
-            max_resid = resid.value();
+            max_resid = resid.value() + 1;
         }
     }
 
     auto& positions = frame.positions();
     for (size_t i = 0; i < frame.size(); i++) {
-
-        std::string resname;
-        std::string resid;
+        std::string resname = "XXXXX";
+        std::string resid = "-1";
         auto residue = frame.topology().residue_for_atom(i);
         if (residue) {
             resname = residue->name();
@@ -202,30 +195,20 @@ void GROFormat::write(const Frame& frame) {
                 );
                 resname = resname.substr(0, 5);
             }
+        }
 
-            if (residue->id()) {
-                auto value = residue->id().value();
-                if (value > 99999) {
-                    warning("Too many residues for GRO format, removing residue id");
-                    resid = "  -1";
-                } else {
-                    resid = std::to_string(residue->id().value());
-                }
-            } else { // We need to assign a residue ID
-                auto value = max_resid++;
-                if (value < 99999) {
-                    resid = to_gro_index(value);
-                } else {
-                    resid = "  -1";
-                }
+        if (residue && residue->id()) {
+            auto value = residue->id().value();
+            if (value <= 99999) {
+                resid = std::to_string(value);
+            } else {
+                warning("Too many residues for GRO format, removing residue id");
             }
         } else {
-            resname = "XXXXX";
+            // We need to manually assign a residue ID
             auto value = max_resid++;
-            if (value < 99999) {
-                resid = to_gro_index(value);
-            } else {
-                resid = "  -1";
+            if (value <= 99999) {
+                resid = std::to_string(value);
             }
         }
 
@@ -289,28 +272,21 @@ void check_values_size(const Vector3D& values, unsigned width, const std::string
 bool forward(TextFile& file) {
     if (!file) {return false;}
 
-    long long natoms = 0;
+    size_t natoms = 0;
     try {
         // Skip the comment line
         file.readline();
-        auto line = file.readline();
-        natoms = string2longlong(line);
+        natoms = parse<size_t>(file.readline());
     } catch (const FileError&) {
         // No more line left in the file
         return false;
-    } catch (const std::invalid_argument&) {
+    } catch (const Error&) {
         // We could not read an integer, so give up here
         return false;
     }
 
-    if (natoms < 0) {
-        throw format_error(
-            "number of atoms can not be negative in '{}'", file.path()
-        );
-    }
-
     try {
-        file.readlines(static_cast<size_t>(natoms) + 1);
+        file.readlines(natoms + 1);
     } catch (const FileError&) {
         // We could not read the lines from the file
         throw format_error(

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -63,11 +63,11 @@ void MOL2Format::read(Frame& frame) {
 
     const auto counts = split(line, ' ');
 
-    long long natoms = string2longlong(counts[0]);
-    long long nbonds = 0;
+    size_t natoms = parse<size_t>(counts[0]);
+    size_t nbonds = 0;
 
     if (counts.size() >= 2) {
-        nbonds = string2longlong(counts[1]);
+        nbonds = parse<size_t>(counts[1]);
     }
 
     residues_.clear();
@@ -130,7 +130,7 @@ void MOL2Format::read_atoms(Frame& frame, size_t natoms, bool charges) {
 
         std::string atom_type;
         bool is_sybyl;
-    
+
         if (std::string(sybyl_type).find('.') != std::string::npos || find_in_periodic_table(sybyl_type)) {
             auto my_split = split(sybyl_type, '.');
             atom_type = my_split[0];
@@ -232,18 +232,10 @@ std::streampos forward(TextFile& file) {
             auto line = file.readline();
 
             const auto counts = split(line, ' ');
-
-            long long natoms, nbonds = 0;
-            natoms = string2longlong(counts[0]);
-
-            if (natoms < 0) {
-                throw format_error(
-                    "number of atoms can not be negative in '{}'", file.path()
-                );
-            }
-
+            auto natoms = parse<size_t>(counts[0]);
+            size_t nbonds = 0;
             if (counts.size() >= 2) {
-                nbonds = string2longlong(counts[1]);
+                nbonds = parse<size_t>(counts[1]);
             }
 
             read_until(file, "@<TRIPOS>ATOM");
@@ -259,7 +251,7 @@ std::streampos forward(TextFile& file) {
             file.readlines(static_cast<size_t>(nbonds));
 
             return pos;
-        } catch (const FileError&) {
+        } catch (const Error&) {
             return {-1};
         }
     }

--- a/src/formats/Tinker.cpp
+++ b/src/formats/Tinker.cpp
@@ -164,7 +164,7 @@ void TinkerFormat::write(const Frame& frame) {
 bool forward(TextFile& file) {
     if (!file) {return false;}
 
-    long long natoms = 0;
+    size_t natoms = 0;
     try {
         auto line = file.readline();
         if (trim(line) == "") {
@@ -172,26 +172,20 @@ bool forward(TextFile& file) {
             return false;
         } else {
             // Get the number of atoms in the line
-            natoms = std::stoll(split(trim(line), ' ')[0]);
+            natoms = parse<size_t>(split(trim(line), ' ')[0]);
         }
     } catch (const FileError&) {
         // No more line left in the file
         return false;
-    } catch (const std::invalid_argument&) {
+    } catch (const Error&) {
         // We could not read an integer, so give up here
         return false;
-    }
-
-    if (natoms < 0) {
-        throw format_error(
-            "number of atoms can not be negative in '{}'", file.path()
-        );
     }
 
     try {
         auto line = file.readline();
         // Minus one because we just read a line.
-        size_t lines_to_skip = static_cast<size_t>(natoms) - 1;
+        size_t lines_to_skip = natoms - 1;
 
         // This is how tinker does it to check if there is unit cell information
         // in the file, so let's follow them here.

--- a/src/selections/lexer.cpp
+++ b/src/selections/lexer.cpp
@@ -195,14 +195,14 @@ Token Tokenizer::variable() {
             break;
         }
     }
-    int data = 0;
+    size_t data = 0;
     auto number = input_.substr(start, count);
     try {
-        data = std::stoi(number);
+        data = parse<size_t>(number);
     } catch (const std::exception&) {
         throw selection_error("could not parse number in '{}'", number);
     }
-    if (data > UINT8_MAX) {
+    if (data > static_cast<size_t>(UINT8_MAX)) {
         throw selection_error("variable index #{} is too big for uint8_t", data);
     } else if (data == 0) {
         throw selection_error("invalid variable index #0");
@@ -298,7 +298,7 @@ Token Tokenizer::number() {
 
     double value = 0;
     try {
-        value = string2double(input_.substr(start, count));
+        value = parse<double>(input_.substr(start, count));
     } catch (const Error& e) {
         throw SelectionError(e.what());
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "dee3659fad8106611a9fd0f0a5ee4596f7fb869d")
+set(TESTS_DATA_GIT "f5262a3d603fd68db8e93e3cb228454096d79cf8")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=4e89a1782a93544c76cd32acd3f9f4401bcdf8fe
+        EXPECTED_HASH SHA1=c318ecc037fbc16c029dfd896c07e863c6027ef9
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/lammps-data.cpp
+++ b/tests/formats/lammps-data.cpp
@@ -93,6 +93,31 @@ TEST_CASE("Read files in LAMMPS data format") {
         CHECK(fabs(cell.gamma() - 81.634113876) < 1e-9);
         CHECK(cell.shape() == UnitCell::TRICLINIC);
     }
+
+    SECTION("Molecule ids") {
+        auto file = Trajectory("data/lammps-data/molid.lmp", 'r', "LAMMPS Data");
+        auto frame = file.read();
+
+        CHECK(frame.size() == 12);
+        CHECK(frame.topology().residues().size() == 3);
+
+        auto& topology = frame.topology();
+        CHECK_FALSE(topology.residue_for_atom(0));
+        CHECK_FALSE(topology.residue_for_atom(1));
+        CHECK_FALSE(topology.residue_for_atom(2));
+
+        CHECK(topology.residue_for_atom(3)->contains(4));
+        CHECK(topology.residue_for_atom(3)->contains(5));
+        CHECK(topology.residue_for_atom(3)->id().value() == 1);
+
+        CHECK(topology.residue_for_atom(6)->contains(7));
+        CHECK(topology.residue_for_atom(6)->contains(8));
+        CHECK(topology.residue_for_atom(6)->id().value() == 2);
+
+        CHECK(topology.residue_for_atom(9)->contains(10));
+        CHECK(topology.residue_for_atom(9)->contains(11));
+        CHECK(topology.residue_for_atom(9)->id().value() == 3);
+    }
 }
 
 TEST_CASE("Write files in LAMMPS data format") {

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -39,16 +39,32 @@ TEST_CASE("split") {
     CHECK(chemfiles::split(",,bla  bla, jk:fiuks", ',') == expected);
 }
 
-TEST_CASE("String to double") {
-    CHECK(chemfiles::string2double("12.5") == 12.5);
-    CHECK(chemfiles::string2longlong("125") == 125);
-    CHECK(chemfiles::string2longlong("-32") == -32);
+TEST_CASE("String parsing") {
+    SECTION("Double") {
+        CHECK(chemfiles::parse<double>("12.5") == 12.5);
+        CHECK(chemfiles::parse<double>("125") == 125);
+        CHECK(chemfiles::parse<double>("-32") == -32);
 
-    CHECK_THROWS_AS(chemfiles::string2double("foo"), chemfiles::Error);
-    CHECK_THROWS_AS(chemfiles::string2double("1,2"), chemfiles::Error);
-    CHECK_THROWS_AS(chemfiles::string2double("3e456782"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<double>("foo"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<double>("1,2"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<double>("3e456782"), chemfiles::Error);
+    }
 
-    CHECK_THROWS_AS(chemfiles::string2longlong("foo"), chemfiles::Error);
-    CHECK_THROWS_AS(chemfiles::string2longlong("2.5"), chemfiles::Error);
-    CHECK_THROWS_AS(chemfiles::string2longlong("9223372036854775808"), chemfiles::Error);
+    SECTION("long long") {
+        CHECK(chemfiles::parse<long long>("125") == 125);
+        CHECK(chemfiles::parse<long long>("-32") == -32);
+
+        CHECK_THROWS_AS(chemfiles::parse<long long>("foo"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<long long>("2.5"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<long long>("9223372036854775808"), chemfiles::Error);
+    }
+
+    SECTION("size_t") {
+        CHECK(chemfiles::parse<size_t>("125") == 125);
+
+        CHECK_THROWS_AS(chemfiles::parse<size_t>("-32"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<size_t>("foo"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<size_t>("2.5"), chemfiles::Error);
+        CHECK_THROWS_AS(chemfiles::parse<size_t>("9223372036854775808"), chemfiles::Error);
+    }
 }


### PR DESCRIPTION
This PR came from an issue where converting LAMMPS Data to PDB would create a warning about residue id 18446744073709551615 (size_t(-1)).

So the commits fix the LAMMPS Data reader wrt molecule id, and force usage of the same function for all parsing of string to numeric types, checking that the parsed value fit in the given type.