### PR TITLE
Use the shared allocator for all C API pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added `chfl_{atom,frame,residue}_properties_count` and
   `chfl_{atom,frame,residue}_list_properties` to list all properties in an
   Atom/Frame/Residue
+* Replaced `chfl_*_free` by an unique `chfl_free` function
 
 ## 0.8 (14 Dec 2017)
 

--- a/doc/src/capi/chfl_atom.rst
+++ b/doc/src/capi/chfl_atom.rst
@@ -29,7 +29,6 @@
     - :cpp:func:`chfl_atom_get_property`
     - :cpp:func:`chfl_atom_properties_count`
     - :cpp:func:`chfl_atom_list_properties`
-    - :cpp:func:`chfl_atom_free`
 
     --------------------------------------------------------------------
 
@@ -73,5 +72,3 @@
 .. doxygenfunction:: chfl_atom_properties_count
 
 .. doxygenfunction:: chfl_atom_list_properties
-
-.. doxygenfunction:: chfl_atom_free

--- a/doc/src/capi/chfl_cell.rst
+++ b/doc/src/capi/chfl_cell.rst
@@ -22,7 +22,6 @@
     - :cpp:func:`chfl_cell_shape`
     - :cpp:func:`chfl_cell_set_shape`
     - :cpp:func:`chfl_cell_wrap`
-    - :cpp:func:`chfl_cell_free`
 
     --------------------------------------------------------------------
 
@@ -53,5 +52,3 @@
 .. doxygenfunction:: chfl_cell_set_shape
 
 .. doxygenfunction:: chfl_cell_wrap
-
-.. doxygenfunction:: chfl_cell_free

--- a/doc/src/capi/chfl_frame.rst
+++ b/doc/src/capi/chfl_frame.rst
@@ -8,7 +8,7 @@
 .. only:: html
 
     Here is the full list of functions acting on :cpp:type:`CHFL_FRAME`:
-    
+
     - :cpp:func:`chfl_frame`
     - :cpp:func:`chfl_frame_copy`
     - :cpp:func:`chfl_frame_atoms_count`
@@ -36,7 +36,6 @@
     - :cpp:func:`chfl_frame_get_property`
     - :cpp:func:`chfl_frame_properties_count`
     - :cpp:func:`chfl_frame_list_properties`
-    - :cpp:func:`chfl_frame_free`
 
     --------------------------------------------------------------------
 
@@ -93,5 +92,3 @@
 .. doxygenfunction:: chfl_frame_properties_count
 
 .. doxygenfunction:: chfl_frame_list_properties
-
-.. doxygenfunction:: chfl_frame_free

--- a/doc/src/capi/chfl_property.rst
+++ b/doc/src/capi/chfl_property.rst
@@ -18,7 +18,6 @@
     - :cpp:func:`chfl_property_get_double`
     - :cpp:func:`chfl_property_get_string`
     - :cpp:func:`chfl_property_get_vector3d`
-    - :cpp:func:`chfl_property_free`
 
     --------------------------------------------------------------------
 
@@ -39,5 +38,3 @@
 .. doxygenfunction:: chfl_property_get_string
 
 .. doxygenfunction:: chfl_property_get_vector3d
-
-.. doxygenfunction:: chfl_property_free

--- a/doc/src/capi/chfl_residue.rst
+++ b/doc/src/capi/chfl_residue.rst
@@ -24,7 +24,6 @@
     - :cpp:func:`chfl_residue_get_property`
     - :cpp:func:`chfl_residue_properties_count`
     - :cpp:func:`chfl_residue_list_properties`
-    - :cpp:func:`chfl_residue_free`
 
     --------------------------------------------------------------------
 
@@ -57,5 +56,3 @@
 .. doxygenfunction:: chfl_residue_properties_count
 
 .. doxygenfunction:: chfl_residue_list_properties
-
-.. doxygenfunction:: chfl_residue_free

--- a/doc/src/capi/chfl_selection.rst
+++ b/doc/src/capi/chfl_selection.rst
@@ -15,7 +15,6 @@
     - :cpp:func:`chfl_selection_string`
     - :cpp:func:`chfl_selection_evaluate`
     - :cpp:func:`chfl_selection_matches`
-    - :cpp:func:`chfl_selection_free`
 
     --------------------------------------------------------------------
 
@@ -31,7 +30,6 @@
 
 .. doxygenfunction:: chfl_selection_matches
 
-.. doxygenfunction:: chfl_selection_free
 
 .. doxygenstruct:: chfl_match
     :members:

--- a/doc/src/capi/chfl_topology.rst
+++ b/doc/src/capi/chfl_topology.rst
@@ -32,7 +32,6 @@
     - :cpp:func:`chfl_topology_bond_with_order`
     - :cpp:func:`chfl_topology_bond_orders`
     - :cpp:func:`chfl_topology_bond_order`
-    - :cpp:func:`chfl_topology_free`
 
     --------------------------------------------------------------------
 
@@ -81,5 +80,3 @@
 .. doxygenfunction:: chfl_topology_bond_orders
 
 .. doxygenfunction:: chfl_topology_bond_order
-
-.. doxygenfunction:: chfl_topology_free

--- a/doc/src/capi/index.rst
+++ b/doc/src/capi/index.rst
@@ -18,8 +18,10 @@ following opaque pointer types:
 
 The user is reponsible for memory management when using these types.
 Constructors functions (functions returning pointers to types defined above)
-return freshly allocated memory, and calling the ``chfl_*_free`` functions
+return freshly allocated memory, and calling the :cpp:func:`chfl_free` function
 return the corresponding memory to the operating system.
+
+.. doxygenfunction:: chfl_free
 
 .. doxygentypedef:: chfl_vector3d
 

--- a/examples/c/generate.c
+++ b/examples/c/generate.c
@@ -18,15 +18,15 @@ int main() {
 
     CHFL_CELL* cell = chfl_cell((chfl_vector3d){10, 10, 10});
     chfl_frame_set_cell(frame, cell);
-    chfl_cell_free(cell);
+    chfl_free(cell);
 
     CHFL_TRAJECTORY* trajectory = chfl_trajectory_open("water.pdb", 'w');
     chfl_trajectory_write(trajectory, frame);
     chfl_trajectory_close(trajectory);
 
-    chfl_frame_free(frame);
-    chfl_atom_free(H);
-    chfl_atom_free(O);
+    chfl_free(frame);
+    chfl_free(H);
+    chfl_free(O);
 
     return 0;
 }

--- a/examples/c/indexes.c
+++ b/examples/c/indexes.c
@@ -30,7 +30,7 @@ int main() {
     }
 
     free(less_than_five);
-    chfl_frame_free(frame);
+    chfl_free(frame);
     chfl_trajectory_close(file);
 
     return 0;

--- a/examples/c/select.c
+++ b/examples/c/select.c
@@ -39,6 +39,11 @@ int main() {
         free(matches);
     }
 
+    chfl_free(frame);
+    chfl_free(selection);
+    chfl_trajectory_close(input);
+    chfl_trajectory_close(output);
+
     return 0;
 }
 

--- a/include/chemfiles/capi/atom.h
+++ b/include/chemfiles/capi/atom.h
@@ -12,55 +12,52 @@ extern "C" {
 /// Create an atom with the given `name`, and set the atom type to `name`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_atom_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/chfl_atom.c}
-/// @return A pointer to the atom, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the atom, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom(const char* name);
 
 /// Get a copy of an `atom`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_atom_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/copy.c}
-/// @return A pointer to the new atom, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the new atom, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom_copy(const CHFL_ATOM* atom);
 
 /// Get access to the atom at the given `index` from a `frame`.
 ///
 /// Any modification to the atom will be reflected in the `frame`. The `frame`
-/// will be kept alive, even if `chfl_frame_free` is called, until
-/// `chfl_atom_free` is also called on the pointer returned by this function.
+/// will be kept alive, even if `chfl_free` is called, until `chfl_free` is also
+/// called on the pointer returned by this function.
 ///
 /// The pointer returned by this function points directly inside the frame, and
-/// will be invalidated if any of the following function is called on the
-/// frame:
+/// will be invalidated if any of the following function is called on the frame:
 ///
 /// - `chfl_frame_resize`
 /// - `chfl_frame_add_atom`
 /// - `chfl_frame_remove`
 /// - `chfl_frame_set_topology`
 ///
-/// Calling any function on an invalidated pointer is undefined behavior.
-/// Even if the pointer if invalidated, it stills needs to be released with
-/// `chfl_atom_free`.
+/// Calling any function on an invalidated pointer is undefined behavior. Even
+/// if the pointer if invalidated, it stills needs to be released with
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/from_frame.c}
 ///
-/// @return A pointer to the atom, or NULL in case of error or if `index` is
-///         out of bounds. You can use `chfl_last_error` to learn about the
-///         error.
+/// @return A pointer to the atom, or NULL in case of error or if `index` is out
+///         of bounds. You can use `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom_from_frame(CHFL_FRAME* frame, uint64_t index);
 
 /// Get access to the atom at the given `index` from a `topology`
 ///
 /// Any modification to the atom will be reflected in the `topology`. The
-/// `topology` will be kept alive, even if `chfl_topology_free` is called,
-/// until `chfl_atom_free` is also called on the pointer returned by this
-/// function.
+/// `topology` will be kept alive, even if `chfl_free` is called, until
+/// `chfl_free` is also called on the pointer returned by this function.
 ///
 /// The pointer returned by this function points directly inside the topology,
 /// and will be invalidated if any of the following function is called on the
@@ -70,14 +67,13 @@ CHFL_EXPORT CHFL_ATOM* chfl_atom_from_frame(CHFL_FRAME* frame, uint64_t index);
 /// - `chfl_topology_add_atom`
 /// - `chfl_topology_remove`
 ///
-/// Calling any function on an invalidated pointer is undefined behavior.
-/// Even if the pointer if invalidated, it stills needs to be released with
-/// `chfl_atom_free`.
+/// Calling any function on an invalidated pointer is undefined behavior. Even
+/// if the pointer if invalidated, it stills needs to be released with
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_atom/from_topology.c}
-/// @return A pointer to the atom, or NULL in case of error or if `index` is
-///         out of bounds. You can use `chfl_last_error` to learn about the
-///         error.
+/// @return A pointer to the atom, or NULL in case of error or if `index` is out
+///         of bounds. You can use `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_ATOM* chfl_atom_from_topology(
     CHFL_TOPOLOGY* topology, uint64_t index
 );
@@ -244,20 +240,14 @@ CHFL_EXPORT chfl_status chfl_atom_set_property(
 /// This function returns `NULL` if no property exists with the given name.
 ///
 /// The user of this function is responsible to deallocate memory using the
-/// `chfl_property_free` function.
+/// `chfl_free` function.
 ///
 /// @example{tests/capi/doc/chfl_atom/property.c}
-/// @return A pointer to the property, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the property, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_PROPERTY* chfl_atom_get_property(
     const CHFL_ATOM* atom, const char* name
 );
-
-/// Free the memory associated with an `atom`.
-///
-/// @example{tests/capi/doc/chfl_atom/chfl_atom.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_atom_free(const CHFL_ATOM* atom);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/cell.h
+++ b/include/chemfiles/capi/cell.h
@@ -25,11 +25,11 @@ typedef enum {  // NOLINT: this is both a C and C++ file
 /// The cell lengths should be in Angstroms.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_cell_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_cell/chfl_cell.c}
-/// @return A pointer to the unit cell, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the unit cell, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_CELL* chfl_cell(const chfl_vector3d lengths);
 
 /// Create an unit cell from three `lengths` and three `angles`. The unit cell
@@ -42,45 +42,43 @@ CHFL_EXPORT CHFL_CELL* chfl_cell(const chfl_vector3d lengths);
 /// angle between `a` and `b`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_cell_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_cell/triclinic.c}
-/// @return A pointer to the unit cell, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the unit cell, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_CELL* chfl_cell_triclinic(
     const chfl_vector3d lengths, const chfl_vector3d angles
 );
 
 /// Get access to the cell of a `frame`
 ///
-/// Any modification to the cell will be reflected in the `frame`. The
-/// `frame` will be kept alive, even if `chfl_frame_free` is called,
-/// until `chfl_cell_free` is also called on the pointer returned by this
-/// function.
+/// Any modification to the cell will be reflected in the `frame`. The `frame`
+/// will be kept alive, even if `chfl_free` is called, until `chfl_free` is also
+/// called on the pointer returned by this function.
 ///
-/// The pointer returned by this function points directly inside the frame,
-/// and will be invalidated if any of the following function is called on the
-/// frame:
+/// The pointer returned by this function points directly inside the frame, and
+/// will be invalidated if any of the following function is called on the frame:
 ///
 /// - `chfl_frame_set_cell`
 ///
