### PR TITLE
Use codecs.open to read files with python

### DIFF
--- a/tests/lints/check-capi-docs.py
+++ b/tests/lints/check-capi-docs.py
@@ -4,8 +4,10 @@
 A small script checking that all the C API functions are documented, and have
 an example.
 """
+from __future__ import print_function
 import os
 import sys
+import codecs
 
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 ERRORS = 0
@@ -22,7 +24,7 @@ def documented_functions():
     DOCS = os.path.join(ROOT, "doc", "src", "capi")
     for (root, _, paths) in os.walk(DOCS):
         for path in paths:
-            with open(os.path.join(root, path)) as fd:
+            with codecs.open(os.path.join(root, path), encoding="utf8") as fd:
                 for line in fd:
                     if line.startswith(".. doxygenfunction::"):
                         name = line.split()[2]
@@ -35,7 +37,7 @@ def functions_in_outline():
     DOCS = os.path.join(ROOT, "doc", "src", "capi")
     for (root, _, paths) in os.walk(DOCS):
         for path in paths:
-            with open(os.path.join(root, path)) as fd:
+            with codecs.open(os.path.join(root, path), encoding="utf8") as fd:
                 for line in fd:
                     if ":cpp:func:" in line:
                         name = line.split("`")[1]
@@ -60,7 +62,7 @@ def all_functions():
     HEADERS = os.path.join(ROOT, "include", "chemfiles", "capi")
     for (root, _, paths) in os.walk(HEADERS):
         for path in paths:
-            with open(os.path.join(root, path)) as fd:
+            with codecs.open(os.path.join(root, path), encoding="utf8") as fd:
                 for line in fd:
                     if line.startswith("CHFL_EXPORT"):
                         functions.append(function_name(line))
@@ -71,7 +73,7 @@ def check_examples():
     HEADERS = os.path.join(ROOT, "include", "chemfiles", "capi")
     for (root, _, paths) in os.walk(HEADERS):
         for path in paths:
-            with open(os.path.join(root, path)) as fd:
+            with codecs.open(os.path.join(root, path), encoding="utf8") as fd:
                 in_doc = False
                 example_found = False
 

--- a/tests/lints/check-error-messages.py
+++ b/tests/lints/check-error-messages.py
@@ -3,10 +3,12 @@
 """
 Check that all error messages are formatted the same way.
 """
+from __future__ import print_function
 import os
 import sys
 import glob
 import re
+import codecs
 
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 ERRORS = 0
@@ -74,7 +76,7 @@ def check_message(path, line, message):
 
 
 def check_file(path):
-    with open(path) as fd:
+    with codecs.open(path, encoding="utf8") as fd:
         lines = [l for l in fd]
 
     for (i, line) in enumerate(lines):

--- a/tests/lints/check-public-headers.py
+++ b/tests/lints/check-public-headers.py
@@ -4,9 +4,11 @@
 This script check that only whitelisted headers are included (transitivly) by
 including chemfiles.h or chemfiles.hpp.
 """
+from __future__ import print_function
 import os
 import sys
 import re
+import codecs
 
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 GENERATED_HEADERS = ["chemfiles/config.h", "chemfiles/exports.h"]
@@ -62,7 +64,7 @@ def error(message):
 
 def included_headers(path):
     includes = set()
-    with open(path) as fd:
+    with codecs.open(path, encoding="utf8") as fd:
         for line in fd:
             if "#include" in line:
                 matched = re.match("#include\\s*[\"<](.*)[\">]", line)

--- a/tests/lints/check-used-functions.py
+++ b/tests/lints/check-used-functions.py
@@ -4,9 +4,11 @@
 This script check for some functions we don't want to use because they are
 better wrappers in chemfiles
 """
+from __future__ import print_function
 import os
 import sys
 import re
+import codecs
 from glob import glob
 
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -51,7 +53,7 @@ def error(message):
 
 
 def check_code(path, replacements):
-    with open(path) as fd:
+    with codecs.open(path, encoding="utf8") as fd:
         for i, line in enumerate(fd):
             for bad, replacement in replacements.items():
                 match = re.search(bad, line)


### PR DESCRIPTION
This is the only way to specify the encoding parmeter with Python2.

The encoding parameter is needed else Python uses the locale to guess the encoding. For LANG=C, this means using ascii encoding and thus having "UnicodeDecodeError: 'ascii' codec can't decode byte ..." exceptions.