### PR TITLE
Fix PDB atom type issue

### DIFF
--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -334,10 +334,13 @@ void PDBFormat::read_ATOM(Frame& frame, const std::string& line,
         }
     }
 
-    auto atom = Atom(trim(line.substr(12, 4)));
-    if (line.length() >= 78) {
-        atom.set_type(trim(line.substr(76, 2)));
-    }
+    auto atom = (line.length() >= 78)?
+        // Read both atom name and atom type
+        Atom(trim(line.substr(12, 4)),
+             trim(line.substr(76, 2))) :
+
+        // Read just the atom name and hope for the best.
+        Atom(trim(line.substr(12, 4)));
 
     auto altloc = line.substr(16, 1);
     if (altloc != " ") {

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -135,7 +135,8 @@ TEST_CASE("Read files in PDB format") {
 
     SECTION("Read ATOM/HETATM information") {
         Trajectory file("data/pdb/hemo.pdb");
-        auto residues = file.read().topology().residues();
+        auto frame = file.read();
+        auto residues = frame.topology().residues();
 
         // HEME group is first
         CHECK(residues[0].get("is_standard_pdb")->as_bool() == false);
@@ -143,6 +144,9 @@ TEST_CASE("Read files in PDB format") {
         for (size_t i = 1; i < residues.size(); i++) {
             CHECK(residues[i].get("is_standard_pdb")->as_bool());
         }
+
+        // Check to be use we've parsed the correct atom type
+        CHECK(frame[74].mass() == 12.011);
     }
 
     SECTION("Handle multiple TER records") {


### PR DESCRIPTION
There's a problem in how the atom type in PDB files was being read. This leads to a confusion between CA (as in alpha-carbon) and Ca (as in calcium). Below is a quick fix.

Previously, the additional test failed as the mass of an alpha carbon was 40!