### PR TITLE
Add a cache for sub-selections

### DIFF
--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -25,6 +25,9 @@ public:
     virtual std::string print(unsigned delta = 0) const = 0;
     /// Check if the `match` is valid in the given `frame`.
     virtual bool is_match(const Frame& frame, const Match& match) const = 0;
+    /// Clear any cached data. This must be called before using the selection
+    /// with a new frame
+    virtual void clear() = 0;
     /// Optimize the AST corresponding to this Selector. Currently, this only
     /// perform constant propgations in mathematical expressions.
     virtual void optimize() {}
@@ -47,6 +50,7 @@ public:
     And(Ast lhs, Ast rhs): lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     Ast lhs_;
     Ast rhs_;
@@ -58,6 +62,7 @@ public:
     Or(Ast lhs, Ast rhs): lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     Ast lhs_;
     Ast rhs_;
@@ -69,6 +74,7 @@ public:
     explicit Not(Ast ast): ast_(std::move(ast)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     Ast ast_;
 };
@@ -79,6 +85,7 @@ public:
     All() = default;
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override {}
 };
 
 /// Selection matching no atoms
@@ -87,6 +94,7 @@ public:
     None() = default;
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override {}
 };
 
 /// Selection based on boolean properties
@@ -96,6 +104,7 @@ public:
         property_(std::move(property)), argument_(argument) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override {}
 
 private:
     std::string property_;
@@ -115,6 +124,8 @@ public:
     std::vector<size_t> eval(const Frame& frame, const Match& match) const;
     /// Pretty-print the sub-selection
     std::string print() const;
+    /// Clear cached data
+    void clear();
 
     bool is_variable() const {
         return selection_ == nullptr;
@@ -133,6 +144,7 @@ public:
     IsBonded(SubSelection i, SubSelection j): i_(std::move(i)), j_(std::move(j)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     SubSelection i_;
     SubSelection j_;
@@ -145,6 +157,7 @@ public:
         i_(std::move(i)), j_(std::move(j)), k_(std::move(k)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     SubSelection i_;
     SubSelection j_;
@@ -158,6 +171,7 @@ public:
         i_(std::move(i)), j_(std::move(j)), k_(std::move(k)), m_(std::move(m)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     SubSelection i_;
     SubSelection j_;
@@ -172,6 +186,7 @@ public:
         i_(std::move(i)), j_(std::move(j)), k_(std::move(k)), m_(std::move(m)) {}
     std::string print(unsigned delta) const override;
     bool is_match(const Frame& frame, const Match& match) const override;
+    void clear() override;
 private:
     SubSelection i_;
     SubSelection j_;
@@ -221,6 +236,7 @@ public:
 
     const std::string& value(const Frame& frame, size_t i) const override;
     std::string name() const override;
+    void clear() override {}
 
 private:
     std::string property_;
@@ -234,6 +250,7 @@ public:
 
     std::string name() const override;
     const std::string& value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 /// Select atoms using their name
@@ -244,6 +261,7 @@ public:
 
     std::string name() const override;
     const std::string& value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 /// Select atoms using their residue name
@@ -254,6 +272,7 @@ public:
 
     std::string name() const override;
     const std::string& value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 class MathExpr;
@@ -276,6 +295,7 @@ public:
     bool is_match(const Frame& frame, const Match& match) const override;
     void optimize() override;
     std::string print(unsigned delta) const override;
+    void clear() override;
 
 private:
     Operator op_;
@@ -302,6 +322,9 @@ public:
     /// value if possible.
     virtual optional<double> optimize() = 0;
 
+    /// Clear any cached data
+    virtual void clear() = 0;
+
     /// Pretty-print the expression
     virtual std::string print() const = 0;
 };
@@ -314,6 +337,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -327,6 +352,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -340,6 +367,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -353,6 +382,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -366,6 +397,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -379,6 +412,7 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
 
 private:
     MathAst ast_;
@@ -392,6 +426,8 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
+
 private:
     MathAst lhs_;
     MathAst rhs_;
@@ -406,6 +442,7 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override;
 
 private:
     std::function<double(double)> fn_;
@@ -421,6 +458,7 @@ public:
     double eval(const Frame& frame, const Match& match) const override;
     optional<double> optimize() override;
     std::string print() const override;
+    void clear() override {}
 
 private:
     double value_;
@@ -436,6 +474,7 @@ public:
         return nullopt;
     }
     std::string print() const override;
+    void clear() override {}
 
 private:
     Variable i_;
@@ -452,6 +491,7 @@ public:
         return nullopt;
     }
     std::string print() const override;
+    void clear() override {}
 
 private:
     Variable i_;
@@ -469,6 +509,7 @@ public:
         return nullopt;
     }
     std::string print() const override;