-/// Calling any function on an invalidated pointer is undefined behavior.
-/// Even if the pointer if invalidated, it stills needs to be released with
-/// `chfl_cell_free`.
+/// Calling any function on an invalidated pointer is undefined behavior. Even
+/// if the pointer if invalidated, it stills needs to be released with
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_cell/from_frame.c}
-/// @return A pointer to the unit cell, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the unit cell, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_CELL* chfl_cell_from_frame(CHFL_FRAME* frame);
 
 /// Get a copy of a `cell`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_cell_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_cell/copy.c}
-/// @return A pointer to the new cell, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the new cell, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_CELL* chfl_cell_copy(const CHFL_CELL* cell);
 
 /// Get the unit cell volume of `cell` in the double pointed to by `volume`.
@@ -178,12 +176,6 @@ CHFL_EXPORT chfl_status chfl_cell_set_shape(
 CHFL_EXPORT chfl_status chfl_cell_wrap(
     const CHFL_CELL* cell, chfl_vector3d vector
 );
-
-/// Free the memory associated with a `cell`.
-///
-/// @example{tests/capi/doc/chfl_cell/chfl_cell.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_cell_free(const CHFL_CELL* cell);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/frame.h
+++ b/include/chemfiles/capi/frame.h
@@ -12,7 +12,7 @@ extern "C" {
 /// Create a new empty frame.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_frame_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_frame/chfl_frame.c}
 /// @return A pointer to the frame, or NULL in case of error. You can use
@@ -22,11 +22,11 @@ CHFL_EXPORT CHFL_FRAME* chfl_frame(void);
 /// Get a copy of a `frame`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_frame_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_frame/copy.c}
-/// @return A pointer to the new frame, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the new frame, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT CHFL_FRAME* chfl_frame_copy(const CHFL_FRAME* frame);
 
 /// Get the current number of atoms in a `frame` in the integer pointed to by
@@ -47,9 +47,9 @@ CHFL_EXPORT chfl_status chfl_frame_atoms_count(
 ///
 /// If the frame is resized (by writing to it, or calling `chfl_frame_resize`,
 /// `chfl_frame_remove` or `chfl_frame_add_atom`), the pointer is invalidated.
-/// If the frame is freed using `chfl_frame_free`, the pointer is freed too.
-/// There is then no need to free the `*positions` pointer for the caller of
-/// this function.
+///
+/// If the frame memory is released using `chfl_free`, the memory behind the
+/// `*positions` pointer is released too.
 ///
 /// @example{tests/capi/doc/chfl_frame/positions.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn
@@ -61,18 +61,18 @@ CHFL_EXPORT chfl_status chfl_frame_positions(
 /// Get a pointer to the velocities array from a `frame`.
 ///
 /// Velocities are stored as a `size x 3` array, this function set the pointer
-/// pointed to by `positions` to point to the first element of this array, and
+/// pointed to by `velocities` to point to the first element of this array, and
 /// give the number of atoms in the integer pointed to by `size`.
 ///
 /// If the frame is resized (by writing to it, or calling `chfl_frame_resize`,
 /// `chfl_frame_remove` or `chfl_frame_add_atom`), the pointer is invalidated.
-/// If the frame is freed using `chfl_frame_free`, the pointer is freed too.
-/// There is then no need to free the `*velocity` pointer for the caller of this
-/// function.
 ///
-/// If the frame does not have velocity, this will return an error. Use
-/// `chfl_frame_add_velocities` to add velocities to a frame before calling
-/// this function.
+/// If the frame memory is released using `chfl_free`, the memory behind the
+/// `*velocities` pointer is released too.
+///
+/// If the frame does not have velocity, this will return an error. You can use
+/// `chfl_frame_add_velocities` to ensure that a frame contains velocity data
+/// before calling this function.
 ///
 /// @example{tests/capi/doc/chfl_frame/velocities.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn
@@ -277,7 +277,7 @@ CHFL_EXPORT chfl_status chfl_frame_set_property(
 /// This function returns `NULL` if no property exists with the given name.
 ///
 /// The user of this function is responsible to deallocate memory using the
-/// `chfl_property_free` function.
+/// `chfl_free` function.
 ///
 /// @example{tests/capi/doc/chfl_frame/property.c}
 /// @return A pointer to the property, or NULL in case of error.
@@ -328,12 +328,6 @@ CHFL_EXPORT chfl_status chfl_frame_remove_bond(
 CHFL_EXPORT chfl_status chfl_frame_add_residue(
     CHFL_FRAME* frame, const CHFL_RESIDUE* residue
 );
-
-/// Free the memory associated with a `frame`.
-///
-/// @example{tests/capi/doc/chfl_frame/chfl_frame.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_frame_free(const CHFL_FRAME* frame);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/property.h
+++ b/include/chemfiles/capi/property.h
@@ -24,7 +24,7 @@ typedef enum {  // NOLINT: this is both a C and C++ file
 /// Create a new property holding a boolean `value`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_property_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_property/bool.c}
 /// @return A pointer to the property, or NULL in case of error. You can use
@@ -34,7 +34,7 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_property_bool(bool value);
 /// Create a new property holding a double `value`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_property_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_property/double.c}
 /// @return A pointer to the property, or NULL in case of error. You can use
@@ -44,7 +44,7 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_property_double(double value);
 /// Create a new property holding a string `value`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_property_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_property/string.c}
 /// @return A pointer to the property, or NULL in case of error. You can use
@@ -54,7 +54,7 @@ CHFL_EXPORT CHFL_PROPERTY* chfl_property_string(const char* value);
 /// Create a new property holding a 3D vector `value`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_property_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_property/vector3d.c}
 /// @return A pointer to the property, or NULL in case of error. You can use
@@ -123,12 +123,6 @@ CHFL_EXPORT chfl_status chfl_property_get_string(
 CHFL_EXPORT chfl_status chfl_property_get_vector3d(
     const CHFL_PROPERTY* property, chfl_vector3d value
 );
-
-/// Free the memory associated with a `property`.
-///
-/// @example{tests/capi/doc/chfl_property/bool.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_property_free(const CHFL_PROPERTY* property);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/residue.h
+++ b/include/chemfiles/capi/residue.h
@@ -12,7 +12,7 @@ extern "C" {
 /// Create a new residue with the given `name`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_residue_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/chfl_residue.c}
 /// @return A pointer to the residue, or NULL in case of error.
@@ -22,7 +22,7 @@ CHFL_EXPORT CHFL_RESIDUE* chfl_residue(const char* name);
 /// Create a new residue with the given `name` and residue identifier `resid`.
 ///
 /// The caller of this function should free the allocated memory using
-/// `chfl_residue_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/with_id.c}
 /// @return A pointer to the residue, or NULL in case of error.
@@ -37,23 +37,18 @@ CHFL_EXPORT CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid)
 /// The residue index in the topology is not always the same as the residue
 /// `id`.
 ///
-/// The `topology` will be kept alive, even if `chfl_topology_free` is called,
-/// until `chfl_residue_free` is also called on the pointer returned by this
-/// function.
+/// The `topology` will be kept alive, even if `chfl_free(topology)` is called,
+/// until `chfl_free` is also called on the pointer returned by this function,
+/// unless the pointer returned by this function is `NULL`.
 ///
 /// The pointer returned by this function points directly inside the topology,
-/// and will be invalidated if any of the following function is called on the
-/// topology:
-///
-/// - `chfl_topology_add_residue`
-///
-/// Calling any function on an invalidated pointer is undefined behavior.
-/// Even if the pointer if invalidated, it stills needs to be released with
-/// `chfl_residue_free`.
+/// and will be invalidated if `chfl_topology_add_residue` is called. Calling
+/// any function on an invalidated pointer is undefined behavior. Even if the
+/// pointer if invalidated, it stills needs to be released with `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/from_topology.c}
-/// @return A pointer to the residue, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the residue, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_from_topology(
     const CHFL_TOPOLOGY* topology, uint64_t i
 );
@@ -64,23 +59,17 @@ CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_from_topology(
 /// This function will return `NULL` if the atom is not in a residue, or if the
 /// index `i` is bigger than `chfl_topology_atoms_count`.
 ///
-/// The `topology` will be kept alive, even if `chfl_topology_free` is called,
-/// until `chfl_residue_free` is also called on the pointer returned by this
-/// function.
+/// The `topology` will be kept alive, even if `chfl_free(topology)` is called,
+/// until `chfl_free` is also called on the pointer returned by this function.
 ///
 /// The pointer returned by this function points directly inside the topology,
-/// and will be invalidated if any of the following function is called on the
-/// topology:
-///
-/// - `chfl_topology_add_residue`
-///
-/// Calling any function on an invalidated pointer is undefined behavior.
-/// Even if the pointer if invalidated, it stills needs to be released with
-/// `chfl_residue_free`.
+/// and will be invalidated if `chfl_topology_add_residue` is called. Calling
+/// any function on an invalidated pointer is undefined behavior. Even if the
+/// pointer if invalidated, it stills needs to be released with `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/for_atom.c}
-/// @return A pointer to the residue, or NULL in case of error.
-///         You can use `chfl_last_error` to learn about the error.
+/// @return A pointer to the residue, or NULL in case of error. You can use
+///         `chfl_last_error` to learn about the error.
 CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_for_atom(
     const CHFL_TOPOLOGY* topology, uint64_t i
 );
@@ -88,7 +77,7 @@ CHFL_EXPORT const CHFL_RESIDUE* chfl_residue_for_atom(
 /// Get a copy of a `residue`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_residue_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_residue/copy.c}
 /// @return A pointer to the new residue, or NULL in case of error.
@@ -204,7 +193,7 @@ CHFL_EXPORT chfl_status chfl_residue_set_property(
 /// This function returns `NULL` if no property exists with the given name.
 ///
 /// The user of this function is responsible to deallocate memory using the
-/// `chfl_property_free` function.
+/// `chfl_free` function.
 ///
 /// @example{tests/capi/doc/chfl_residue/property.c}
 /// @return A pointer to the property, or NULL in case of error.
@@ -212,12 +201,6 @@ CHFL_EXPORT chfl_status chfl_residue_set_property(
 CHFL_EXPORT CHFL_PROPERTY* chfl_residue_get_property(
     const CHFL_RESIDUE* residue, const char* name
 );
-
-/// Free the memory associated with a `residue`.
-///
-/// @example{tests/capi/doc/chfl_residue/chfl_residue.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_residue_free(const CHFL_RESIDUE* residue);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/selection.h
+++ b/include/chemfiles/capi/selection.h
@@ -12,7 +12,7 @@ extern "C" {
 /// Create a new selection from the given `selection` string.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_selection_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_selection/chfl_selection.c}
 /// @return A pointer to the selection, or NULL in case of error.
@@ -25,7 +25,7 @@ CHFL_EXPORT CHFL_SELECTION* chfl_selection(const char* selection);
 /// called again before using `chfl_selection_matches`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_selection_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_selection/copy.c}
 /// @return A pointer to the new selection, or NULL in case of error.
@@ -97,12 +97,6 @@ typedef struct {  // NOLINT: this is both a C and C++ file
 CHFL_EXPORT chfl_status chfl_selection_matches(
     const CHFL_SELECTION* selection, chfl_match matches[], uint64_t n_matches
 );
-
-/// Free the memory associated with a `selection`.
-///
-/// @example{tests/capi/doc/chfl_selection/chfl_selection.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_selection_free(const CHFL_SELECTION* selection);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/topology.h
+++ b/include/chemfiles/capi/topology.h
@@ -12,7 +12,7 @@ extern "C" {
 /// Create a new empty topology.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_topology_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_topology/chfl_topology.c}
 /// @return A pointer to the topology, or NULL in case of error.
@@ -21,8 +21,8 @@ CHFL_EXPORT CHFL_TOPOLOGY* chfl_topology(void);
 
 /// Get access to the topology of a `frame`.
 ///
-/// The `frame` will be kept alive, even if `chfl_frame_free` is called,
-/// until `chfl_topology_free` is also called on the pointer returned by this
+/// The `frame` will be kept alive, even if `chfl_free` is called,
+/// until `chfl_free` is also called on the pointer returned by this
 /// function.
 ///
 /// If `chfl_frame_set_topology` is called, this pointer will point to the new
@@ -36,7 +36,7 @@ CHFL_EXPORT const CHFL_TOPOLOGY* chfl_topology_from_frame(const CHFL_FRAME* fram
 /// Get a copy of a `topology`.
 ///
 /// The caller of this function should free the associated memory using
-/// `chfl_topology_free`.
+/// `chfl_free`.
 ///
 /// @example{tests/capi/doc/chfl_topology/copy.c}
 /// @return A pointer to the new topology, or NULL in case of error.
@@ -266,12 +266,6 @@ CHFL_EXPORT chfl_status chfl_topology_bond_orders(
 CHFL_EXPORT chfl_status chfl_topology_bond_order(
     const CHFL_TOPOLOGY* topology, uint64_t i, uint64_t j, chfl_bond_order* order
 );
-
-/// Free the memory associated with a `topology`.
-///
-/// @example{tests/capi/doc/chfl_topology/chfl_topology.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_topology_free(const CHFL_TOPOLOGY* topology);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/trajectory.h
+++ b/include/chemfiles/capi/trajectory.h
@@ -137,8 +137,7 @@ CHFL_EXPORT chfl_status chfl_trajectory_nsteps(
 /// storage (hard drive, network, ...) used for this file.
 ///
 /// @example{tests/capi/doc/chfl_trajectory/open.c}
-/// @return `CHFL_SUCCESS`
-CHFL_EXPORT chfl_status chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory);
+CHFL_EXPORT void chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory);
 
 #ifdef __cplusplus
 }

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -164,6 +164,15 @@ typedef enum {  // NOLINT: this is both a C and C++ file
     CHFL_BOND_AROMATIC = 255,
 } chfl_bond_order;
 
+/// Free the memory associated with a chemfiles object.
+///
+/// This function is NOT equivalent to the standard C function `free`, as memory
+/// is acquired and released for all chemfiles objects using a references
+/// counter to allow direct modification of C++ objects.
+///
+/// @example{tests/capi/doc/chfl_atom/chfl_atom.c}
+CHFL_EXPORT void chfl_free(const void* objet);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/chemfiles/shared_allocator.hpp
+++ b/include/chemfiles/shared_allocator.hpp
@@ -26,7 +26,7 @@ struct shared_metadata {
 ///
 /// This is used in the C API to ensure that when taking pointers to
 /// atoms/residues/cell inside a frame/topology, the frame/topology is keept
-/// alive even if the user call chfl_xxx_free.
+/// alive even if the user calls chfl_free.
 class shared_allocator {
 public:
     shared_allocator() = default;
@@ -62,6 +62,9 @@ public:
 
     /// Decrease the reference count of `ptr`, and delete it if needed.
     static void free(const void* ptr) {
+        if (ptr == nullptr) {
+            return;
+        }
         auto instance = instance_.lock();
         auto it = instance->map_.find(ptr);
         if (it == instance->map_.end()) {

--- a/scripts/ci/lint-code.py
+++ b/scripts/ci/lint-code.py
@@ -6,24 +6,30 @@ better wrappers in chemfiles
 """
 import os
 import sys
+import re
 from glob import glob
 
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 ERRORS = 0
 
 PARSING_FUNCTIONS = {
-    'stof': 'parse<double>',
-    'stod': 'parse<double>',
-    'stold': 'parse<double>',
-    'stoi': 'parse<long long>',
-    'stol': 'parse<long long>',
-    'stoll': 'parse<long long>',
-    'stoul': 'parse<size_t>',
-    'stoull': 'parse<size_t>',
+    # Match 'std::<...>',  '::<...>' and '<...>'
+    r"(?P<name>\b(std)?(::)?stof\b)": "parse<double>",
+    r"(?P<name>\b(std)?(::)?stod\b)": "parse<double>",
+    r"(?P<name>\b(std)?(::)?stold\b)": "parse<double>",
+    r"(?P<name>\b(std)?(::)?stoi\b)": "parse<long long>",
+    r"(?P<name>\b(std)?(::)?stol\b)": "parse<long long>",
+    r"(?P<name>\b(std)?(::)?stoll\b)": "parse<long long>",
+    r"(?P<name>\b(std)?(::)?stoul\b)": "parse<size_t>",
+    r"(?P<name>\b(std)?(::)?stoull\b)": "parse<size_t>",
 }
 
 CAPI_FUNCTIONS = {
-    'static_cast<size_t>': 'checked_cast'
+    r"(?P<name>\bstatic_cast<size_t>\b)": "checked_cast",
+    r"(?P<name>\bnew\b)": "shared_allocator::make_shared",
+    r"(?P<name>\bdelete\b)": "shared_allocator::free",
+    r"(?P<name>\bmalloc\b)": "shared_allocator::make_shared",
+    r"(?P<name>\bfree\b)": "shared_allocator::free",
 }
 
 
@@ -37,13 +43,19 @@ def check_code(path, replacements):
     with open(path) as fd:
         for i, line in enumerate(fd):
             for bad, replacement in replacements.items():
-                if bad in line:
-                    error("Please replace '{}' by '{}' at {}:{}".format(
-                        bad, replacement, os.path.relpath(path), i
-                    ))
+                match = re.search(bad, line)
+                if match and "NOLINT" not in line:
+                    error(
+                        "Please replace '{}' by '{}' at {}:{}".format(
+                            match.group("name"),
+                            replacement,
+                            os.path.relpath(path),
+                            i + 1,
+                        )
+                    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     for file in glob(os.path.join(ROOT, "include", "chemfiles", "*.hpp")):
         if file.endswith("utils.hpp"):
             continue

--- a/src/capi/atom.cpp
+++ b/src/capi/atom.cpp
@@ -19,7 +19,7 @@ extern "C" CHFL_ATOM* chfl_atom(const char* name) {
     )
     return atom;
 error:
-    delete atom;
+    chfl_free(atom);
     return nullptr;
 }
 
@@ -30,7 +30,7 @@ extern "C" CHFL_ATOM* chfl_atom_copy(const CHFL_ATOM* const atom) {
     )
     return new_atom;
 error:
-    delete new_atom;
+    chfl_free(new_atom);
     return nullptr;
 }
 
@@ -49,7 +49,7 @@ extern "C" CHFL_ATOM* chfl_atom_from_frame(CHFL_FRAME* const frame, uint64_t ind
     )
     return atom;
 error:
-    delete atom;
+    chfl_free(atom);
     return nullptr;
 }
 
@@ -68,7 +68,7 @@ extern "C" CHFL_ATOM* chfl_atom_from_topology(CHFL_TOPOLOGY* const topology, uin
     )
     return atom;
 error:
-    delete atom;
+    chfl_free(atom);
     return nullptr;
 }
 
@@ -216,23 +216,13 @@ extern "C" CHFL_PROPERTY* chfl_atom_get_property(const CHFL_ATOM* const atom, co
     CHFL_ERROR_GOTO(
         auto atom_property = atom->get(name);
         if (atom_property) {
-            property = new Property(*atom_property);
+            property = shared_allocator::make_shared<Property>(*atom_property);
         } else {
             throw property_error("can not find a property named '{}' in this atom", name);
         }
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
-}
-
-extern "C" chfl_status chfl_atom_free(const CHFL_ATOM* const atom) {
-    CHFL_ERROR_CATCH(
-        if (atom == nullptr) {
-            return CHFL_SUCCESS;
-        } else {
-            shared_allocator::free(atom);
-        }
-    )
 }

--- a/src/capi/cell.cpp
+++ b/src/capi/cell.cpp
@@ -19,7 +19,7 @@ extern "C" CHFL_CELL* chfl_cell(const chfl_vector3d lengths) {
     )
     return cell;
 error:
-    delete cell;
+    chfl_free(cell);
     return nullptr;
 }
 
@@ -38,7 +38,7 @@ extern "C" CHFL_CELL* chfl_cell_triclinic(const chfl_vector3d lengths, const chf
     )
     return cell;
 error:
-    delete cell;
+    chfl_free(cell);
     return nullptr;
 }
 
@@ -51,7 +51,7 @@ extern "C" CHFL_CELL* chfl_cell_from_frame(CHFL_FRAME* const frame) {
     )
     return cell;
 error:
-    delete cell;
+    chfl_free(cell);
     return nullptr;
 }
 
@@ -62,7 +62,7 @@ extern "C" CHFL_CELL* chfl_cell_copy(const CHFL_CELL* const cell) {
     )
     return new_cell;
 error:
-    delete new_cell;
+    chfl_free(new_cell);
     return nullptr;
 }
 
@@ -145,15 +145,5 @@ extern "C" chfl_status chfl_cell_wrap(const CHFL_CELL* const cell, chfl_vector3d
         vector[0] = result[0];
         vector[1] = result[1];
         vector[2] = result[2];
-    )
-}
-
-extern "C" chfl_status chfl_cell_free(const CHFL_CELL* const cell) {
-    CHFL_ERROR_CATCH(
-        if (cell == nullptr) {
-            return CHFL_SUCCESS;
-        } else {
-            shared_allocator::free(cell);
-        }
     )
 }

--- a/src/capi/misc.cpp
+++ b/src/capi/misc.cpp
@@ -5,6 +5,7 @@
 #include "chemfiles/config.hpp"
 #include "chemfiles/capi/misc.h"
 #include "chemfiles/capi.hpp"
+#include "chemfiles/shared_allocator.hpp"
 using namespace chemfiles;
 
 static_assert(sizeof(chfl_status) == sizeof(int), "Wrong size for chfl_status enum");
@@ -13,6 +14,10 @@ static CHFL_THREAD_LOCAL std::string CAPI_LAST_ERROR;
 
 void chemfiles::set_last_error(const std::string& message) {
     CAPI_LAST_ERROR = message;
+}
+
+extern "C" void chfl_free(const void* const object) {
+    shared_allocator::free(object); // NOLINT: we can use shared_allocator::free to implement chfl_free
 }
 
 extern "C" const char* chfl_version(void) {

--- a/src/capi/property.cpp
+++ b/src/capi/property.cpp
@@ -1,6 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
+#include "chemfiles/shared_allocator.hpp"
 #include "chemfiles/capi/property.h"
 #include "chemfiles/capi.hpp"
 
@@ -12,44 +13,44 @@ static_assert(sizeof(chfl_property_kind) == sizeof(int), "Wrong size for chfl_pr
 extern "C" CHFL_PROPERTY* chfl_property_bool(bool value) {
     CHFL_PROPERTY* property = nullptr;
     CHFL_ERROR_GOTO(
-        property = new Property(value);
+        property = shared_allocator::make_shared<Property>(value);
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
 }
 
 extern "C" CHFL_PROPERTY* chfl_property_double(double value) {
     CHFL_PROPERTY* property = nullptr;
     CHFL_ERROR_GOTO(
-        property = new Property(value);
+        property = shared_allocator::make_shared<Property>(value);
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
 }
 
 extern "C" CHFL_PROPERTY* chfl_property_string(const char* value) {
     CHFL_PROPERTY* property = nullptr;
     CHFL_ERROR_GOTO(
-        property = new Property(value);
+        property = shared_allocator::make_shared<Property>(value);
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
 }
 
 extern "C" CHFL_PROPERTY* chfl_property_vector3d(const chfl_vector3d value) {
     CHFL_PROPERTY* property = nullptr;
     CHFL_ERROR_GOTO(
-        property = new Property(vector3d(value));
+        property = shared_allocator::make_shared<Property>(vector3d(value));
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
 }
 
@@ -96,9 +97,4 @@ extern "C" chfl_status chfl_property_get_vector3d(const CHFL_PROPERTY* const pro
         value[1] = vector[1];
         value[2] = vector[2];
     )
-}
-
-extern "C" chfl_status chfl_property_free(const CHFL_PROPERTY* property) {
-    delete property;
-    return CHFL_SUCCESS;
 }

--- a/src/capi/residue.cpp
+++ b/src/capi/residue.cpp
@@ -3,9 +3,9 @@
 
 #include <cstring>
 
+#include "chemfiles/shared_allocator.hpp"
 #include "chemfiles/capi/residue.h"
 #include "chemfiles/capi.hpp"
-#include "chemfiles/shared_allocator.hpp"
 
 #include "chemfiles/ErrorFmt.hpp"
 #include "chemfiles/Residue.hpp"
@@ -20,7 +20,7 @@ extern "C" CHFL_RESIDUE* chfl_residue(const char* name) {
     )
     return residue;
 error:
-    delete residue;
+    chfl_free(residue);
     return nullptr;
 }
 
@@ -32,7 +32,7 @@ extern "C" CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid) 
     )
     return residue;
 error:
-    delete residue;
+    chfl_free(residue);
     return nullptr;
 }
 
@@ -44,7 +44,7 @@ extern "C" const CHFL_RESIDUE* chfl_residue_from_topology(const CHFL_TOPOLOGY* c
     )
     return residue;
 error:
-    delete residue;
+    chfl_free(residue);
     return nullptr;
 }
 
@@ -59,7 +59,7 @@ extern "C" const CHFL_RESIDUE* chfl_residue_for_atom(const CHFL_TOPOLOGY* const 
     )
     return residue;
 error:
-    delete residue;
+    chfl_free(residue);
     return nullptr;
 }
 
@@ -70,7 +70,7 @@ extern "C" CHFL_RESIDUE* chfl_residue_copy(const CHFL_RESIDUE* const residue) {
     )
     return new_residue;
 error:
-    delete new_residue;
+    chfl_free(new_residue);
     return nullptr;
 }
 
@@ -177,23 +177,13 @@ extern "C" CHFL_PROPERTY* chfl_residue_get_property(const CHFL_RESIDUE* const re
     CHFL_ERROR_GOTO(
         auto residue_property = residue->get(name);
         if (residue_property) {
-            property = new Property(*residue_property);
+            property = shared_allocator::make_shared<Property>(*residue_property);
         } else {
             throw property_error("can not find a property named '{}' in this residue", name);
         }
     )
     return property;
 error:
-    delete property;
+    chfl_free(property);
     return nullptr;
-}
-
-extern "C" chfl_status chfl_residue_free(const CHFL_RESIDUE* const residue) {
-    CHFL_ERROR_CATCH(
-        if (residue == nullptr) {
-            return CHFL_SUCCESS;
-        } else {
-            shared_allocator::free(residue);
-        }
-    )
 }

--- a/src/capi/topology.cpp
+++ b/src/capi/topology.cpp
@@ -18,7 +18,7 @@ extern "C" CHFL_TOPOLOGY* chfl_topology(void) {
     )
     return topology;
 error:
-    delete topology;
+    chfl_free(topology);
     return nullptr;
 }
 
@@ -30,7 +30,7 @@ extern "C" const CHFL_TOPOLOGY* chfl_topology_from_frame(const CHFL_FRAME* const
     )
     return topology;
 error:
-    delete topology;
+    chfl_free(topology);
     return nullptr;
 }
 
@@ -41,7 +41,7 @@ extern "C" CHFL_TOPOLOGY* chfl_topology_copy(const CHFL_TOPOLOGY* const topology
     )
     return new_topology;
 error:
-    delete new_topology;
+    chfl_free(new_topology);
     return nullptr;
 }
 
@@ -258,15 +258,5 @@ extern "C" chfl_status chfl_topology_bond_order( const CHFL_TOPOLOGY* const topo
         *order = static_cast<chfl_bond_order>(
             topology->bond_order(checked_cast(i), checked_cast(j))
         );
-    )
-}
-
-extern "C" chfl_status chfl_topology_free(const CHFL_TOPOLOGY* const topology) {
-    CHFL_ERROR_CATCH(
-        if (topology == nullptr) {
-            return CHFL_SUCCESS;
-        } else {
-            shared_allocator::free(topology);
-        }
     )
 }

--- a/src/capi/trajectory.cpp
+++ b/src/capi/trajectory.cpp
@@ -1,7 +1,9 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
+#include "chemfiles/shared_allocator.hpp"
 #include "chemfiles/capi/trajectory.h"
+#include "chemfiles/capi/misc.h"
 #include "chemfiles/capi.hpp"
 
 #include "chemfiles/Trajectory.hpp"
@@ -11,11 +13,11 @@ extern "C" CHFL_TRAJECTORY* chfl_trajectory_open(const char* path, char mode) {
     CHFL_TRAJECTORY* trajectory = nullptr;
     CHECK_POINTER_GOTO(path);
     CHFL_ERROR_GOTO(
-        trajectory = new Trajectory(path, mode);
+        trajectory = shared_allocator::make_shared<Trajectory>(path, mode);
     )
     return trajectory;
 error:
-    delete trajectory;
+    chfl_trajectory_close(trajectory);
     return nullptr;
 }
 
@@ -24,11 +26,11 @@ extern "C" CHFL_TRAJECTORY* chfl_trajectory_with_format(const char* path, char m
     CHECK_POINTER_GOTO(path);
     CHECK_POINTER_GOTO(format);
     CHFL_ERROR_GOTO(
-        trajectory = new Trajectory(path, mode, format);
+        trajectory = shared_allocator::make_shared<Trajectory>(path, mode, format);
     )
     return trajectory;
 error:
-    delete trajectory;
+    chfl_trajectory_close(trajectory);
     return nullptr;
 }
 
@@ -99,7 +101,6 @@ extern "C" chfl_status chfl_trajectory_nsteps(CHFL_TRAJECTORY* const trajectory,
     )
 }
 
-extern "C" chfl_status chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory) {
-    delete trajectory;
-    return CHFL_SUCCESS;
+extern "C" void chfl_trajectory_close(const CHFL_TRAJECTORY* trajectory) {
+    chfl_free(trajectory);
 }

--- a/tests/capi/atom.cpp
+++ b/tests/capi/atom.cpp
@@ -18,7 +18,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string("H5"));
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Type") {
@@ -40,7 +40,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_full_name(atom, name, sizeof(name)));
         CHECK(name == std::string("Zinc"));
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Mass") {
@@ -55,7 +55,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_mass(atom, &mass));
         CHECK(mass == 678);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Charge") {
@@ -70,7 +70,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_charge(atom, &charge));
         CHECK(charge == -1.8);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Radius") {
@@ -84,7 +84,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_covalent_radius(atom, &radius));
         CHECK(radius == 1.31);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         atom = chfl_atom("");
         REQUIRE(atom);
@@ -96,7 +96,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_covalent_radius(atom, &radius));
         CHECK(radius == 0.0);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Number") {
@@ -107,7 +107,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_atomic_number(atom, &number));
         CHECK(number == 30);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         atom = chfl_atom("");
         REQUIRE(atom);
@@ -115,7 +115,7 @@ TEST_CASE("chfl_atom") {
         CHECK_STATUS(chfl_atom_atomic_number(atom, &number));
         CHECK(number == 0);
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 
     SECTION("Property") {
@@ -126,14 +126,14 @@ TEST_CASE("chfl_atom") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_atom_set_property(atom, "this", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
         property = nullptr;
 
         property = chfl_atom_get_property(atom, "this");
         double value = 0;
         CHECK_STATUS(chfl_property_get_double(property, &value));
         CHECK(value == -23);
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
         property = nullptr;
 
         CHECK_FALSE(chfl_atom_get_property(atom, "that"));
@@ -142,7 +142,7 @@ TEST_CASE("chfl_atom") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_atom_set_property(atom, "that", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
 
         uint64_t count = 0;
         CHECK_STATUS(chfl_atom_properties_count(atom, &count));
@@ -158,6 +158,6 @@ TEST_CASE("chfl_atom") {
             CHECK(names[1] == std::string("this"));
         }
 
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
     }
 }

--- a/tests/capi/cell.cpp
+++ b/tests/capi/cell.cpp
@@ -31,7 +31,7 @@ TEST_CASE("chfl_cell") {
         CHECK(data[1] == 90);
         CHECK(data[2] == 90);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         lengths[0] = 20; lengths[1] = 21; lengths[2] = 22;
         chfl_vector3d angles = {90, 100, 120};
@@ -48,7 +48,7 @@ TEST_CASE("chfl_cell") {
         CHECK(data[1] == 100);
         CHECK(data[2] == 120);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         // Check that a call to chfl_cell_triclinic always gives a triclinic
         // cell, even with all angles equal to 90°
@@ -60,7 +60,7 @@ TEST_CASE("chfl_cell") {
         CHECK_STATUS(chfl_cell_shape(cell, &shape));
         CHECK(shape == CHFL_CELL_TRICLINIC);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Length") {
@@ -81,7 +81,7 @@ TEST_CASE("chfl_cell") {
         CHECK(data[1] == 20);
         CHECK(data[2] == 30);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Angles") {
@@ -107,7 +107,7 @@ TEST_CASE("chfl_cell") {
         CHECK(data[1] == 89);
         CHECK(data[2] == 100);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Volume") {
@@ -119,7 +119,7 @@ TEST_CASE("chfl_cell") {
         CHECK_STATUS(chfl_cell_volume(cell, &volume));
         CHECK(volume == 2 * 3 * 4);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Matrix") {
@@ -132,7 +132,7 @@ TEST_CASE("chfl_cell") {
         CHECK_STATUS(chfl_cell_matrix(cell, matrix));
         CHECK(approx_eq(expected, matrix));
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Shape") {
@@ -154,7 +154,7 @@ TEST_CASE("chfl_cell") {
         CHECK_STATUS(chfl_cell_shape(cell, &shape));
         CHECK(shape == CHFL_CELL_INFINITE);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 
     SECTION("Wrap") {
@@ -168,6 +168,6 @@ TEST_CASE("chfl_cell") {
         CHECK(vector[1] == -1.3);
         CHECK(vector[2] == 2);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
     }
 }

--- a/tests/capi/doc/chfl_atom/atomic_number.c
+++ b/tests/capi/doc/chfl_atom/atomic_number.c
@@ -13,7 +13,7 @@ int main() {
     chfl_atom_atomic_number(atom, &number);
     assert(number == 11);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/charge.c
+++ b/tests/capi/doc/chfl_atom/charge.c
@@ -13,7 +13,7 @@ int main() {
     chfl_atom_charge(atom, &charge);
     assert(charge == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/chfl_atom.c
+++ b/tests/capi/doc/chfl_atom/chfl_atom.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/copy.c
+++ b/tests/capi/doc/chfl_atom/copy.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_atom_free(copy);
-    chfl_atom_free(atom);
+    chfl_free(copy);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/covalent_radius.c
+++ b/tests/capi/doc/chfl_atom/covalent_radius.c
@@ -14,7 +14,7 @@ int main() {
     chfl_atom_covalent_radius(atom, &radius);
     assert(fabs(radius - 1.54) < 1e-15);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/from_frame.c
+++ b/tests/capi/doc/chfl_atom/from_frame.c
@@ -16,8 +16,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/from_topology.c
+++ b/tests/capi/doc/chfl_atom/from_topology.c
@@ -15,8 +15,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_atom_free(atom);
-    chfl_topology_free(topology);
+    chfl_free(atom);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/full_name.c
+++ b/tests/capi/doc/chfl_atom/full_name.c
@@ -13,7 +13,7 @@ int main() {
     chfl_atom_full_name(atom, name, sizeof(name));
     assert(strcmp(name, "Sodium") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/list_properties.c
+++ b/tests/capi/doc/chfl_atom/list_properties.c
@@ -13,7 +13,7 @@ int main() {
 
     chfl_atom_set_property(atom, "this", property);
     chfl_atom_set_property(atom, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_atom_properties_count(atom, &count);
@@ -26,7 +26,7 @@ int main() {
     assert(strcmp(names[0], "this") == 0 || strcmp(names[0], "that") == 0);
     assert(strcmp(names[1], "this") == 0 || strcmp(names[1], "that") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/mass.c
+++ b/tests/capi/doc/chfl_atom/mass.c
@@ -14,7 +14,7 @@ int main() {
     chfl_atom_mass(atom, &mass);
     assert(fabs(mass - 22.98976928) < 1e-15);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/name.c
+++ b/tests/capi/doc/chfl_atom/name.c
@@ -13,7 +13,7 @@ int main() {
     chfl_atom_name(atom, name, sizeof(name));
     assert(strcmp(name, "Na") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/properties_count.c
+++ b/tests/capi/doc/chfl_atom/properties_count.c
@@ -12,13 +12,13 @@ int main() {
 
     chfl_atom_set_property(atom, "this", property);
     chfl_atom_set_property(atom, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_atom_properties_count(atom, &count);
     assert(count == 2);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/property.c
+++ b/tests/capi/doc/chfl_atom/property.c
@@ -11,7 +11,7 @@ int main() {
     CHFL_PROPERTY* property = chfl_property_double(-23);
 
     chfl_atom_set_property(atom, "this", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     property = chfl_atom_get_property(atom, "this");
 
@@ -19,8 +19,8 @@ int main() {
     chfl_property_get_double(property, &value);
     assert(value == -23);
 
-    chfl_property_free(property);
-    chfl_atom_free(atom);
+    chfl_free(property);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/set_charge.c
+++ b/tests/capi/doc/chfl_atom/set_charge.c
@@ -16,7 +16,7 @@ int main() {
     chfl_atom_charge(atom, &charge);
     assert(fabs(charge - 0.82) < 1e-15);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/set_mass.c
+++ b/tests/capi/doc/chfl_atom/set_mass.c
@@ -16,7 +16,7 @@ int main() {
     chfl_atom_mass(atom, &mass);
     assert(fabs(mass - 1.45) < 1e-15);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/set_name.c
+++ b/tests/capi/doc/chfl_atom/set_name.c
@@ -15,7 +15,7 @@ int main() {
     chfl_atom_name(atom, name, sizeof(name));
     assert(strcmp(name, "Cs") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/set_type.c
+++ b/tests/capi/doc/chfl_atom/set_type.c
@@ -15,7 +15,7 @@ int main() {
     chfl_atom_type(atom, type, sizeof(type));
     assert(strcmp(type, "Cs") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/type.c
+++ b/tests/capi/doc/chfl_atom/type.c
@@ -13,7 +13,7 @@ int main() {
     chfl_atom_type(atom, type, sizeof(type));
     assert(strcmp(type, "Na") == 0);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_atom/vdw_radius.c
+++ b/tests/capi/doc/chfl_atom/vdw_radius.c
@@ -14,7 +14,7 @@ int main() {
     chfl_atom_vdw_radius(atom, &radius);
     assert(fabs(radius - 2.4) < 1e-15);
 
-    chfl_atom_free(atom);
+    chfl_free(atom);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/angles.c
+++ b/tests/capi/doc/chfl_cell/angles.c
@@ -15,7 +15,7 @@ int main() {
     assert(angles[1] == 90);
     assert(angles[2] == 90);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/chfl_cell.c
+++ b/tests/capi/doc/chfl_cell/chfl_cell.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/copy.c
+++ b/tests/capi/doc/chfl_cell/copy.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_cell_free(copy);
-    chfl_cell_free(cell);
+    chfl_free(copy);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/from_frame.c
+++ b/tests/capi/doc/chfl_cell/from_frame.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_cell_free(cell);
-    chfl_frame_free(frame);
+    chfl_free(cell);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/lengths.c
+++ b/tests/capi/doc/chfl_cell/lengths.c
@@ -15,7 +15,7 @@ int main() {
     assert(lengths[1] == 11);
     assert(lengths[2] == 12);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/matrix.c
+++ b/tests/capi/doc/chfl_cell/matrix.c
@@ -18,7 +18,7 @@ int main() {
     // Out of diagonal terms are zero
     assert(matrix[2][1] == 0);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/set_angles.c
+++ b/tests/capi/doc/chfl_cell/set_angles.c
@@ -17,7 +17,7 @@ int main() {
     assert(angles[1] == 110);
     assert(angles[2] == 100);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/set_lengths.c
+++ b/tests/capi/doc/chfl_cell/set_lengths.c
@@ -17,7 +17,7 @@ int main() {
     assert(lengths[1] == 8);
     assert(lengths[2] == 3);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/set_shape.c
+++ b/tests/capi/doc/chfl_cell/set_shape.c
@@ -15,7 +15,7 @@ int main() {
     chfl_cell_shape(cell, &shape);
     assert(shape == CHFL_CELL_TRICLINIC);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/shape.c
+++ b/tests/capi/doc/chfl_cell/shape.c
@@ -13,7 +13,7 @@ int main() {
     chfl_cell_shape(cell, &shape);
     assert(shape == CHFL_CELL_ORTHORHOMBIC);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/triclinic.c
+++ b/tests/capi/doc/chfl_cell/triclinic.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/volume.c
+++ b/tests/capi/doc/chfl_cell/volume.c
@@ -13,7 +13,7 @@ int main() {
     chfl_cell_volume(cell, &volume);
     assert(volume == 1000);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_cell/wrap.c
+++ b/tests/capi/doc/chfl_cell/wrap.c
@@ -16,7 +16,7 @@ int main() {
     assert(position[1] == 2);
     assert(position[2] == 2);
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/add_atom.c
+++ b/tests/capi/doc/chfl_frame/add_atom.c
@@ -11,8 +11,8 @@ int main() {
 
     chfl_frame_add_atom(frame, atom, (chfl_vector3d){1, 2, 3}, NULL);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/add_bond.c
+++ b/tests/capi/doc/chfl_frame/add_bond.c
@@ -16,8 +16,8 @@ int main() {
     chfl_frame_add_bond(frame, 0, 1);
     chfl_frame_bond_with_order(frame, 0, 2, CHFL_BOND_DOUBLE);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/add_residue.c
+++ b/tests/capi/doc/chfl_frame/add_residue.c
@@ -12,8 +12,8 @@ int main() {
 
     chfl_frame_add_residue(frame, residue);
 
-    chfl_residue_free(residue);
-    chfl_frame_free(frame);
+    chfl_free(residue);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/add_velocities.c
+++ b/tests/capi/doc/chfl_frame/add_velocities.c
@@ -15,7 +15,7 @@ int main() {
     chfl_frame_has_velocities(frame, &velocities);
     assert(velocities == true);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/angle.c
+++ b/tests/capi/doc/chfl_frame/angle.c
@@ -23,8 +23,8 @@ int main() {
     chfl_frame_angle(frame, 0, 1, 2, &angle);
     assert(fabs(angle - M_PI / 2) < 1e-12);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/atoms_count.c
+++ b/tests/capi/doc/chfl_frame/atoms_count.c
@@ -14,7 +14,7 @@ int main() {
     chfl_frame_atoms_count(frame, &atoms);
     assert(atoms == 42);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/chfl_frame.c
+++ b/tests/capi/doc/chfl_frame/chfl_frame.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/copy.c
+++ b/tests/capi/doc/chfl_frame/copy.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_frame_free(copy);
-    chfl_frame_free(frame);
+    chfl_free(copy);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/dihedral.c
+++ b/tests/capi/doc/chfl_frame/dihedral.c
@@ -24,8 +24,8 @@ int main() {
     chfl_frame_dihedral(frame, 0, 1, 2, 3, &dihedral);
     assert(fabs(dihedral - M_PI / 2) < 1e-12);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/distance.c
+++ b/tests/capi/doc/chfl_frame/distance.c
@@ -18,8 +18,8 @@ int main() {
     chfl_frame_distance(frame, 0, 1, &distance);
     assert(distance == sqrt(14));
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/guess_bonds.c
+++ b/tests/capi/doc/chfl_frame/guess_bonds.c
@@ -13,14 +13,14 @@ int main() {
     CHFL_ATOM* Cl = chfl_atom("Cl");
     chfl_frame_add_atom(frame, Cl, (chfl_vector3d){0, 0, 0}, NULL);
     chfl_frame_add_atom(frame, Cl, (chfl_vector3d){2, 0, 0}, NULL);
-    chfl_atom_free(Cl);
+    chfl_free(Cl);
 
     // Check that the topology does not contain any bond
     const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
     uint64_t bonds = 0;
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 0);
-    chfl_topology_free(topology);
+    chfl_free(topology);
 
     chfl_frame_guess_bonds(frame);
 
@@ -29,8 +29,8 @@ int main() {
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 1);
 
-    chfl_topology_free(topology);
-    chfl_frame_free(frame);
+    chfl_free(topology);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/has_velocities.c
+++ b/tests/capi/doc/chfl_frame/has_velocities.c
@@ -13,7 +13,7 @@ int main() {
     chfl_frame_has_velocities(frame, &velocities);
     assert(velocities == false);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/list_properties.c
+++ b/tests/capi/doc/chfl_frame/list_properties.c
@@ -13,7 +13,7 @@ int main() {
 
     chfl_frame_set_property(frame, "this", property);
     chfl_frame_set_property(frame, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_frame_properties_count(frame, &count);
@@ -26,7 +26,7 @@ int main() {
     assert(strcmp(names[0], "this") == 0 || strcmp(names[0], "that") == 0);
     assert(strcmp(names[1], "this") == 0 || strcmp(names[1], "that") == 0);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/out_of_plane.c
+++ b/tests/capi/doc/chfl_frame/out_of_plane.c
@@ -20,8 +20,8 @@ int main() {
     chfl_frame_out_of_plane(frame, 0, 1, 2, 3, &distance);
     assert(fabs(distance - 2) < 1e-12);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/positions.c
+++ b/tests/capi/doc/chfl_frame/positions.c
@@ -16,7 +16,7 @@ int main() {
         // use positions[i] here
     }
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/properties_count.c
+++ b/tests/capi/doc/chfl_frame/properties_count.c
@@ -12,13 +12,13 @@ int main() {
 
     chfl_frame_set_property(frame, "this", property);
     chfl_frame_set_property(frame, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_frame_properties_count(frame, &count);
     assert(count == 2);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/property.c
+++ b/tests/capi/doc/chfl_frame/property.c
@@ -11,7 +11,7 @@ int main() {
     CHFL_PROPERTY* property = chfl_property_double(-23);
 
     chfl_frame_set_property(frame, "this", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     property = chfl_frame_get_property(frame, "this");
 
@@ -19,8 +19,8 @@ int main() {
     chfl_property_get_double(property, &value);
     assert(value == -23);
 
-    chfl_property_free(property);
-    chfl_frame_free(frame);
+    chfl_free(property);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/remove.c
+++ b/tests/capi/doc/chfl_frame/remove.c
@@ -21,7 +21,7 @@ int main() {
     chfl_frame_atoms_count(frame, &atoms);
     assert(atoms == 39);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/remove_bond.c
+++ b/tests/capi/doc/chfl_frame/remove_bond.c
@@ -23,8 +23,8 @@ int main() {
     // Removing non-existing bond
     chfl_frame_remove_bond(frame, 2, 3);
 
-    chfl_atom_free(atom);
-    chfl_frame_free(frame);
+    chfl_free(atom);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/resize.c
+++ b/tests/capi/doc/chfl_frame/resize.c
@@ -15,7 +15,7 @@ int main() {
     chfl_frame_atoms_count(frame, &atoms);
     assert(atoms == 55);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/set_cell.c
+++ b/tests/capi/doc/chfl_frame/set_cell.c
@@ -11,8 +11,8 @@ int main() {
 
     chfl_frame_set_cell(frame, cell);
 
-    chfl_cell_free(cell);
-    chfl_frame_free(frame);
+    chfl_free(cell);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/set_step.c
+++ b/tests/capi/doc/chfl_frame/set_step.c
@@ -15,7 +15,7 @@ int main() {
     chfl_frame_step(frame, &step);
     assert(step == 678);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/set_topology.c
+++ b/tests/capi/doc/chfl_frame/set_topology.c
@@ -19,14 +19,14 @@ int main() {
         chfl_topology_add_atom(topology, H);
         chfl_topology_add_atom(topology, H);
 
-        chfl_atom_free(O);
-        chfl_atom_free(H);
+        chfl_free(O);
+        chfl_free(H);
     }
 
     chfl_frame_set_topology(frame, topology);
 
-    chfl_topology_free(topology);
-    chfl_frame_free(frame);
+    chfl_free(topology);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/step.c
+++ b/tests/capi/doc/chfl_frame/step.c
@@ -13,7 +13,7 @@ int main() {
     chfl_frame_step(frame, &step);
     assert(step == 0);
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_frame/velocities.c
+++ b/tests/capi/doc/chfl_frame/velocities.c
@@ -17,7 +17,7 @@ int main() {
         // use velocities[i] here
     }
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_property/bool.c
+++ b/tests/capi/doc/chfl_property/bool.c
@@ -12,7 +12,7 @@ int main() {
     chfl_property_get_bool(property, &value);
     assert(value == true);
 
-    chfl_property_free(property);
+    chfl_free(property);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_property/double.c
+++ b/tests/capi/doc/chfl_property/double.c
@@ -12,7 +12,7 @@ int main() {
     chfl_property_get_double(property, &value);
     assert(value == 256);
 
-    chfl_property_free(property);
+    chfl_free(property);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_property/kind.c
+++ b/tests/capi/doc/chfl_property/kind.c
@@ -12,7 +12,7 @@ int main() {
     chfl_property_get_kind(property, &kind);
     assert(kind == CHFL_PROPERTY_DOUBLE);
 
-    chfl_property_free(property);
+    chfl_free(property);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_property/string.c
+++ b/tests/capi/doc/chfl_property/string.c
@@ -13,7 +13,7 @@ int main() {
     chfl_property_get_string(property, value, sizeof(value));
     assert(strcmp(value, "a great property") == 0);
 
-    chfl_property_free(property);
+    chfl_free(property);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_property/vector3d.c
+++ b/tests/capi/doc/chfl_property/vector3d.c
@@ -15,7 +15,7 @@ int main() {
     assert(fabs(value[1] - 3.2) < 1e-12);
     assert(fabs(value[2] - -1) < 1e-12);
 
-    chfl_property_free(property);
+    chfl_free(property);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/add_atom.c
+++ b/tests/capi/doc/chfl_residue/add_atom.c
@@ -13,7 +13,7 @@ int main() {
     chfl_residue_add_atom(residue, 32);
     chfl_residue_add_atom(residue, 28);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/atoms.c
+++ b/tests/capi/doc/chfl_residue/atoms.c
@@ -18,7 +18,7 @@ int main() {
     assert(atoms[1] == 28);
     assert(atoms[2] == 32);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/atoms_count.c
+++ b/tests/capi/doc/chfl_residue/atoms_count.c
@@ -16,7 +16,7 @@ int main() {
     chfl_residue_atoms_count(residue, &atoms);
     assert(atoms == 3);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/chfl_residue.c
+++ b/tests/capi/doc/chfl_residue/chfl_residue.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/contains.c
+++ b/tests/capi/doc/chfl_residue/contains.c
@@ -20,7 +20,7 @@ int main() {
     chfl_residue_contains(residue, 11, &contained);
     assert(contained == false);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/copy.c
+++ b/tests/capi/doc/chfl_residue/copy.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_residue_free(copy);
-    chfl_residue_free(residue);
+    chfl_free(copy);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/for_atom.c
+++ b/tests/capi/doc/chfl_residue/for_atom.c
@@ -16,8 +16,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_residue_free(residue);
-    chfl_topology_free(topology);
+    chfl_free(residue);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/from_topology.c
+++ b/tests/capi/doc/chfl_residue/from_topology.c
@@ -16,8 +16,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_residue_free(residue);
-    chfl_topology_free(topology);
+    chfl_free(residue);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/id.c
+++ b/tests/capi/doc/chfl_residue/id.c
@@ -13,7 +13,7 @@ int main() {
     chfl_residue_id(residue, &id);
     assert(id == 3);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/list_properties.c
+++ b/tests/capi/doc/chfl_residue/list_properties.c
@@ -13,7 +13,7 @@ int main() {
 
     chfl_residue_set_property(residue, "this", property);
     chfl_residue_set_property(residue, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_residue_properties_count(residue, &count);
@@ -26,7 +26,7 @@ int main() {
     assert(strcmp(names[0], "this") == 0 || strcmp(names[0], "that") == 0);
     assert(strcmp(names[1], "this") == 0 || strcmp(names[1], "that") == 0);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/name.c
+++ b/tests/capi/doc/chfl_residue/name.c
@@ -14,7 +14,7 @@ int main() {
     chfl_residue_name(residue, name, sizeof(name));
     assert(strcmp(name, "water") == 0);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/properties_count.c
+++ b/tests/capi/doc/chfl_residue/properties_count.c
@@ -12,13 +12,13 @@ int main() {
 
     chfl_residue_set_property(residue, "this", property);
     chfl_residue_set_property(residue, "that", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     uint64_t count = 0;
     chfl_residue_properties_count(residue, &count);
     assert(count == 2);
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/property.c
+++ b/tests/capi/doc/chfl_residue/property.c
@@ -11,7 +11,7 @@ int main() {
     CHFL_PROPERTY* property = chfl_property_double(-23);
 
     chfl_residue_set_property(residue, "this", property);
-    chfl_property_free(property);
+    chfl_free(property);
 
     property = chfl_residue_get_property(residue, "this");
 
@@ -19,8 +19,8 @@ int main() {
     chfl_property_get_double(property, &value);
     assert(value == -23);
 
-    chfl_property_free(property);
-    chfl_residue_free(residue);
+    chfl_free(property);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_residue/with_id.c
+++ b/tests/capi/doc/chfl_residue/with_id.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_residue_free(residue);
+    chfl_free(residue);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/chfl_selection.c
+++ b/tests/capi/doc/chfl_selection/chfl_selection.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_selection_free(selection);
+    chfl_free(selection);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/copy.c
+++ b/tests/capi/doc/chfl_selection/copy.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_selection_free(copy);
-    chfl_selection_free(selection);
+    chfl_free(copy);
+    chfl_free(selection);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/evaluate.c
+++ b/tests/capi/doc/chfl_selection/evaluate.c
@@ -14,8 +14,8 @@ int main() {
     chfl_frame_add_atom(frame, O, (chfl_vector3d){0, 0, 0}, NULL);
     chfl_frame_add_atom(frame, H, (chfl_vector3d){1, 0, 0}, NULL);
     chfl_frame_add_atom(frame, H, (chfl_vector3d){0, 1, 0}, NULL);
-    chfl_atom_free(O);
-    chfl_atom_free(H);
+    chfl_free(O);
+    chfl_free(H);
 
     CHFL_SELECTION* selection = chfl_selection("name H");
 
@@ -23,8 +23,8 @@ int main() {
     chfl_selection_evaluate(selection, frame, &size);
     assert(size == 2);
 
-    chfl_selection_free(selection);
-    chfl_frame_free(frame);
+    chfl_free(selection);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/matches.c
+++ b/tests/capi/doc/chfl_selection/matches.c
@@ -14,8 +14,8 @@ int main() {
     chfl_frame_add_atom(frame, O, (chfl_vector3d){0, 0, 0}, NULL);
     chfl_frame_add_atom(frame, H, (chfl_vector3d){1, 0, 0}, NULL);
     chfl_frame_add_atom(frame, H, (chfl_vector3d){0, 1, 0}, NULL);
-    chfl_atom_free(O);
-    chfl_atom_free(H);
+    chfl_free(O);
+    chfl_free(H);
 
     CHFL_SELECTION* selection = chfl_selection("name H");
 
@@ -28,8 +28,8 @@ int main() {
     assert(matches[0].atoms[0] == 1);
     assert(matches[1].atoms[0] == 2);
 
-    chfl_selection_free(selection);
-    chfl_frame_free(frame);
+    chfl_free(selection);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/size.c
+++ b/tests/capi/doc/chfl_selection/size.c
@@ -13,7 +13,7 @@ int main() {
     chfl_selection_size(selection, &size);
     assert(size == 2);
 
-    chfl_selection_free(selection);
+    chfl_free(selection);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_selection/string.c
+++ b/tests/capi/doc/chfl_selection/string.c
@@ -14,7 +14,7 @@ int main() {
     chfl_selection_string(selection, string, sizeof(string));
     assert(strcmp(string, "pairs: name(#1) O and name(#2) H") == 0);
 
-    chfl_selection_free(selection);
+    chfl_free(selection);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/add_atom.c
+++ b/tests/capi/doc/chfl_topology/add_atom.c
@@ -16,10 +16,10 @@ int main() {
     chfl_topology_add_atom(topology, H);
     chfl_topology_add_atom(topology, H);
 
-    chfl_atom_free(O);
-    chfl_atom_free(H);
+    chfl_free(O);
+    chfl_free(H);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/add_bond.c
+++ b/tests/capi/doc/chfl_topology/add_bond.c
@@ -12,7 +12,7 @@ int main() {
     CHFL_ATOM* atom = chfl_atom("F");
     chfl_topology_add_atom(topology, atom);
     chfl_topology_add_atom(topology, atom);
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
 
@@ -20,7 +20,7 @@ int main() {
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 1);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/add_residue.c
+++ b/tests/capi/doc/chfl_topology/add_residue.c
@@ -12,8 +12,8 @@ int main() {
 
     chfl_topology_add_residue(topology, residue);
 
-    chfl_residue_free(residue);
-    chfl_topology_free(topology);
+    chfl_free(residue);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/angles.c
+++ b/tests/capi/doc/chfl_topology/angles.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
     chfl_topology_add_bond(topology, 1, 2);
@@ -29,7 +29,7 @@ int main() {
     assert(angles[1][1] == 2);
     assert(angles[1][2] == 3);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/angles_count.c
+++ b/tests/capi/doc/chfl_topology/angles_count.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     // We have two angles: 0-1-2 and 1-2-3
     chfl_topology_add_bond(topology, 0, 1);
@@ -24,7 +24,7 @@ int main() {
     chfl_topology_angles_count(topology, &angles);
     assert(angles == 2);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/atoms_count.c
+++ b/tests/capi/doc/chfl_topology/atoms_count.c
@@ -13,13 +13,13 @@ int main() {
     chfl_topology_add_atom(topology, atom);
     chfl_topology_add_atom(topology, atom);
     chfl_topology_add_atom(topology, atom);
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     uint64_t atoms = 0;
     chfl_topology_atoms_count(topology, &atoms);
     assert(atoms == 3);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/bond_order.c
+++ b/tests/capi/doc/chfl_topology/bond_order.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_bond_with_order(topology, 0, 1, CHFL_BOND_SINGLE);
     chfl_topology_bond_with_order(topology, 2, 3, CHFL_BOND_DOUBLE);
@@ -26,7 +26,7 @@ int main() {
     chfl_topology_bond_order(topology, 2, 3, &order);
     assert(order == CHFL_BOND_DOUBLE);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/bonds.c
+++ b/tests/capi/doc/chfl_topology/bonds.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
     chfl_topology_add_bond(topology, 2, 3);
@@ -26,7 +26,7 @@ int main() {
     assert(bonds[1][0] == 2);
     assert(bonds[1][1] == 3);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/bonds_count.c
+++ b/tests/capi/doc/chfl_topology/bonds_count.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
     chfl_topology_add_bond(topology, 2, 3);
@@ -22,7 +22,7 @@ int main() {
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 2);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/chfl_topology.c
+++ b/tests/capi/doc/chfl_topology/chfl_topology.c
@@ -12,7 +12,7 @@ int main() {
         /* handle error */
     }
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/copy.c
+++ b/tests/capi/doc/chfl_topology/copy.c
@@ -12,7 +12,7 @@ int main() {
     chfl_topology_add_atom(topology, atom);
     chfl_topology_add_atom(topology, atom);
     chfl_topology_add_atom(topology, atom);
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     CHFL_TOPOLOGY* copy = chfl_topology_copy(topology);
 
@@ -20,8 +20,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_topology_free(copy);
-    chfl_topology_free(topology);
+    chfl_free(copy);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/dihedrals.c
+++ b/tests/capi/doc/chfl_topology/dihedrals.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
     chfl_topology_add_bond(topology, 1, 2);
@@ -26,7 +26,7 @@ int main() {
     assert(dihedrals[0][2] == 2);
     assert(dihedrals[0][3] == 3);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/dihedrals_count.c
+++ b/tests/capi/doc/chfl_topology/dihedrals_count.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     // We have one dihedral angle: 0-1-2-3
     chfl_topology_add_bond(topology, 0, 1);
@@ -24,7 +24,7 @@ int main() {
     chfl_topology_dihedrals_count(topology, &dihedrals);
     assert(dihedrals == 1);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/from_frame.c
+++ b/tests/capi/doc/chfl_topology/from_frame.c
@@ -13,8 +13,8 @@ int main() {
         /* handle error */
     }
 
-    chfl_topology_free(topology);
-    chfl_frame_free(frame);
+    chfl_free(topology);
+    chfl_free(frame);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/impropers.c
+++ b/tests/capi/doc/chfl_topology/impropers.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 3, 0);
     chfl_topology_add_bond(topology, 3, 1);
@@ -26,7 +26,7 @@ int main() {
     assert(impropers[0][2] == 1);
     assert(impropers[0][3] == 2);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/impropers_count.c
+++ b/tests/capi/doc/chfl_topology/impropers_count.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 1, 0);
     chfl_topology_add_bond(topology, 1, 2);
@@ -23,7 +23,7 @@ int main() {
     chfl_topology_impropers_count(topology, &impropers);
     assert(impropers == 1);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/remove.c
+++ b/tests/capi/doc/chfl_topology/remove.c
@@ -16,8 +16,8 @@ int main() {
     chfl_topology_add_atom(topology, H);
     chfl_topology_add_atom(topology, H);
     chfl_topology_add_atom(topology, O);
-    chfl_atom_free(O);
-    chfl_atom_free(H);
+    chfl_free(O);
+    chfl_free(H);
 
     uint64_t atoms = 0;
     chfl_topology_atoms_count(topology, &atoms);
@@ -28,7 +28,7 @@ int main() {
     chfl_topology_atoms_count(topology, &atoms);
     assert(atoms == 3);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/remove_bond.c
+++ b/tests/capi/doc/chfl_topology/remove_bond.c
@@ -13,7 +13,7 @@ int main() {
     for (size_t i=0; i<5; i++) {
         chfl_topology_add_atom(topology, atom);
     }
-    chfl_atom_free(atom);
+    chfl_free(atom);
 
     chfl_topology_add_bond(topology, 0, 1);
     chfl_topology_add_bond(topology, 1, 2);
@@ -28,7 +28,7 @@ int main() {
     chfl_topology_bonds_count(topology, &bonds);
     assert(bonds == 2);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/residues_count.c
+++ b/tests/capi/doc/chfl_topology/residues_count.c
@@ -11,13 +11,13 @@ int main() {
 
     CHFL_RESIDUE* residue = chfl_residue("res");
     chfl_topology_add_residue(topology, residue);
-    chfl_residue_free(residue);
+    chfl_free(residue);
 
     uint64_t residues = 0;
     chfl_topology_residues_count(topology, &residues);
     assert(residues == 1);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/residues_linked.c
+++ b/tests/capi/doc/chfl_topology/residues_linked.c
@@ -17,10 +17,10 @@ int main() {
     bool linked = false;
     chfl_topology_residues_linked(topology, first, second, &linked);
 
-    chfl_residue_free(first);
-    chfl_residue_free(second);
+    chfl_free(first);
+    chfl_free(second);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_topology/resize.c
+++ b/tests/capi/doc/chfl_topology/resize.c
@@ -15,7 +15,7 @@ int main() {
     chfl_topology_atoms_count(topology, &atoms);
     assert(atoms == 67);
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     // [example]
     return 0;
 }

--- a/tests/capi/doc/chfl_trajectory/nsteps.c
+++ b/tests/capi/doc/chfl_trajectory/nsteps.c
@@ -17,7 +17,7 @@ int main() {
         /* Do stuff with the frame */
     }
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     chfl_trajectory_close(trajectory);
     // [example]
     return 0;

--- a/tests/capi/doc/chfl_trajectory/read.c
+++ b/tests/capi/doc/chfl_trajectory/read.c
@@ -17,7 +17,7 @@ int main() {
     chfl_trajectory_read(trajectory, frame);
     /* We can use the second frame here */
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     chfl_trajectory_close(trajectory);
     // [example]
     return 0;

--- a/tests/capi/doc/chfl_trajectory/read_step.c
+++ b/tests/capi/doc/chfl_trajectory/read_step.c
@@ -12,7 +12,7 @@ int main() {
 
     /* We can use the 42nd frame here */
 
-    chfl_frame_free(frame);
+    chfl_free(frame);
     chfl_trajectory_close(trajectory);
     // [example]
     return 0;

--- a/tests/capi/doc/chfl_trajectory/set_cell.c
+++ b/tests/capi/doc/chfl_trajectory/set_cell.c
@@ -12,7 +12,7 @@ int main() {
 
     /* Reading from the trajectory use the cell */
 
-    chfl_cell_free(cell);
+    chfl_free(cell);
     chfl_trajectory_close(trajectory);
     // [example]
     return 0;

--- a/tests/capi/doc/chfl_trajectory/set_topology.c
+++ b/tests/capi/doc/chfl_trajectory/set_topology.c
@@ -13,7 +13,7 @@ int main() {
 
     /* Reading from the trajectory use the topology we built */
 
-    chfl_topology_free(topology);
+    chfl_free(topology);
     chfl_trajectory_close(trajectory);
     // [example]
     return 0;

--- a/tests/capi/doc/chfl_trajectory/write.c
+++ b/tests/capi/doc/chfl_trajectory/write.c
@@ -15,7 +15,7 @@ int main() {
     }
 
     chfl_trajectory_close(trajectory);
-    chfl_frame_free(frame);
+    chfl_free(frame);
     // [example]
 
     remove("water.xyz");

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -25,7 +25,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_atoms_count(frame, &natoms));
         CHECK(natoms == 3);
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Step") {
@@ -40,7 +40,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_step(frame, &step));
         CHECK(step == 42);
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Positions") {
@@ -67,7 +67,7 @@ TEST_CASE("chfl_frame") {
             }
         }
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Velocities") {
@@ -101,7 +101,7 @@ TEST_CASE("chfl_frame") {
             }
         }
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Unit cell") {
@@ -122,14 +122,14 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_cell_shape(cell, &shape));
         CHECK(shape == CHFL_CELL_INFINITE);
 
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         // Setting an unit cell
         lengths[0] = 3; lengths[1] = 4; lengths[2] = 5;
         cell = chfl_cell(lengths);
         REQUIRE(cell);
         CHECK_STATUS(chfl_frame_set_cell(frame, cell));
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         cell = chfl_cell_from_frame(frame);
         REQUIRE(cell);
@@ -142,8 +142,8 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_cell_shape(cell, &shape));
         CHECK(shape == CHFL_CELL_ORTHORHOMBIC);
 
-        CHECK_STATUS(chfl_cell_free(cell));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(cell);
+        chfl_free(frame);
     }
 
     SECTION("Add atoms") {
@@ -161,7 +161,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_add_atom(frame, atom, position, nullptr));
         chfl_vector3d velocity = {1, 2, 1};
         CHECK_STATUS(chfl_frame_add_atom(frame, atom, position, velocity));
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         CHECK_STATUS(chfl_frame_atoms_count(frame, &natoms));
         CHECK(natoms == 2);
@@ -189,7 +189,7 @@ TEST_CASE("chfl_frame") {
         CHECK(velocities[1][1] == 2);
         CHECK(velocities[1][2] == 1);
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Topology") {
@@ -209,11 +209,11 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_topology_add_atom(topology, Ar));
         CHECK_STATUS(chfl_topology_add_atom(topology, Zn));
         CHECK_STATUS(chfl_topology_add_atom(topology, Ar));
-        CHECK_STATUS(chfl_atom_free(Zn));
-        CHECK_STATUS(chfl_atom_free(Ar));
+        chfl_free(Zn);
+        chfl_free(Ar);
 
         CHECK_STATUS(chfl_frame_set_topology(frame, topology));
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
 
         const CHFL_TOPOLOGY* check_topology = chfl_topology_from_frame(frame);
         REQUIRE(check_topology);
@@ -222,8 +222,8 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_topology_atoms_count(check_topology, &natoms));
         CHECK(natoms == 4);
 
-        CHECK_STATUS(chfl_topology_free(check_topology));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(check_topology);
+        chfl_free(frame);
     }
 
     SECTION("Change topology") {
@@ -245,14 +245,14 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_topology_add_bond(new_topology, 3, 2));
 
         CHECK_STATUS(chfl_frame_set_topology(frame, new_topology));
-        CHECK_STATUS(chfl_topology_free(new_topology));
+        chfl_free(new_topology);
 
         // Topology changed
         CHECK_STATUS(chfl_topology_bonds_count(topology, &nbonds));
         CHECK(nbonds == 2);
 
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(topology);
+        chfl_free(frame);
     }
 
     SECTION("Get atoms") {
@@ -266,21 +266,21 @@ TEST_CASE("chfl_frame") {
         char name[32] = {0};
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string(""));
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         // Get the same atom twice
         CHFL_ATOM* first = chfl_atom_from_frame(frame, 1);
         CHFL_ATOM* second = chfl_atom_from_frame(frame, 1);
         REQUIRE(first);
         REQUIRE(second);
-        CHECK_STATUS(chfl_atom_free(first));
-        CHECK_STATUS(chfl_atom_free(second));
+        chfl_free(first);
+        chfl_free(second);
 
         // Out of bounds access
         atom = chfl_atom_from_frame(frame, 10000);
         CHECK_FALSE(atom);
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Guess topology") {
@@ -290,7 +290,7 @@ TEST_CASE("chfl_frame") {
         chfl_vector3d lengths = {30, 30, 30};
         CHFL_CELL* cell = chfl_cell(lengths);
         CHECK_STATUS(chfl_trajectory_set_cell(trajectory, cell));
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         CHFL_FRAME* frame = chfl_frame();
         REQUIRE(frame);
@@ -310,9 +310,9 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_topology_dihedrals_count(topology, &n));
         CHECK(n == 0);
 
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(topology);
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("PBC distance, angles and dihedrals") {
@@ -354,8 +354,8 @@ TEST_CASE("chfl_frame") {
         CHECK(chfl_frame_dihedral(frame, 0, 6, 2, 3, &distance) == CHFL_OUT_OF_BOUNDS);
         CHECK(chfl_frame_out_of_plane(frame, 0, 6, 2, 3, &distance) == CHFL_OUT_OF_BOUNDS);
 
-        CHECK_STATUS(chfl_atom_free(atom));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(atom);
+        chfl_free(frame);
     }
 
     SECTION("Property") {
@@ -366,14 +366,14 @@ TEST_CASE("chfl_frame") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_frame_set_property(frame, "this", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
         property = nullptr;
 
         property = chfl_frame_get_property(frame, "this");
         double value = 0;
         CHECK_STATUS(chfl_property_get_double(property, &value));
         CHECK(value == -23);
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
 
         CHECK_FALSE(chfl_frame_get_property(frame, "that"));
 
@@ -381,7 +381,7 @@ TEST_CASE("chfl_frame") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_frame_set_property(frame, "that", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
 
         uint64_t count = 0;
         CHECK_STATUS(chfl_frame_properties_count(frame, &count));
@@ -397,7 +397,7 @@ TEST_CASE("chfl_frame") {
             CHECK(names[1] == std::string("this"));
         }
 
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(frame);
     }
 
     SECTION("Bonds") {
@@ -432,7 +432,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_remove_bond(frame, 0, 2));
 
         // We need to get a new copy of the topology
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
         topology = chfl_topology_from_frame(frame);
         REQUIRE(topology);
 
@@ -451,8 +451,8 @@ TEST_CASE("chfl_frame") {
         chfl_topology_bond_order(topology, 0, 3, &bond_order);
         CHECK(bond_order == CHFL_BOND_TRIPLE);
 
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(topology);
+        chfl_free(frame);
     }
 
     SECTION("Residues") {
@@ -463,7 +463,7 @@ TEST_CASE("chfl_frame") {
             CHFL_RESIDUE* residue = chfl_residue("X");
             REQUIRE(residue);
             CHECK_STATUS(chfl_frame_add_residue(frame, residue));
-            CHECK_STATUS(chfl_residue_free(residue));
+            chfl_free(residue);
         }
 
         const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
@@ -473,7 +473,7 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_topology_residues_count(topology, &count));
         CHECK(count == 3);
 
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(topology);
+        chfl_free(frame);
     }
 }

--- a/tests/capi/property.cpp
+++ b/tests/capi/property.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Property") {
         CHECK_STATUS(chfl_property_get_kind(property, &kind));
         CHECK(kind == CHFL_PROPERTY_BOOL);
 
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
     }
 
     SECTION("Double") {
@@ -47,7 +47,7 @@ TEST_CASE("Property") {
         CHECK_STATUS(chfl_property_get_kind(property, &kind));
         CHECK(kind == CHFL_PROPERTY_DOUBLE);
 
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
     }
 
     SECTION("String") {
@@ -69,7 +69,7 @@ TEST_CASE("Property") {
         CHECK_STATUS(chfl_property_get_kind(property, &kind));
         CHECK(kind == CHFL_PROPERTY_STRING);
 
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
     }
 
     SECTION("Vector3D") {
@@ -94,6 +94,6 @@ TEST_CASE("Property") {
         CHECK_STATUS(chfl_property_get_kind(property, &kind));
         CHECK(kind == CHFL_PROPERTY_VECTOR3D);
 
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
     }
 }

--- a/tests/capi/residue.cpp
+++ b/tests/capi/residue.cpp
@@ -14,7 +14,7 @@ TEST_CASE("chfl_residue") {
         CHECK_STATUS(chfl_residue_name(residue, name, sizeof(name)));
         CHECK(name == std::string("Foo"));
 
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
     }
 
     SECTION("Id") {
@@ -25,14 +25,14 @@ TEST_CASE("chfl_residue") {
         CHECK_STATUS(chfl_residue_id(residue, &resid));
         CHECK(resid == 5426);
 
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
 
         residue = chfl_residue("");
         REQUIRE(residue);
 
         CHECK(chfl_residue_id(residue, &resid) == CHFL_GENERIC_ERROR);
 
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
     }
 
     SECTION("Atoms") {
@@ -62,7 +62,7 @@ TEST_CASE("chfl_residue") {
         CHECK(atoms[1] == 1);
         CHECK(atoms[2] == 20);
 
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
     }
 
     SECTION("Topology") {
@@ -80,7 +80,7 @@ TEST_CASE("chfl_residue") {
         CHECK(size == 0);
 
         CHECK_STATUS(chfl_topology_add_residue(topology, residue));
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
 
         CHECK_STATUS(chfl_topology_residues_count(topology, &size));
         CHECK(size == 1);
@@ -90,7 +90,7 @@ TEST_CASE("chfl_residue") {
         uint64_t resid = 0;
         CHECK_STATUS(chfl_residue_id(checking_residue, &resid));
         CHECK(resid == 56);
-        CHECK_STATUS(chfl_residue_free(checking_residue));
+        chfl_free(checking_residue);
 
         checking_residue = chfl_residue_from_topology(topology, 10);
         CHECK_FALSE(checking_residue);
@@ -101,13 +101,13 @@ TEST_CASE("chfl_residue") {
         resid = 0;
         CHECK_STATUS(chfl_residue_id(checking_residue, &resid));
         CHECK(resid == 56);
-        CHECK_STATUS(chfl_residue_free(checking_residue));
+        chfl_free(checking_residue);
 
         checking_residue = chfl_residue_for_atom(topology, 10);
         CHECK_FALSE(checking_residue);
 
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_residue_free(checking_residue));
+        chfl_free(topology);
+        chfl_free(checking_residue);
     }
 
     SECTION("Property") {
@@ -118,14 +118,14 @@ TEST_CASE("chfl_residue") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_residue_set_property(residue, "this", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
         property = nullptr;
 
         property = chfl_residue_get_property(residue, "this");
         double value = 0;
         CHECK_STATUS(chfl_property_get_double(property, &value));
         CHECK(value == -23);
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
 
         CHECK_FALSE(chfl_residue_get_property(residue, "that"));
 
@@ -133,7 +133,7 @@ TEST_CASE("chfl_residue") {
         REQUIRE(property);
 
         CHECK_STATUS(chfl_residue_set_property(residue, "that", property));
-        CHECK_STATUS(chfl_property_free(property));
+        chfl_free(property);
 
         uint64_t count = 0;
         CHECK_STATUS(chfl_residue_properties_count(residue, &count));
@@ -149,7 +149,7 @@ TEST_CASE("chfl_residue") {
             CHECK(names[1] == std::string("this"));
         }
 
-        CHECK_STATUS(chfl_residue_free(residue));
+        chfl_free(residue);
     }
 
 }

--- a/tests/capi/selections.cpp
+++ b/tests/capi/selections.cpp
@@ -17,7 +17,7 @@ TEST_CASE("chfl_selection") {
         CHECK_STATUS(chfl_selection_string(selection, buffer, sizeof(buffer)));
         CHECK(buffer == std::string("name O"));
 
-        CHECK_STATUS(chfl_selection_free(selection));
+        chfl_free(selection);
 
         selection = chfl_selection("angles: all");
         REQUIRE(selection);
@@ -25,7 +25,7 @@ TEST_CASE("chfl_selection") {
         CHECK_STATUS(chfl_selection_string(selection, buffer, sizeof(buffer)));
         CHECK(buffer == std::string("angles: all"));
 
-        CHECK_STATUS(chfl_selection_free(selection));
+        chfl_free(selection);
     }
 
     SECTION("Size") {
@@ -36,7 +36,7 @@ TEST_CASE("chfl_selection") {
         CHECK_STATUS(chfl_selection_size(selection, &size));
         CHECK(size == 1);
 
-        CHECK_STATUS(chfl_selection_free(selection));
+        chfl_free(selection);
 
         selection = chfl_selection("angles: all");
         REQUIRE(selection);
@@ -44,7 +44,7 @@ TEST_CASE("chfl_selection") {
         CHECK_STATUS(chfl_selection_size(selection, &size));
         CHECK(size == 3);
 
-        CHECK_STATUS(chfl_selection_free(selection));
+        chfl_free(selection);
     }
 
     SECTION("Evaluate") {
@@ -73,7 +73,7 @@ TEST_CASE("chfl_selection") {
         CHECK(matches[1].atoms[3] == static_cast<uint64_t>(-1));
         delete[] matches;
 
-        CHECK_STATUS(chfl_selection_free(selection));
+        chfl_free(selection);
 
         selection = chfl_selection("angles: all");
         REQUIRE(selection);
@@ -93,8 +93,8 @@ TEST_CASE("chfl_selection") {
         CHECK(find_match(matches, matches_count, match_2));
         delete[] matches;
 
-        CHECK_STATUS(chfl_selection_free(selection));
-        CHECK_STATUS(chfl_frame_free(frame));
+        chfl_free(selection);
+        chfl_free(frame);
     }
 }
 
@@ -110,8 +110,8 @@ static CHFL_FRAME* testing_frame(void) {
     CHECK_STATUS(chfl_topology_add_atom(topology, O));
     CHECK_STATUS(chfl_topology_add_atom(topology, O));
     CHECK_STATUS(chfl_topology_add_atom(topology, H));
-    CHECK_STATUS(chfl_atom_free(O));
-    CHECK_STATUS(chfl_atom_free(H));
+    chfl_free(O);
+    chfl_free(H);
 
     CHECK_STATUS(chfl_topology_add_bond(topology, 0, 1));
     CHECK_STATUS(chfl_topology_add_bond(topology, 1, 2));
@@ -121,7 +121,7 @@ static CHFL_FRAME* testing_frame(void) {
     REQUIRE(frame);
     CHECK_STATUS(chfl_frame_resize(frame, 4));
     CHECK_STATUS(chfl_frame_set_topology(frame, topology));
-    CHECK_STATUS(chfl_topology_free(topology));
+    chfl_free(topology);
     return frame;
 }
 

--- a/tests/capi/topology.cpp
+++ b/tests/capi/topology.cpp
@@ -20,7 +20,7 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_atoms_count(topology, &natoms));
         CHECK(natoms == 42);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Atoms") {
@@ -41,13 +41,13 @@ TEST_CASE("chfl_topology") {
         char name[32];
         CHECK_STATUS(chfl_atom_type(atom, name, sizeof(name)));
         CHECK(name == std::string("H"));
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         // Out of bound access
         atom = chfl_atom_from_topology(topology, 10000);
         CHECK_FALSE(atom);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Bonds") {
@@ -71,7 +71,7 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_bonds_count(topology, &n));
         CHECK(n == 2);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Angles") {
@@ -95,7 +95,7 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_angles_count(topology, &n));
         CHECK(n == 1);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Dihedrals") {
@@ -117,7 +117,7 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_dihedrals_count(topology, &n));
         CHECK(n == 0);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Impropers") {
@@ -128,7 +128,7 @@ TEST_CASE("chfl_topology") {
         REQUIRE(H);
         CHECK_STATUS(chfl_topology_add_atom(topology, H));
         CHECK_STATUS(chfl_topology_add_bond(topology, 2, 4));
-        CHECK_STATUS(chfl_atom_free(H));
+        chfl_free(H);
 
         uint64_t n = 0;
         CHECK_STATUS(chfl_topology_impropers_count(topology, &n));
@@ -145,7 +145,7 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_impropers_count(topology, &n));
         CHECK(n == 0);
 
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(topology);
     }
 
     SECTION("Residues") {
@@ -156,7 +156,7 @@ TEST_CASE("chfl_topology") {
         for (uint64_t i=0; i<10; i++) {
             CHECK_STATUS(chfl_topology_add_atom(topology, atom));
         }
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         uint64_t residues[3][3] = {{2, 3, 6}, {0, 1, 9}, {4, 5, 8}};
         for (uint64_t i=0; i<3; i++) {
@@ -167,7 +167,7 @@ TEST_CASE("chfl_topology") {
             }
 
             CHECK_STATUS(chfl_topology_add_residue(topology, residue));
-            CHECK_STATUS(chfl_residue_free(residue));
+            chfl_free(residue);
         }
 
         uint64_t count = 0;
@@ -190,9 +190,9 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_residues_linked(topology, first, second, &linked));
         CHECK(linked == true);
 
-        CHECK_STATUS(chfl_residue_free(first));
-        CHECK_STATUS(chfl_residue_free(second));
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(first);
+        chfl_free(second);
+        chfl_free(topology);
     }
 }
 
@@ -210,8 +210,8 @@ static CHFL_TOPOLOGY* testing_topology() {
     CHECK_STATUS(chfl_topology_add_atom(topology, O));
     CHECK_STATUS(chfl_topology_add_atom(topology, H));
 
-    CHECK_STATUS(chfl_atom_free(O));
-    CHECK_STATUS(chfl_atom_free(H));
+    chfl_free(O);
+    chfl_free(H);
 
     CHECK_STATUS(chfl_topology_add_bond(topology, 0, 1));
     CHECK_STATUS(chfl_topology_add_bond(topology, 1, 2));

--- a/tests/capi/trajectory.cpp
+++ b/tests/capi/trajectory.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_trajectory_path(trajectory, &path));
         CHECK(std::string(path) == "data/xyz/water.xyz");
 
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Number of steps") {
@@ -30,7 +30,7 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_trajectory_nsteps(trajectory, &nsteps));
         CHECK(nsteps == 100);
 
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Open with format") {
@@ -45,8 +45,8 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_frame_atoms_count(frame, &natoms));
         CHECK(natoms == 125);
 
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Read next step") {
@@ -76,8 +76,8 @@ TEST_CASE("Read trajectory") {
             CHECK(data[124][i] == positions_124[i]);
         }
 
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Read specific step") {
@@ -103,8 +103,8 @@ TEST_CASE("Read trajectory") {
             CHECK(positions[124][i] == positions_124[i]);
         }
 
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Get topology") {
@@ -133,10 +133,10 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string("O"));
 
-        CHECK_STATUS(chfl_atom_free(atom));
-        CHECK_STATUS(chfl_topology_free(topology));
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(atom);
+        chfl_free(topology);
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Set cell") {
@@ -146,7 +146,7 @@ TEST_CASE("Read trajectory") {
         chfl_vector3d lengths = {30, 30, 30};
         CHFL_CELL* cell = chfl_cell(lengths);
         CHECK_STATUS(chfl_trajectory_set_cell(trajectory, cell));
-        CHECK_STATUS(chfl_cell_free(cell));
+        chfl_free(cell);
 
         CHFL_FRAME* frame = chfl_frame();
         REQUIRE(frame);
@@ -161,9 +161,9 @@ TEST_CASE("Read trajectory") {
         CHECK(data[1] == 30.0);
         CHECK(data[2] == 30.0);
 
-        CHECK_STATUS(chfl_cell_free(cell));
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(cell);
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Set topology") {
@@ -181,8 +181,8 @@ TEST_CASE("Read trajectory") {
 
         CHECK_STATUS(chfl_trajectory_set_topology(trajectory, topology));
 
-        CHECK_STATUS(chfl_atom_free(atom));
-        CHECK_STATUS(chfl_topology_free(topology));
+        chfl_free(atom);
+        chfl_free(topology);
 
         CHFL_FRAME* frame = chfl_frame();
         REQUIRE(frame);
@@ -193,9 +193,9 @@ TEST_CASE("Read trajectory") {
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string("Cs"));
 
-        CHECK_STATUS(chfl_atom_free(atom));
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(atom);
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 
     SECTION("Set topology from file") {
@@ -212,7 +212,7 @@ TEST_CASE("Read trajectory") {
         char name[32] = {0};
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string("Zn"));
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
         CHECK_STATUS(chfl_trajectory_topology_file(trajectory, "data/xyz/topology.xyz.topology", "XYZ"));
         CHECK_STATUS(chfl_trajectory_read(trajectory, frame));
@@ -220,10 +220,10 @@ TEST_CASE("Read trajectory") {
         atom = chfl_atom_from_frame(frame, 0);
         CHECK_STATUS(chfl_atom_name(atom, name, sizeof(name)));
         CHECK(name == std::string("Zn"));
-        CHECK_STATUS(chfl_atom_free(atom));
+        chfl_free(atom);
 
-        CHECK_STATUS(chfl_frame_free(frame));
-        CHECK_STATUS(chfl_trajectory_close(trajectory));
+        chfl_free(frame);
+        chfl_trajectory_close(trajectory);
     }
 }
 
@@ -245,8 +245,8 @@ TEST_CASE("Write trajectory") {
 
     CHECK_STATUS(chfl_trajectory_write(trajectory, frame));
 
-    CHECK_STATUS(chfl_frame_free(frame));
-    CHECK_STATUS(chfl_trajectory_close(trajectory));
+    chfl_free(frame);
+    chfl_trajectory_close(trajectory);
 
     std::ifstream file(filename);
     REQUIRE(file.is_open());
@@ -266,14 +266,14 @@ static CHFL_FRAME* testing_frame() {
     for (unsigned i=0; i<4; i++) {
         CHECK_STATUS(chfl_topology_add_atom(topology, atom));
     }
-    CHECK_STATUS(chfl_atom_free(atom));
+    chfl_free(atom);
 
     CHFL_FRAME* frame = chfl_frame();
     REQUIRE(frame);
     CHECK_STATUS(chfl_frame_resize(frame, 4));
 
     CHECK_STATUS(chfl_frame_set_topology(frame, topology));
-    CHECK_STATUS(chfl_topology_free(topology));
+    chfl_free(topology);
 
     chfl_vector3d* positions = nullptr;
     uint64_t natoms = 0;


### PR DESCRIPTION
This allows to only provide chfl_free for memory release, instead of having separate functions for atoms, cell, topology, ...

I would like to incorporate this in the 0.9 release, what do you think? It feels like it belongs to the same changeset as the shared allocator.