### PR TITLE
Do not resize frames to 0 when reading

### DIFF
--- a/src/formats/CSSR.cpp
+++ b/src/formats/CSSR.cpp
@@ -66,9 +66,7 @@ void CSSRFormat::read_next(Frame& frame) {
     // Title line
     file_.readline();
 
-    frame.resize(0);
     frame.reserve(natoms);
-
     std::vector<std::vector<size_t>> connectivity(natoms);
     for (size_t i=0; i<natoms; i++) {
         auto line = file_.readline();

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -41,6 +41,8 @@ template<> FormatInfo chemfiles::format_information<GROFormat>() {
 static void check_values_size(const Vector3D& values, unsigned width, const std::string& context);
 
 void GROFormat::read_next(Frame& frame) {
+    residues_.clear();
+
     size_t natoms = 0;
     try {
         // GRO comment line is used as frame name
@@ -51,10 +53,8 @@ void GROFormat::read_next(Frame& frame) {
         throw format_error("can not read next step as GRO: {}", e.what());
     }
 
-    residues_.clear();
     frame.add_velocities();
     frame.reserve(natoms);
-    frame.resize(0);
 
     for (size_t i=0; i<natoms; i++) {
         auto line = file_.readline();

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -88,8 +88,6 @@ void MMTFFormat::read_step(const size_t step, Frame& frame) {
 }
 
 void MMTFFormat::read(Frame& frame) {
-    frame.resize(0);
-
     if (structure_.unitCell.size() == 6) {
         frame.set_cell({
             static_cast<double>(structure_.unitCell[0]),

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -41,6 +41,7 @@ template<> FormatInfo chemfiles::format_information<MOL2Format>() {
 static uint64_t read_until(TextFile& file, string_view tag);
 
 void MOL2Format::read_next(Frame& frame) {
+    residues_.clear();
     auto line = file_.readline();
     if (trim(line) != "@<TRIPOS>MOLECULE") {
         throw format_error("wrong starting line for a molecule in MOL2 formart: '{}'", line);
@@ -59,12 +60,9 @@ void MOL2Format::read_next(Frame& frame) {
         nbonds = parse<size_t>(counts[1]);
     }
 
-    residues_.clear();
-    frame.resize(0);
-    frame.reserve(natoms);
 
     file_.readline();
-
+    frame.reserve(natoms);
     // If charges are specified, we need to expect an addition term for each atom
     line = file_.readline();
     bool charges = (trim(line) != "NO_CHARGES");

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -80,7 +80,6 @@ enum class Record {
 static Record get_record(string_view line);
 
 void PDBFormat::read_next(Frame& frame) {
-    frame.resize(0);
     residues_.clear();
     atom_offsets_.clear();
 

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -39,8 +39,6 @@ void XYZFormat::read_next(Frame& frame) {
     }
 
     frame.reserve(natoms);
-    frame.resize(0);
-
     for (size_t i=0; i<natoms; i++) {
         auto line = file_.readline();
         double x = 0, y = 0, z = 0;

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -211,7 +211,6 @@ void mmCIFFormat::read_step(const size_t step, Frame& frame) {
 }
 
 void mmCIFFormat::read(Frame& frame) {
-    frame.resize(0);
     residues_.clear();
     frame.set_cell(cell_);
 


### PR DESCRIPTION
There is no need to resize frames when reading to them, a new frame is created in Trajectory::read anyway.