### PR TITLE
fix(UnitCell): constructing infinite cell from zero lengths

### DIFF
--- a/src/UnitCell.cpp
+++ b/src/UnitCell.cpp
@@ -48,11 +48,19 @@ UnitCell::UnitCell(double a, double b, double c, double alpha, double beta, doub
     beta_(beta),
     gamma_(gamma)
 {
+    auto is_zero = [](double length) {
+        // We think that 0.00001 is close enough to 0
+        return fabs(length) < 1e-5;
+    };
     auto is_90 = [](double angle) {
         // We think that 89.999° is close enough to 90°
         return fabs(angle - 90.0) < 1e-3;
     };
-    if (is_90(alpha_) && is_90(beta_) && is_90(gamma_)) {
+    if (is_zero(a_) && is_zero(b_) && is_zero(c_)) {
+        shape_ = INFINITE;
+        a_ = b_ = c_ = 0;
+        alpha_ = beta_ = gamma_ = 90;
+    } else if (is_90(alpha_) && is_90(beta_) && is_90(gamma_)) {
         shape_ = ORTHORHOMBIC;
         // Make sure alpha/beta/gamma are actually 90°, so that the matrix
         // update below does not create a non diagonal matrix.

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -56,6 +56,17 @@ TEST_CASE("Use the UnitCell type") {
         CHECK(infinite2 == infinite);
         CHECK(approx_eq(infinite2.matrix(), Matrix3D::zero()));
 
+        UnitCell infinite3(0, 0, 0);
+        CHECK(infinite3.shape() == UnitCell::INFINITE);
+        CHECK(infinite3.a() == 0);
+        CHECK(infinite3.b() == 0);
+        CHECK(infinite3.c() == 0);
+        CHECK(infinite3.alpha() == 90);
+        CHECK(infinite3.beta() == 90);
+        CHECK(infinite3.gamma() == 90);
+        CHECK(infinite3.volume() == 0);
+        CHECK(approx_eq(infinite3.matrix(), Matrix3D::zero()));
+
         auto ortho_matrix = Matrix3D(10, 0, 0, 0, 11, 0, 0, 0, 12);
         UnitCell ortho3(ortho_matrix);
         CHECK(ortho3.shape() == UnitCell::ORTHORHOMBIC);


### PR DESCRIPTION
I noticed that infinite cells are not persistent when writing and then reading .gro files.
This is because we [write zeros](https://github.com/chemfiles/chemfiles/blob/master/src/formats/GRO.cpp#L227) for infinite cells. But when reading we find 3 values and construct a unit cell from those values. The result is an orthorhombic cell with lengths zero. This breaks distances and other stuff.

I guess it would be good to also handle setter functions similar (as described in #69) in the long run.