### PR TITLE
Bug fixes

### DIFF
--- a/include/chemfiles/Residue.hpp
+++ b/include/chemfiles/Residue.hpp
@@ -148,7 +148,16 @@ private:
     /// Additional properties of this residue
     property_map properties_;
 
+    /// Update the atomic indexes in this residue after an atom has been
+    /// removed from the containing topology.
+    ///
+    /// This function removes the atom with index `i` from this residue if it
+    /// exists, and shifts all the indexes bigger than `i` by -1.
+    void atom_removed(size_t i);
+
     friend bool operator==(const Residue& lhs, const Residue& rhs);
+
+    friend class Topology;
 };
 
 inline bool operator==(const Residue& lhs, const Residue& rhs) {

--- a/src/Residue.cpp
+++ b/src/Residue.cpp
@@ -16,3 +16,16 @@ void Residue::add_atom(size_t i) {
 bool Residue::contains(size_t i) const {
     return atoms_.find(i) != atoms_.end();
 }
+
+void Residue::atom_removed(size_t i) {
+    auto iter = atoms_.find(i);
+    if (iter != atoms_.end()) {
+        atoms_.erase(iter);
+    }
+
+    for (size_t j = 0; j < atoms_.size(); ++j) {
+        if (atoms_[j] > i) {
+            --atoms_[j];
+        }
+    }
+}

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -79,6 +79,10 @@ void Topology::remove(size_t i) {
     }
     // Shift all bonds indexes
     connect_.atom_removed(i);
+    // Remove and shift all residue atoms
+    for (auto& res : residues_) {
+        res.atom_removed(i);
+    }
 }
 
 const std::vector<Bond>& Topology::bonds() const {

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -462,7 +462,7 @@ void PDBFormat::link_standard_residue_bonds(Frame& frame) {
         }
 
         const auto& amide_nitrogen = atom_name_to_index.find("N");
-        const auto& amide_carbon = atom_name_to_index.find("O");
+        const auto& amide_carbon = atom_name_to_index.find("C");
 
         if (!residue.id()) {
             warning("got a residues without id in PDB format. This should not happen");

--- a/tests/topology.cpp
+++ b/tests/topology.cpp
@@ -321,4 +321,13 @@ TEST_CASE("Residues in topologies") {
     // A residue is linked to itself
     second = topology.residue_for_atom(0);
     CHECK(topology.are_linked(*first, *second));
+
+    // Remove an atom and ensure the residues are updated
+    topology.remove(8);
+    auto& all_residues = topology.residues();
+    CHECK(all_residues[0].size() == 3); // Not affected
+    CHECK(all_residues[1].size() == 3); // This is updated
+    CHECK(all_residues[1].contains(8));
+    CHECK(!all_residues[1].contains(9));
+    CHECK(all_residues[2].size() == 2); // Totally removed
 }


### PR DESCRIPTION
This PR has two bug fixes. 

- The first is rather minor and was the result of a typo in the PDB format code which resulted in improper linkage between peptide residues.

- The second is more complicated and involves the removal of atoms from a topology. Currently, when an atom is removed from a topology, the residues in that topology are not updated which leads to a misalignment of indicies above the index removed as well as a 'dangling' atom index. I've fixed this in two steps: the first is adding a method to the `Residue` class when removes atoms and updates the indicies above the removed index; the second is running this in a loop during the removal of an atom from a topology.

Note: I'm willing to update the other language bindings for residue atom removal as needed.