### PR TITLE
Small fixes related to exceptions at the C APi boundary

### DIFF
--- a/include/chemfiles/capi/utils.hpp
+++ b/include/chemfiles/capi/utils.hpp
@@ -84,6 +84,9 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
     catch (const std::exception& e) {                                          \
         set_last_error(e.what());                                              \
         return CHFL_CXX_ERROR;                                                 \
+    } catch (...) {                                                            \
+        set_last_error("UNKNOWN ERROR");                                       \
+        return CHFL_CXX_ERROR;                                                 \
     }                                                                          \
     return CHFL_SUCCESS;
 
@@ -98,6 +101,9 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
         goto error;  /* NOLINT: goto is OK here */                             \
     } catch (const std::exception& e) {                                        \
         set_last_error(e.what());                                              \
+        goto error;  /* NOLINT: goto is OK here */                             \
+    } catch (...) {                                                            \
+        set_last_error("UNKNOWN ERROR");                                       \
         goto error;  /* NOLINT: goto is OK here */                             \
     }
 

--- a/include/chemfiles/capi/utils.hpp
+++ b/include/chemfiles/capi/utils.hpp
@@ -38,7 +38,7 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
 #define CATCH_AND_RETURN(_exception_, _retval_)                                \
     catch (const chemfiles::_exception_& e) {                                  \
         set_last_error(e.what());                                              \
-        chemfiles::warning("", e.what());                                      \
+        chemfiles::send_warning(e.what());                                     \
         return _retval_;                                                       \
     }
 
@@ -49,7 +49,7 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
                 "parameter '{}' cannot be NULL in {}", #_ptr_, __func__        \
             );                                                                 \
             set_last_error(message);                                           \
-            chemfiles::warning("", message.c_str());                           \
+            chemfiles::send_warning(message.c_str());                          \
             return CHFL_MEMORY_ERROR;                                          \
         }                                                                      \
     } while (false)
@@ -61,7 +61,7 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
                 "parameter '{}' cannot be NULL in {}", #_ptr_, __func__        \
             );                                                                 \
             set_last_error(message);                                           \
-            chemfiles::warning("", message.c_str());                           \
+            chemfiles::send_warning(message.c_str());                          \
             goto error;  /* NOLINT: goto is OK here */                         \
         }                                                                      \
     } while (false)
