### PR TITLE
fix(README): replace outdated method in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ int main() {
     chemfiles::Trajectory trajectory("filename.xyz");
 
     auto frame = trajectory.read();
-    std::cout << "There are " << frame.natoms() << " atoms in the frame" << std::endl;
+    std::cout << "There are " << frame.size() << " atoms in the frame" << std::endl;
 
     auto positions = frame.positions();
     // Do awesome science with the positions here !


### PR DESCRIPTION
See #126. Not a big issue, but I'm just getting started and the first thing I tried didn't work.