### PR TITLE
Fix a segfault in SMI reader

### DIFF
--- a/src/formats/SDF.cpp
+++ b/src/formats/SDF.cpp
@@ -325,13 +325,18 @@ optional<uint64_t> SDFFormat::forward() {
     auto position = file_.tellpos();
     size_t natoms = 0;
     size_t nbonds = 0;
+    auto counts_line = string_view("");
     try {
         // Ignore junk lines
         for (size_t i=0; i<3; i++) {
             file_.readline();
         }
 
-        auto counts_line = file_.readline();
+        if (file_.eof()) {
+            return nullopt;
+        }
+
+        counts_line = file_.readline();
         if (counts_line.length() < 10) {
             throw format_error("counts line must have at least 10 digits, it has {}", counts_line.length());
         }
@@ -340,7 +345,7 @@ optional<uint64_t> SDFFormat::forward() {
         nbonds = parse<size_t>(counts_line.substr(3,3));
     } catch (const Error&) {
         // We could not read an integer, so give up here
-        return nullopt;
+        throw format_error("could not parse counts line: '{}'", counts_line);
     }
 
     try {

--- a/src/formats/SMI.cpp
+++ b/src/formats/SMI.cpp
@@ -345,6 +345,9 @@ void SMIFormat::read_next(Frame& frame) {
             branch_point_.push(previous_atom_);
             break;
         case ')':
+            if (branch_point_.empty()) {
+                throw format_error("SMI Reader: unmatched ')'");
+            }
             previous_atom_ = branch_point_.top();
             branch_point_.pop();
             break;

--- a/src/formats/SMI.cpp
+++ b/src/formats/SMI.cpp
@@ -379,7 +379,7 @@ void SMIFormat::read_next(Frame& frame) {
     }
 
     if (!rings_ids_.empty()) {
-        throw format_error("SMI Reader: {} unclosed ringid '{}'", rings_ids_.begin()->first);
+        throw format_error("SMI Reader: unclosed ringid '{}'", rings_ids_.begin()->first);
     }
 
     frame.resize(topology.size());

--- a/tests/formats/sdf.cpp
+++ b/tests/formats/sdf.cpp
@@ -99,14 +99,20 @@ TEST_CASE("Errors in SDF format") {
     auto file = Trajectory("data/sdf/bad/bad_atom_line.sdf");
     CHECK_THROWS_WITH(file.read(), "atom line is too small for SDF: '    3.7320   -0.0600'");
 
-    file = Trajectory("data/sdf/bad/bad_counts_line.sdf");
-    CHECK_THROWS_WITH(file.read(), "can not read file 'data/sdf/bad/bad_counts_line.sdf' at step 0, it does not contain any step");
+    CHECK_THROWS_WITH(
+        Trajectory("data/sdf/bad/bad_counts_line.sdf"),
+        "could not parse counts line: ' 21aaa           '"
+    );
 
-    file = Trajectory("data/sdf/bad/bad_counts_line2.sdf");
-    CHECK_THROWS_WITH(file.read(), "can not read file 'data/sdf/bad/bad_counts_line2.sdf' at step 0, it does not contain any step");
+    CHECK_THROWS_WITH(
+        Trajectory("data/sdf/bad/bad_counts_line2.sdf"),
+        "could not parse counts line: '  0  0'"
+    );
 
-    file = Trajectory("data/sdf/bad/blank.sdf");
-    CHECK_THROWS_WITH(file.read(), "can not read file 'data/sdf/bad/blank.sdf' at step 0, it does not contain any step");
+    CHECK_THROWS_WITH(
+        Trajectory("data/sdf/bad/blank.sdf"),
+        "could not parse counts line: 'asdf'"
+    );
 }
 
 TEST_CASE("Write files in SDF format") {

--- a/tests/formats/smi.cpp
+++ b/tests/formats/smi.cpp
@@ -234,7 +234,7 @@ TEST_CASE("Check parsing results") {
 
         // In Issue 303, this failed due to the '%11' marker.
         frame = file.read();
-        
+
         // No explict hydrogens, so the size should be 26 atoms
         frame = file.read();
         CHECK(frame.size() == 26);
@@ -275,6 +275,12 @@ TEST_CASE("Errors in SMI format") {
             file.read();
         };
         CHECK_THROWS(test());
+    }
+
+    SECTION("Unmatched )") {
+        auto bad = std::string("C)");
+        auto file = Trajectory::memory_reader(bad.c_str(), bad.size(), "SMI");
+        CHECK_THROWS_WITH(file.read(), "SMI Reader: unmatched ')'");
     }
 }
 


### PR DESCRIPTION
While I was at, I also changed the few remaining tests using boost::fs to loop over 'bad' files, and found one case of broken error message.