### PR TITLE
Speed up atom removal in large structures

### DIFF
--- a/include/chemfiles/Residue.hpp
+++ b/include/chemfiles/Residue.hpp
@@ -138,9 +138,11 @@ private:
     /// Update the atomic indexes in this residue after an atom has been
     /// removed from the containing topology.
     ///
-    /// This function removes the atom with index `i` from this residue if it
-    /// exists, and shifts all the indexes bigger than `i` by -1.
+    /// This function shifts all the indexes bigger than `i` by -1.
     void atom_removed(size_t i);
+
+    /// remove the atom at index i from this residue
+    void remove(size_t i);
 
     friend bool operator==(const Residue& lhs, const Residue& rhs);
 

--- a/include/chemfiles/sorted_set.hpp
+++ b/include/chemfiles/sorted_set.hpp
@@ -26,7 +26,6 @@ public:
     sorted_set(sorted_set&&) = default;
     sorted_set& operator=(sorted_set&&) = default;
 
-    using super::operator[];
     using super::cbegin;
     using super::cend;
     using super::crbegin;
@@ -35,6 +34,8 @@ public:
     const_iterator end() const {return super::end();}
     const_iterator rbegin() const {return super::rbegin();}
     const_iterator rend() const {return super::rend();}
+
+    const T& operator[](size_t i) const {return super::operator[](i);}
 
     using super::empty;
     using super::size;
@@ -88,6 +89,14 @@ public:
 
     /// Get the underlying vector data wihtout a copy
     const super& as_vec() const {
+        return *this;
+    }
+
+    /// Get the underlying vector data wihtout a copy.
+    ///
+    /// WARNING: the vector is not const and can be modified, the user is
+    /// supposed to ensure that the values inside stay ordered.
+    super& as_mutable_vec() {
         return *this;
     }
 };

--- a/src/Connectivity.cpp
+++ b/src/Connectivity.cpp
@@ -219,8 +219,9 @@ void Connectivity::atom_removed(size_t index) {
     auto to_add = std::vector<Bond>();
     auto bo_add = std::vector<Bond::BondOrder>();
 
+    const auto& bonds = bonds_.as_vec();
     for (size_t idx = 0; idx < bonds_.size(); idx++) {
-        auto& bond = bonds_[idx];
+        const auto& bond = bonds[idx];
 
         if (bond[0] == index || bond[1] == index) {
             throw error("can not shift atomic indexes that still have a bond");

--- a/src/Residue.cpp
+++ b/src/Residue.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
 #include "chemfiles/Residue.hpp"
+#include "chemfiles/error_fmt.hpp"
 
 using namespace chemfiles;
 
@@ -17,12 +18,16 @@ bool Residue::contains(size_t i) const {
     return atoms_.find(i) != atoms_.end();
 }
 
-void Residue::atom_removed(size_t i) {
+void Residue::remove(size_t i) {
     auto iter = atoms_.find(i);
-    if (iter != atoms_.end()) {
-        atoms_.erase(iter);
+    if (iter == atoms_.end()) {
+        // we should only remove an atom if we know it exists in the residue
+        throw error("invalid call to Residue::remove, this is a bug");
     }
+    atoms_.erase(iter);
+}
 
+void Residue::atom_removed(size_t i) {
     for (auto& atom: atoms_.as_mutable_vec()) {
         if (atom > i) {
             atom -= 1;

--- a/src/Residue.cpp
+++ b/src/Residue.cpp
@@ -23,9 +23,9 @@ void Residue::atom_removed(size_t i) {
         atoms_.erase(iter);
     }
 
-    for (size_t j = 0; j < atoms_.size(); ++j) {
-        if (atoms_[j] > i) {
-            --atoms_[j];
+    for (auto& atom: atoms_.as_mutable_vec()) {
+        if (atom > i) {
+            atom -= 1;
         }
     }
 }

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -79,6 +79,7 @@ void Topology::remove(size_t i) {
         );
     }
     atoms_.erase(atoms_.begin() + static_cast<std::ptrdiff_t>(i));
+
     // Remove all bonds with the removed atom
     auto bonds = connect_.bonds();
     for (auto& bond : bonds) {
@@ -86,9 +87,15 @@ void Topology::remove(size_t i) {
             connect_.remove_bond(bond[0], bond[1]);
         }
     }
-    // Shift all bonds indexes
+    // remove the atom from the corresponding residue
+    auto it = residue_mapping_.find(i);
+    if (it != residue_mapping_.end()) {
+        residues_[it->second].remove(i);
+    }
+
+    // shift all bonds indexes
     connect_.atom_removed(i);
-    // Remove and shift all residue atoms
+    // shift all residue atoms
     for (auto& res : residues_) {
         res.atom_removed(i);
     }


### PR DESCRIPTION
Instead of checking each residue to find if the removed atom was inside, directly remove the atom from the corresponding residue