### PR TITLE
fix(tests): missing fabs in approx_eq

### DIFF
--- a/tests/external/helpers.cpp
+++ b/tests/external/helpers.cpp
@@ -61,7 +61,7 @@ bool approx_eq(const chemfiles::Matrix3D& lhs, const chemfiles::Matrix3D& rhs, d
 }
 
 bool approx_eq(double a, double b, double tolerance) {
-    return (a - b) < tolerance;
+    return fabs(a - b) < tolerance;
 }
 
 bool is_valgrind_and_travis() {

--- a/tests/formats/xtc.cpp
+++ b/tests/formats/xtc.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Read files in XTC format") {
         frame = file.read();
 
         CHECK(frame.get("md_step")->as_double() == 200);
-        CHECK(approx_eq(frame.get("time")->as_double(), 0.6));
+        CHECK(approx_eq(frame.get("time")->as_double(), 0.4, 1e-4));
         CHECK(frame.get("xtc_precision")->as_double() == 1000);
         CHECK(frame.size() == 20455);
 


### PR DESCRIPTION
Unfortunately this breaks tests for mmcif format. The test file contains the correct entries like `_cell.length_a`, but chemfiles only seems to parse deprecated entries `_cell_length_a`.
Don't really know how to fix this easily, because I've never used this format :(