+    void clear() override {}
 
 private:
     Variable i_;
@@ -487,6 +528,7 @@ public:
         return nullopt;
     }
     std::string print() const override;
+    void clear() override {}
 
 private:
     Variable i_;
@@ -511,10 +553,11 @@ public:
     optional<double> optimize() override final;
     std::string print() const override final;
 
-    /// Get the value of the property for the atom at index `i` in the `frame`
+    /// Get the value for the atom at index `i` in the `frame`
     virtual double value(const Frame& frame, size_t i) const = 0;
-    /// Get the name of the property
+    /// Get the name of the selector
     virtual std::string name() const = 0;
+
 private:
     /// Which atom in the candidate match are we checking?
     Variable argument_;
@@ -526,6 +569,7 @@ public:
     NumericProperty(std::string property, Variable argument): NumericSelector(argument), property_(std::move(property)) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 
 private:
     std::string property_;
@@ -538,6 +582,7 @@ public:
     Index(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 /// Select atoms using their residue id (residue number)
@@ -546,6 +591,7 @@ public:
     Resid(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 /// Select atoms using their mass.
@@ -554,6 +600,7 @@ public:
     Mass(Variable argument): NumericSelector(argument) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
 };
 
 enum class Coordinate {
@@ -570,6 +617,8 @@ public:
     Position(Variable argument, Coordinate coordinate): NumericSelector(argument), coordinate_(coordinate) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
+
 private:
     Coordinate coordinate_;
 };
@@ -582,6 +631,8 @@ public:
     Velocity(Variable argument, Coordinate coordinate): NumericSelector(argument), coordinate_(coordinate) {}
     std::string name() const override;
     double value(const Frame& frame, size_t i) const override;
+    void clear() override {}
+
 private:
     Coordinate coordinate_;
 };

--- a/include/chemfiles/selections/expr.hpp
+++ b/include/chemfiles/selections/expr.hpp
@@ -121,7 +121,7 @@ public:
     SubSelection(std::string selection);
 
     /// Evaluate the sub-selection and return the list of matching atoms
-    std::vector<size_t> eval(const Frame& frame, const Match& match) const;
+    const std::vector<size_t>& eval(const Frame& frame, const Match& match) const;
     /// Pretty-print the sub-selection
     std::string print() const;
     /// Clear cached data
@@ -136,6 +136,10 @@ private:
     std::unique_ptr<Selection> selection_;
     /// Variable to use if selection_ is nullptr
     Variable variable_;
+    /// Cache matches for the selection on the first call to eval
+    mutable std::vector<size_t> matches_;
+    /// Did we update the cached matches ?
+    mutable bool updated_ = false;
 };
 
 /// Checking if two atoms are bonded together

--- a/src/Selection.cpp
+++ b/src/Selection.cpp
@@ -251,6 +251,7 @@ std::vector<Match> Selection::evaluate(const Frame& frame) const {
         return ast_->is_match(f, match);
     };
 
+    ast_->clear();
     switch (context_) {
         case Context::ATOM:
             return evaluate_atoms(frame, is_match);

--- a/src/selections/expr.cpp
+++ b/src/selections/expr.cpp
@@ -53,6 +53,10 @@ std::string SubSelection::print() const {
     }
 }
 
