### PR TITLE
Improve speed of MMTF parsing for global bonds

### DIFF
--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -128,6 +128,21 @@ void MMTFFormat::read(Frame& frame) {
         frame.set("deposition_date", structure_.depositionDate);
     }
 
+    auto inter_residue_bond_count = structure_.bondAtomList.size() / 2;
+    size_t bond_index = 0;
+    while (bond_index < inter_residue_bond_count) {
+        auto atom1 = structure_.bondAtomList[bond_index * 2 + 0];
+        auto atom2 = structure_.bondAtomList[bond_index * 2 + 1];
+
+        // We are below the atoms we care about
+        if ((atom1 < atomSkip_) || (atom2 < atomSkip_)) {
+            bond_index++;
+            continue;
+        }
+
+        break;
+    }
+
     // count the number of atoms in this frame/model
     size_t natoms = 0;
     auto modelChainCount = static_cast<size_t>(structure_.chainsPerModel[modelIndex_]);
@@ -217,6 +232,28 @@ void MMTFFormat::read(Frame& frame) {
                 );
             }
 
+            // Add additional global (not by group) bonds
+            while (bond_index < inter_residue_bond_count) {
+                auto atom1 = static_cast<size_t>(structure_.bondAtomList[bond_index * 2]);
+                auto atom2 = static_cast<size_t>(structure_.bondAtomList[bond_index * 2 + 1]);
+
+                // We are below the atoms we care about
+                if (atom1 < atomSkip_ || atom2 < atomSkip_) {
+                    if (!(atom1 < atomSkip_ && atom2 < atomSkip_)) {
+                        warning("MMTF Reader", "chemfiles can not represent bonds between different models");
+                    }
+                    continue;
+                }
+
+                // We are above the atoms we care about
+                if (atom1 > atomIndex_ || atom2 > atomIndex_) {
+                    break;
+                }
+
+                frame.add_bond(atom_id(atom1), atom_id(atom2));
+                bond_index++;
+            }
+
             if (groupIndex_ < structure_.secStructList.size()) {
                 set_secondary(residue, structure_.secStructList[groupIndex_]);
             }
@@ -241,30 +278,6 @@ void MMTFFormat::read(Frame& frame) {
         chainIndex_++;
     }
     modelIndex_++;
-
-    // Add additional global (not by group) bonds
-    for (size_t i = 0; i < structure_.bondAtomList.size() / 2; i++) {
-        auto atom1 = static_cast<size_t>(structure_.bondAtomList[i * 2]);
-        auto atom2 = static_cast<size_t>(structure_.bondAtomList[i * 2 + 1]);
-
-        // We are below the atoms we care about
-        if (atom1 < atomSkip_ || atom2 < atomSkip_) {
-            if (!(atom1 < atomSkip_ && atom2 < atomSkip_)) {
-                warning("MMTF Reader", "chemfiles can not represent bonds between different models");
-            }
-            continue;
-        }
-
-        // We are above the atoms we care about
-        if (atom1 > atomIndex_ || atom2 > atomIndex_) {
-            if (!(atom1 > atomIndex_ && atom2 > atomIndex_)) {
-                warning("MMTF Reader", "chemfiles can not represent bonds between different models");
-            }
-            continue;
-        }
-
-        frame.add_bond(atom_id(atom1), atom_id(atom2));
-    }
 
     atomSkip_ = atomIndex_;
 }

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -239,9 +239,6 @@ void MMTFFormat::read(Frame& frame) {
 
                 // We are below the atoms we care about
                 if (atom1 < atomSkip_ || atom2 < atomSkip_) {
-                    if (!(atom1 < atomSkip_ && atom2 < atomSkip_)) {
-                        warning("MMTF Reader", "chemfiles can not represent bonds between different models");
-                    }
                     continue;
                 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "c473c983d0251b2917ba8f3902b1fcc5be81458c")
+set(TESTS_DATA_GIT "f72e432e1d1f449125cf1909cc0d14e05bdbcd23")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=1193ae44d2e2a36006add8869e576f9e22afdf0f
+        EXPECTED_HASH SHA1=c8f6fb397a11d5e4525c5000723901a0f6676c48
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -190,8 +190,19 @@ TEST_CASE("Read files in MMTF format") {
     }
 
     SECTION("Large MMTF file") {
-        auto file = Trajectory("data/mmtf/3J3Q.mmtf.gz");
-        auto frame = file.read_step(0);
+    // Test fails on Windows due to timing of MSVC debug builds
+    #ifndef CHEMFILES_WINDOWS
+        // Test takes too long with valgrind
+        if (!is_valgrind_and_travis()) {
+            auto file = Trajectory("data/mmtf/3J3Q.mmtf.gz");
+            auto frame = file.read_step(0);
+
+            // We just read 2,400,000 atoms and 2,500,000 bonds
+            // in ~3s (in release mode) !!!
+            CHECK(frame.size() == 2440800);
+            CHECK(frame.topology().bonds().size() == 2497752);
+        }
+    #endif
     }
 
     SECTION("XZ Files") {

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -189,6 +189,11 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(!topology.are_linked(topology.residue(0), topology.residue(2)));
     }
 
+    SECTION("Large MMTF file") {
+        auto file = Trajectory("data/mmtf/3J3Q.mmtf.gz");
+        auto frame = file.read_step(0);
+    }
+
     SECTION("XZ Files") {
         auto file = Trajectory("data/mmtf/1J8K.mmtf.xz");
 


### PR DESCRIPTION
Before:

```
$ time ./mmtf
[chemfiles] MMTF Writer: atom name 'C23456' is too long for MMTF format, it will be truncated
[chemfiles] MMTF Writer: atom type 'HuuuuH' is too long for MMTF format, it will be truncated
===============================================================================
All tests passed (117 assertions in 2 test cases)

./mmtf  785.46s user 0.25s system 99% cpu 13:05.78 total
```

After:
 ```
$ time ./mmtf
[chemfiles] MMTF Writer: atom name 'C23456' is too long for MMTF format, it will be truncated
[chemfiles] MMTF Writer: atom type 'HuuuuH' is too long for MMTF format, it will be truncated
===============================================================================
All tests passed (117 assertions in 2 test cases)

./mmtf  1.79s user 0.28s system 99% cpu 2.067 total
```