### PR TITLE
Fix/cell matrix

### DIFF
--- a/src/UnitCell.cpp
+++ b/src/UnitCell.cpp
@@ -77,6 +77,8 @@ UnitCell::UnitCell(const Matrix3D& matrix): h_(Matrix3D::unit()), h_inv_(Matrix3
         a_ = b_ = c_ = 0;
         alpha_ = beta_ = gamma_ = 90.0;
 
+        update_matrix();
+
         return;
     }
 
@@ -88,6 +90,8 @@ UnitCell::UnitCell(const Matrix3D& matrix): h_(Matrix3D::unit()), h_inv_(Matrix3
         c_ = matrix[2][2];
 
         alpha_ = beta_ = gamma_ = 90.0;
+
+        update_matrix();
 
         return;
     }

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -17,6 +17,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(infinite.beta() == 90);
         CHECK(infinite.gamma() == 90);
         CHECK(infinite.volume() == 0);
+        CHECK(approx_eq(infinite.matrix(), Matrix3D::zero()));
 
         UnitCell ortho1(10);
         CHECK(ortho1.shape() == UnitCell::ORTHORHOMBIC);
@@ -26,6 +27,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(ortho1.alpha() == 90);
         CHECK(ortho1.beta() == 90);
         CHECK(ortho1.gamma() == 90);
+        CHECK(approx_eq(ortho1.matrix(), Matrix3D(10, 0, 0, 0, 10, 0, 0, 0, 10)));
 
         UnitCell ortho2(10, 11, 12);
         CHECK(ortho2.shape() == UnitCell::ORTHORHOMBIC);
@@ -36,6 +38,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(ortho2.beta() == 90);
         CHECK(ortho2.gamma() == 90);
         CHECK(ortho2.volume() == 10*11*12);
+        CHECK(approx_eq(ortho2.matrix(), Matrix3D(10, 0, 0, 0, 11, 0, 0, 0, 12)));
 
         UnitCell triclinic(10, 11, 12, 90, 80, 120);
         CHECK(triclinic.shape() == UnitCell::TRICLINIC);
@@ -46,9 +49,12 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(triclinic.beta() == 80);
         CHECK(triclinic.gamma() == 120);
         CHECK(approx_eq(triclinic.volume(), 1119.9375925598192, 1e-12));
+        CHECK(approx_eq(triclinic.matrix(),
+                        Matrix3D(10, -5.5, 2.08378, 0, 9.52628, 1.20307, 0, 0, 11.7563), 1e-4));
 
         UnitCell infinite2(Matrix3D::zero());
         CHECK(infinite2 == infinite);
+        CHECK(approx_eq(infinite2.matrix(), Matrix3D::zero()));
 
         auto ortho_matrix = Matrix3D(10, 0, 0, 0, 11, 0, 0, 0, 12);
         UnitCell ortho3(ortho_matrix);
@@ -60,6 +66,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(ortho3.beta() == 90);
         CHECK(ortho3.gamma() == 90);
         CHECK(ortho3.volume() == 10*11*12);
+        CHECK(approx_eq(ortho3.matrix(), Matrix3D(10, 0, 0, 0, 11, 0, 0, 0, 12)));
 
         // These need to be approximate due to acos used in this constructor
         UnitCell triclinic2(triclinic.matrix());
@@ -71,6 +78,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(approx_eq(triclinic2.beta(), 80.0, 1e-12));
         CHECK(approx_eq(triclinic2.gamma(), 120.0, 1e-12));
         CHECK(approx_eq(triclinic2.volume(), 1119.9375925598192, 1e-12));
+        CHECK(approx_eq(triclinic2.matrix(), triclinic.matrix(), 1e-12));
 
         auto wrong_matrix = Matrix3D(
             1.0, 2.0, 3.0,
@@ -94,6 +102,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(approx_eq(triclinic3.alpha(), 90.0, 1e-4));
         CHECK(approx_eq(triclinic3.beta(), 112.159, 1e-4));
         CHECK(approx_eq(triclinic3.gamma(), 90.0, 1e-4));
+        CHECK(approx_eq(triclinic3.matrix(), triclinic_matrix, 1e-4));
     }
 
     SECTION("Operators") {
@@ -110,6 +119,7 @@ TEST_CASE("Use the UnitCell type") {
 
         cell.set_shape(UnitCell::ORTHORHOMBIC);
         CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+        CHECK(approx_eq(cell.matrix(), Matrix3D::zero()));
 
         cell.set_a(10);
         CHECK(cell.a() == 10);
@@ -117,6 +127,7 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(cell.b() == 15);
         cell.set_c(20);
         CHECK(cell.c() == 20);
+        CHECK(approx_eq(cell.matrix(), Matrix3D(10, 0, 0, 0, 15, 0, 0, 0, 20), 1e-12));
 
         cell.set_shape(UnitCell::TRICLINIC);
         CHECK(cell.shape() == UnitCell::TRICLINIC);
@@ -127,6 +138,8 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(cell.beta() == 120);
         cell.set_gamma(60);
         CHECK(cell.gamma() == 60);
+        CHECK(approx_eq(cell.matrix(), Matrix3D(10, 7.5, -10, 0, 12.9904, 9.78374, 0, 0, 14.2926),
+                        1e-4));
     }
 
     SECTION("Matricial representation") {


### PR DESCRIPTION
While using the matrix of the `UnitCell` for some computations I noticed that in some cases one gets a unit matrix but the cell parameters (`a`, `b`, `c` and angles) are correct. There were some missing `update_matrix` calls.
This happens when reading e.g. a .gro file with 9 cell entries.

Also added some test for that :)