+void SubSelection::clear() {
+    // TODO
+}
+
 std::string And::print(unsigned delta) const {
     auto lhs = lhs_->print(7);
     auto rhs = rhs_->print(7);
@@ -61,6 +65,11 @@ std::string And::print(unsigned delta) const {
 
 bool And::is_match(const Frame& frame, const Match& match) const {
     return lhs_->is_match(frame, match) && rhs_->is_match(frame, match);
+}
+
+void And::clear() {
+    lhs_->clear();
+    rhs_->clear();
 }
 
 std::string Or::print(unsigned delta) const {
@@ -73,12 +82,21 @@ bool Or::is_match(const Frame& frame, const Match& match) const {
     return lhs_->is_match(frame, match) || rhs_->is_match(frame, match);
 }
 
+void Or::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 std::string Not::print(unsigned /*unused*/) const {
     return "not " + ast_->print(4);
 }
 
 bool Not::is_match(const Frame& frame, const Match& match) const {
     return !ast_->is_match(frame, match);
+}
+
+void Not::clear() {
+    ast_->clear();
 }
 
 std::string All::print(unsigned /*unused*/) const {
@@ -145,6 +163,11 @@ bool IsBonded::is_match(const Frame& frame, const Match& match) const {
     return false;
 }
 
+void IsBonded::clear() {
+    i_.clear();
+    j_.clear();
+}
+
 std::string IsAngle::print(unsigned /*unused*/) const {
     return fmt::format("is_angle({}, {}, {})", i_.print(), j_.print(), k_.print());
 }
@@ -168,6 +191,12 @@ bool IsAngle::is_match(const Frame& frame, const Match& match) const {
         }
     }
     return false;
+}
+
+void IsAngle::clear() {
+    i_.clear();
+    j_.clear();
+    k_.clear();
 }
 
 std::string IsDihedral::print(unsigned /*unused*/) const {
@@ -197,6 +226,13 @@ bool IsDihedral::is_match(const Frame& frame, const Match& match) const {
     return false;
 }
 
+void IsDihedral::clear() {
+    i_.clear();
+    j_.clear();
+    k_.clear();
+    m_.clear();
+}
+
 std::string IsImproper::print(unsigned /*unused*/) const {
     return fmt::format("is_improper({}, {}, {}, {})", i_.print(), j_.print(), k_.print(), m_.print());
 }
@@ -222,6 +258,13 @@ bool IsImproper::is_match(const Frame& frame, const Match& match) const {
         }
     }
     return false;
+}
+
+void IsImproper::clear() {
+    i_.clear();
+    j_.clear();
+    k_.clear();
+    m_.clear();
 }
 
 std::string StringSelector::print(unsigned /*unused*/) const {
@@ -351,6 +394,11 @@ void Math::optimize() {
     }
 }
 
+void Math::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 double Add::eval(const Frame& frame, const Match& match) const {
     return lhs_->eval(frame, match) + rhs_->eval(frame, match);
 }
@@ -370,6 +418,11 @@ optional<double> Add::optimize() {
 
 std::string Add::print() const {
     return fmt::format("({} + {})", lhs_->print(), rhs_->print());
+}
+
+void Add::clear() {
+    lhs_->clear();
+    rhs_->clear();
 }
 
 double Sub::eval(const Frame& frame, const Match& match) const {
@@ -393,6 +446,11 @@ std::string Sub::print() const {
     return fmt::format("({} - {})", lhs_->print(), rhs_->print());
 }
 
+void Sub::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 double Mul::eval(const Frame& frame, const Match& match) const {
     return lhs_->eval(frame, match) * rhs_->eval(frame, match);
 }
@@ -412,6 +470,11 @@ optional<double> Mul::optimize() {
 
 std::string Mul::print() const {
     return fmt::format("({} * {})", lhs_->print(), rhs_->print());
+}
+
+void Mul::clear() {
+    lhs_->clear();
+    rhs_->clear();
 }
 
 double Div::eval(const Frame& frame, const Match& match) const {
@@ -435,6 +498,11 @@ std::string Div::print() const {
     return fmt::format("({} / {})", lhs_->print(), rhs_->print());
 }
 
+void Div::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 double Pow::eval(const Frame& frame, const Match& match) const {
     return pow(lhs_->eval(frame, match), rhs_->eval(frame, match));
 }
@@ -456,6 +524,11 @@ std::string Pow::print() const {
     return fmt::format("{} ^({})", lhs_->print(), rhs_->print());
 }
 
+void Pow::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 double Neg::eval(const Frame& frame, const Match& match) const {
     return - ast_->eval(frame, match);
 }
@@ -471,6 +544,10 @@ optional<double> Neg::optimize() {
 
 std::string Neg::print() const {
     return fmt::format("(-{})", ast_->print());
+}
+
+void Neg::clear() {
+    ast_->clear();
 }
 
 double Mod::eval(const Frame& frame, const Match& match) const {
@@ -494,6 +571,11 @@ std::string Mod::print() const {
     return fmt::format("({} % {})", lhs_->print(), rhs_->print());
 }
 
+void Mod::clear() {
+    lhs_->clear();
+    rhs_->clear();
+}
+
 double Function::eval(const Frame& frame, const Match& match) const {
     return fn_(ast_->eval(frame, match));
 }
@@ -509,6 +591,10 @@ optional<double> Function::optimize() {
 
 std::string Function::print() const {
     return fmt::format("{}({})", name_, ast_->print());
+}
+
+void Function::clear() {
+    ast_->clear();
 }
 
 double Number::eval(const Frame& /*unused*/, const Match& /*unused*/) const {


### PR DESCRIPTION
Sub selections (the `name O` in `is_bonded(#1, name O)` where evaluated at every call to is_match, which is once by atom/bond/pairs in the system depending on the selection context.

This PR adds a way for selection element to cache data (more specifically a way to know when to clear the cached data), and uses it for sub selections.

On a test locally using [cfiles](https://github.com/chemfiles/cfiles), this makes the time for hydrogen bonds detection in a small trajectory go from 172s to 60s (almost three time faster!!) for the `name O and is_bonded (#1, name C) and is_bonded (#1, name H)` selection.