@@ -97,7 +97,7 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
         _instructions_                                                         \
     } catch (const chemfiles::Error& e) {                                      \
         set_last_error(e.what());                                              \
-        chemfiles::warning("", e.what());                                      \
+        chemfiles::send_warning(e.what());                                     \
         goto error;  /* NOLINT: goto is OK here */                             \
     } catch (const std::exception& e) {                                        \
         set_last_error(e.what());                                              \

--- a/include/chemfiles/error_fmt.hpp
+++ b/include/chemfiles/error_fmt.hpp
@@ -17,50 +17,50 @@ namespace chemfiles {
 
 /// Create an `Error` using the given `format` and `arguments`.
 template <typename... Args>
-inline Error error(const char *format, const Args & ... arguments) {
-    return Error(fmt::format(format, arguments...));
+inline Error error(const char *format, Args && ... arguments) {
+    return Error(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `FileError` using the given `format` and `arguments`.
 template <typename... Args>
-inline FileError file_error(const char *format, const Args & ... arguments) {
-    return FileError(fmt::format(format, arguments...));
+inline FileError file_error(const char *format, Args && ... arguments) {
+    return FileError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `MemoryError` using the given `format` and `arguments`.
 template <typename... Args>
-inline MemoryError memory_error(const char *format, const Args & ... arguments) {
-    return MemoryError(fmt::format(format, arguments...));
+inline MemoryError memory_error(const char *format, Args && ... arguments) {
+    return MemoryError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `FormatError` using the given `format` and `arguments`.
 template <typename... Args>
-inline FormatError format_error(const char *format, const Args & ... arguments) {
-    return FormatError(fmt::format(format, arguments...));
+inline FormatError format_error(const char *format, Args && ... arguments) {
+    return FormatError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `SelectionError` using the given `format` and `arguments`.
 template <typename... Args>
-inline SelectionError selection_error(const char *format, const Args & ... arguments) {
-    return SelectionError(fmt::format(format, arguments...));
+inline SelectionError selection_error(const char *format, Args && ... arguments) {
+    return SelectionError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `ConfigurationError` using the given `format` and `arguments`.
 template <typename... Args>
-inline ConfigurationError configuration_error(const char *format, const Args & ... arguments) {
-    return ConfigurationError(fmt::format(format, arguments...));
+inline ConfigurationError configuration_error(const char *format, Args && ... arguments) {
+    return ConfigurationError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create an `OutOfBounds` error using the given `format` and `arguments`.
 template <typename... Args>
-inline OutOfBounds out_of_bounds(const char *format, const Args & ... arguments) {
-    return OutOfBounds(fmt::format(format, arguments...));
+inline OutOfBounds out_of_bounds(const char *format, Args && ... arguments) {
+    return OutOfBounds(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 /// Create a `PropertyError` using the given `format` and `arguments`.
 template <typename... Args>
-inline PropertyError property_error(const char *format, const Args & ... arguments) {
-    return PropertyError(fmt::format(format, arguments...));
+inline PropertyError property_error(const char *format, Args && ... arguments) {
+    return PropertyError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
 } // namespace chemfiles

--- a/include/chemfiles/warnings.hpp
+++ b/include/chemfiles/warnings.hpp
@@ -21,12 +21,12 @@ void send_warning(const std::string& message);
 ///
 /// [fmt]: https://github.com/fmtlib/fmt
 template<typename... Args>
-void warning(std::string context, const char* message, Args const&... arguments) {
+void warning(std::string context, const char* message, Args &&... arguments) {
     if (context.empty()) {
-        send_warning(fmt::format(message, arguments...));
+        send_warning(fmt::format(message, std::forward<Args>(arguments)...));
     } else {
         context += ": ";
-        fmt::format_to(std::back_inserter(context), message, arguments...);
+        fmt::format_to(std::back_inserter(context), message, std::forward<Args>(arguments)...);
         send_warning(context);
     }
 }

--- a/include/chemfiles/warnings.hpp
+++ b/include/chemfiles/warnings.hpp
@@ -11,7 +11,7 @@
 namespace chemfiles {
 
 /// Send a warning with the given message
-void send_warning(const std::string& message);
+void send_warning(const std::string& message) noexcept;
 
 /// Create a message for the given `context` formatting the `message` with the
 /// `arguments`, and send a warning with this message.

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -131,8 +131,8 @@ void MMTFFormat::read(Frame& frame) {
     auto inter_residue_bond_count = structure_.bondAtomList.size() / 2;
     size_t bond_index = 0;
     while (bond_index < inter_residue_bond_count) {
-        auto atom1 = structure_.bondAtomList[bond_index * 2 + 0];
-        auto atom2 = structure_.bondAtomList[bond_index * 2 + 1];
+        auto atom1 = static_cast<size_t>(structure_.bondAtomList[bond_index * 2 + 0]);
+        auto atom2 = static_cast<size_t>(structure_.bondAtomList[bond_index * 2 + 1]);
 
         // We are below the atoms we care about
         if ((atom1 < atomSkip_) || (atom2 < atomSkip_)) {

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -21,7 +21,13 @@ void chemfiles::set_warning_callback(warning_callback_t callback) {
     *guard = std::move(callback);
 }
 
-void chemfiles::send_warning(const std::string& message) {
-    auto callback = CALLBACK.lock();
-    (*callback)(message);
+void chemfiles::send_warning(const std::string& message) noexcept {
+    try {
+        auto callback = CALLBACK.lock();
+        (*callback)(message);
+    } catch (const std::exception& e) {
+        std::cerr << "exception while sending warning: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "unknown exception while sending warning" << std::endl;
+    }
 }

--- a/tests/capi/utils.cpp
+++ b/tests/capi/utils.cpp
@@ -1,0 +1,167 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <stdexcept>
+
+#include "catch.hpp"
+#include "helpers.hpp"
+
+#include "chemfiles/capi/utils.hpp"
+#include "chemfiles/Error.hpp"
+
+#include "chemfiles.h"
+
+using namespace chemfiles;
+
+struct CustomError: Error {
+    CustomError(std::string message): Error(message) {}
+};
+
+struct std_derived: public std::exception {
+    std_derived(std::string): std::exception() {}
+};
+
+struct std_derived_2: public std::runtime_error {
+    std_derived_2(std::string message): std::runtime_error(message) {}
+};
+
+#define generate_function_status(__error__)                                    \
+static chfl_status throw_ ##__error__ () {                                     \
+    CHFL_ERROR_CATCH(                                                          \
+        throw __error__ (#__error__);                                          \
+    )                                                                          \
+    return CHFL_SUCCESS;                                                       \
+}
+
+generate_function_status(MemoryError)
+generate_function_status(FileError)
+generate_function_status(FormatError)
+generate_function_status(SelectionError)
+generate_function_status(ConfigurationError)
+generate_function_status(OutOfBounds)
+generate_function_status(PropertyError)
+generate_function_status(Error)
+generate_function_status(CustomError)
+
+using std::runtime_error;
+using std::string;
+generate_function_status(runtime_error)
+generate_function_status(std_derived)
+generate_function_status(std_derived_2)
+generate_function_status(string)
+
+
+#define generate_function_goto(__error__)                                      \
+static int goto_ ##__error__ () {                                              \
+    CHFL_ERROR_GOTO(                                                           \
+        throw __error__ (#__error__);                                          \
+        return 0;                                                              \
+    )                                                                          \
+    error:                                                                     \
+        return 1;                                                              \
+}
+
+generate_function_goto(MemoryError)
+generate_function_goto(FileError)
+generate_function_goto(FormatError)
+generate_function_goto(SelectionError)
+generate_function_goto(ConfigurationError)
+generate_function_goto(OutOfBounds)
+generate_function_goto(PropertyError)
+generate_function_goto(Error)
+generate_function_goto(CustomError)
+generate_function_goto(runtime_error)
+generate_function_goto(std_derived)
+generate_function_goto(std_derived_2)
+generate_function_goto(string)
+
+
+TEST_CASE("Error handling") {
+    SECTION("Status code") {
+        CHECK(throw_Error() == CHFL_GENERIC_ERROR);
+        CHECK(std::string(chfl_last_error()) == "Error");
+
+        CHECK(throw_MemoryError() == CHFL_MEMORY_ERROR);
+        CHECK(std::string(chfl_last_error()) == "MemoryError");
+
+        CHECK(throw_FileError() == CHFL_FILE_ERROR);
+        CHECK(std::string(chfl_last_error()) == "FileError");
+
+        CHECK(throw_FormatError() == CHFL_FORMAT_ERROR);
+        CHECK(std::string(chfl_last_error()) == "FormatError");
+
+        CHECK(throw_SelectionError() == CHFL_SELECTION_ERROR);
+        CHECK(std::string(chfl_last_error()) == "SelectionError");
+
+        CHECK(throw_ConfigurationError() == CHFL_CONFIGURATION_ERROR);
+        CHECK(std::string(chfl_last_error()) == "ConfigurationError");
+
+        CHECK(throw_OutOfBounds() == CHFL_OUT_OF_BOUNDS);
+        CHECK(std::string(chfl_last_error()) == "OutOfBounds");
+
+        CHECK(throw_PropertyError() == CHFL_PROPERTY_ERROR);
+        CHECK(std::string(chfl_last_error()) == "PropertyError");
+
+        CHECK(throw_CustomError() == CHFL_GENERIC_ERROR);
+        CHECK(std::string(chfl_last_error()) == "CustomError");
+
+        CHECK(throw_runtime_error() == CHFL_CXX_ERROR);
+        CHECK(std::string(chfl_last_error()) == "runtime_error");
+
+        CHECK_STATUS(chfl_clear_errors());
+        CHECK(std::string(chfl_last_error()) == "");
+
+        CHECK(throw_std_derived() == CHFL_CXX_ERROR);
+        CHECK(std::string(chfl_last_error()) != "");
+
+        CHECK(throw_std_derived_2() == CHFL_CXX_ERROR);
+        CHECK(std::string(chfl_last_error()) == "std_derived_2");
+
+        CHECK(throw_string() == CHFL_CXX_ERROR);
+        CHECK(std::string(chfl_last_error()) == "UNKNOWN ERROR");
+    }
+
+    SECTION("goto") {
+        CHECK(goto_Error() == 1);
+        CHECK(std::string(chfl_last_error()) == "Error");
+
+        CHECK(goto_MemoryError() == 1);
+        CHECK(std::string(chfl_last_error()) == "MemoryError");
+
+        CHECK(goto_FileError() == 1);
+        CHECK(std::string(chfl_last_error()) == "FileError");
+
+        CHECK(goto_FormatError() == 1);
+        CHECK(std::string(chfl_last_error()) == "FormatError");
+
+        CHECK(goto_SelectionError() == 1);
+        CHECK(std::string(chfl_last_error()) == "SelectionError");
+
+        CHECK(goto_ConfigurationError() == 1);
+        CHECK(std::string(chfl_last_error()) == "ConfigurationError");
+
+        CHECK(goto_OutOfBounds() == 1);
+        CHECK(std::string(chfl_last_error()) == "OutOfBounds");
+
+        CHECK(goto_PropertyError() == 1);
+        CHECK(std::string(chfl_last_error()) == "PropertyError");
+
+        CHECK(goto_CustomError() == 1);
+        CHECK(std::string(chfl_last_error()) == "CustomError");
+
+        CHECK(goto_runtime_error() == 1);
+        CHECK(std::string(chfl_last_error()) == "runtime_error");
+
+        CHECK_STATUS(chfl_clear_errors());
+        CHECK(std::string(chfl_last_error()) == "");
+
+        CHECK(goto_std_derived() == 1);
+        CHECK(std::string(chfl_last_error()) != "");
+
+        CHECK(goto_std_derived_2() == 1);
+        CHECK(std::string(chfl_last_error()) == "std_derived_2");
+
+        CHECK(goto_string() == 1);
+        CHECK(std::string(chfl_last_error()) == "UNKNOWN ERROR");
+    }
+}


### PR DESCRIPTION
Related to #303. The first examples now properly fails with `SMI Reader: unknown symbol: '{'`.