### PR TITLE
feat: NetCDF scale factor

### DIFF
--- a/include/chemfiles/files/NcFile.hpp
+++ b/include/chemfiles/files/NcFile.hpp
@@ -53,12 +53,12 @@ namespace nc {
         /// Get the dimensions size for this variable
         std::vector<size_t> dimmensions() const;
 
-        /// Get the attribute `name`.
-        std::string attribute(const std::string& name) const;
+        /// Get the string attribute `name`.
+        std::string string_attribute(const std::string& name) const;
         /// Get the float attribute `name`.
-        float attribute_float(const std::string& name) const;
-        /// Add an attribute with the given `value` and `name`.
-        void add_attribute(const std::string& name, const std::string& value);
+        float float_attribute(const std::string& name) const;
+        /// Add a string attribute with the given `value` and `name`.
+        void add_string_attribute(const std::string& name, const std::string& value);
         /// Check if an attribute exists
         bool attribute_exists(const std::string& name) const;
 

--- a/include/chemfiles/files/NcFile.hpp
+++ b/include/chemfiles/files/NcFile.hpp
@@ -55,9 +55,14 @@ namespace nc {
 
         /// Get the attribute `name`.
         std::string attribute(const std::string& name) const;
+        /// Get the float attribute `name`.
+        float attribute_float(const std::string& name) const;
         /// Add an attribute with the given `value` and `name`.
         void add_attribute(const std::string& name, const std::string& value);
-    protected:
+        /// Check if an attribute exists
+        bool attribute_exists(const std::string& name) const;
+
+      protected:
         netcdf_id_t file_id_;
         netcdf_id_t var_id_;
     };

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -56,10 +56,29 @@ std::string nc::NcVariable::attribute(const std::string& name) const {
     return value;
 }
 
+float nc::NcVariable::attribute_float(const std::string& name) const {
+    size_t size = 0;
+    int status = nc_inq_attlen(file_id_, var_id_, name.c_str(), &size);
+    nc::check(status, "can not read attribute id for attribute '{}'", name);
+    if (size != 1) {
+        throw file_error("expected one value for attribute '{}'", name);
+    }
+
+    float value = -1;
+    status = nc_get_att_float(file_id_, var_id_, name.c_str(), &value);
+    nc::check(status, "can not read attribute float for attribute '{}'", name);
+    return value;
+}
 
 void nc::NcVariable::add_attribute(const std::string& name, const std::string& value) {
     int status = nc_put_att_text(file_id_, var_id_, name.c_str(), value.size(), value.c_str());
     nc::check(status, "can not set attribute '{}'", name);
+}
+
+bool nc::NcVariable::attribute_exists(const std::string& name) const {
+    auto id = nc::netcdf_id_t(-1);
+    auto status = nc_inq_attid(file_id_, var_id_, name.c_str(), &id);
+    return status == NC_NOERR;
 }
 
 std::vector<float> nc::NcFloat::get(count_t start, count_t count) const {

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -44,8 +44,7 @@ std::vector<size_t> nc::NcVariable::dimmensions() const {
     return result;
 }
 
-
-std::string nc::NcVariable::attribute(const std::string& name) const {
+std::string nc::NcVariable::string_attribute(const std::string& name) const {
     size_t size = 0;
     int status = nc_inq_attlen(file_id_, var_id_, name.c_str(), &size);
     nc::check(status, "can not read attribute id for attribute '{}'", name);
@@ -56,7 +55,7 @@ std::string nc::NcVariable::attribute(const std::string& name) const {
     return value;
 }
 
-float nc::NcVariable::attribute_float(const std::string& name) const {
+float nc::NcVariable::float_attribute(const std::string& name) const {
     size_t size = 0;
     int status = nc_inq_attlen(file_id_, var_id_, name.c_str(), &size);
     nc::check(status, "can not read attribute id for attribute '{}'", name);
@@ -70,7 +69,7 @@ float nc::NcVariable::attribute_float(const std::string& name) const {
     return value;
 }
 
-void nc::NcVariable::add_attribute(const std::string& name, const std::string& value) {
+void nc::NcVariable::add_string_attribute(const std::string& name, const std::string& value) {
     int status = nc_put_att_text(file_id_, var_id_, name.c_str(), value.size(), value.c_str());
     nc::check(status, "can not set attribute '{}'", name);
 }

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -128,14 +128,14 @@ UnitCell AmberNetCDFFormat::read_cell() {
     assert(angles.size() == 3);
 
     if (length_var.attribute_exists("scale_factor")) {
-        float scale_factor = length_var.attribute_float("scale_factor");
+        float scale_factor = length_var.float_attribute("scale_factor");
         length[0] *= scale_factor;
         length[1] *= scale_factor;
         length[2] *= scale_factor;
     }
 
     if (angles_var.attribute_exists("scale_factor")) {
-        float scale_factor = angles_var.attribute_float("scale_factor");
+        float scale_factor = angles_var.float_attribute("scale_factor");
         angles[0] *= scale_factor;
         angles[1] *= scale_factor;
         angles[2] *= scale_factor;
@@ -161,7 +161,7 @@ void AmberNetCDFFormat::read_array(span<Vector3D> array, const std::string& name
     auto data = array_var.get(start, count);
 
     if (array_var.attribute_exists("scale_factor")) {
-        float scale_factor = array_var.attribute_float("scale_factor");
+        float scale_factor = array_var.float_attribute("scale_factor");
         for (auto& value : data) {
             value *= scale_factor;
         }
@@ -197,20 +197,20 @@ static void initialize(NcFile& file, size_t natoms, bool with_velocities) {
 
     auto coordinates =
         file.add_variable<nc::NcFloat>("coordinates", "frame", "atom", "spatial");
-    coordinates.add_attribute("units", "angstrom");
+    coordinates.add_string_attribute("units", "angstrom");
 
     auto cell_lenght =
         file.add_variable<nc::NcFloat>("cell_lengths", "frame", "cell_spatial");
-    cell_lenght.add_attribute("units", "angstrom");
+    cell_lenght.add_string_attribute("units", "angstrom");
 
     auto cell_angles =
         file.add_variable<nc::NcFloat>("cell_angles", "frame", "cell_angular");
-    cell_angles.add_attribute("units", "degree");
+    cell_angles.add_string_attribute("units", "degree");
 
     if (with_velocities) {
         auto velocities =
             file.add_variable<nc::NcFloat>("velocities", "frame", "atom", "spatial");
-        velocities.add_attribute("units", "angstrom/picosecond");
+        velocities.add_string_attribute("units", "angstrom/picosecond");
     }
     file.set_nc_mode(NcFile::DATA);
 

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -127,6 +127,20 @@ UnitCell AmberNetCDFFormat::read_cell() {
     assert(length.size() == 3);
     assert(angles.size() == 3);
 
+    if (length_var.attribute_exists("scale_factor")) {
+        float scale_factor = length_var.attribute_float("scale_factor");
+        length[0] *= scale_factor;
+        length[1] *= scale_factor;
+        length[2] *= scale_factor;
+    }
+
+    if (angles_var.attribute_exists("scale_factor")) {
+        float scale_factor = angles_var.attribute_float("scale_factor");
+        angles[0] *= scale_factor;
+        angles[1] *= scale_factor;
+        angles[2] *= scale_factor;
+    }
+
     return {
         static_cast<double>(length[0]),
         static_cast<double>(length[1]),
@@ -145,6 +159,13 @@ void AmberNetCDFFormat::read_array(span<Vector3D> array, const std::string& name
     std::vector<size_t> start{step_, 0, 0};
     std::vector<size_t> count{1, natoms, 3};
     auto data = array_var.get(start, count);
+
+    if (array_var.attribute_exists("scale_factor")) {
+        float scale_factor = array_var.attribute_float("scale_factor");
+        for (auto& value : data) {
+            value *= scale_factor;
+        }
+    }
 
     for (size_t i = 0; i < natoms; i++) {
         array[i][0] = static_cast<double>(data[3 * i + 0]);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "4d599c1856e9454b8969591bdbc4e5d42091c6cb")
+set(TESTS_DATA_GIT "e1c6a19ad774a4fc7c3e55e59c30834bdcf7066e")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=ea3ca400e6ce2228d1996786901e2686179e4f1c
+        EXPECTED_HASH SHA1=1c5d32c945106dedaaacfb13f2e97ef5ec2fe26f
 
     )
 

--- a/tests/files/netcdf-file.cpp
+++ b/tests/files/netcdf-file.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Read a NetCDF file") {
     // Unlimited dimension
     CHECK(file.dimension("frame") == 100);
 
-    CHECK(file.variable<nc::NcFloat>("cell_lengths").attribute("units") == "Angstrom");
+    CHECK(file.variable<nc::NcFloat>("cell_lengths").string_attribute("units") == "Angstrom");
 
     auto var = file.variable<nc::NcFloat>("coordinates");
     auto dims = var.dimmensions();
@@ -38,7 +38,7 @@ TEST_CASE("Errors in NetCDF files") {
 
     CHECK_THROWS_AS(file.global_attribute("FOO"), FileError);
     CHECK_THROWS_AS(file.dimension("FOO"), FileError);
-    CHECK_THROWS_AS(file.variable<nc::NcFloat>("cell_lengths").attribute("Bar"), FileError);
+    CHECK_THROWS_AS(file.variable<nc::NcFloat>("cell_lengths").string_attribute("Bar"), FileError);
     CHECK_THROWS_AS(file.variable<nc::NcFloat>("FOO"), FileError);
 }
 
@@ -52,7 +52,7 @@ TEST_CASE("Write NetCDF files") {
         file.add_dimension("infinite");
         file.add_dimension("finite", 42);
         auto variable = file.add_variable<nc::NcFloat>("variable", "infinite", "finite");
-        variable.add_attribute("attribute", "hello");
+        variable.add_string_attribute("attribute", "hello");
 
         file.set_nc_mode(NcFile::DATA);
         variable.add({0, 0}, {1, 42}, std::vector<float>(42, 38.2f));
@@ -72,7 +72,7 @@ TEST_CASE("Write NetCDF files") {
         CHECK(file.variable_exists("variable"));
         CHECK_FALSE(file.variable_exists("bar"));
         auto variable = file.variable<nc::NcFloat>("variable");
-        CHECK(variable.attribute("attribute") == "hello");
+        CHECK(variable.string_attribute("attribute") == "hello");
         CHECK(variable.get({0, 0}, {1, 42}) == std::vector<float>(42, 38.2f));
         CHECK(variable.get({1, 0}, {1, 42}) == std::vector<float>(42, 55.1f));
     }

--- a/tests/formats/amber-netcdf.cpp
+++ b/tests/formats/amber-netcdf.cpp
@@ -46,6 +46,29 @@ TEST_CASE("Read files in NetCDF format") {
         CHECK(frame.size() == 1989);
         CHECK(frame.cell() == UnitCell());
     }
+
+    SECTION("Scale factor") {
+        auto file = Trajectory("data/netcdf/scaled_traj.nc");
+        CHECK(file.nsteps() == 26);
+        auto frame = file.read_step(12);
+        CHECK(frame.size() == 1938);
+        // Check cell
+        auto cell = frame.cell();
+        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+        CHECK(approx_eq(cell.a(), 60.9682 * 1.765, 1e-4));
+        CHECK(approx_eq(cell.b(), 60.9682 * 1.765, 1e-4));
+        CHECK(cell.c() == 0);
+        // Check positions
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(1.39, 1.39, 0) * 0.455, 1e-4));
+        CHECK(approx_eq(positions[296], Vector3D(29.1, 37.41, 0) * 0.455, 1e-4));
+        // Check velocities
+        auto velocities = *frame.velocities();
+        CHECK(
+            approx_eq(velocities[1400], Vector3D(0.6854072, 0.09196011, 2.260214) * -0.856, 1e-4));
+        CHECK(
+            approx_eq(velocities[1600], Vector3D(-0.3342645, 0.322594, -2.446901) * -0.856, 1e-4));
+    }
 }
 
 TEST_CASE("Write files in NetCDF format") {


### PR DESCRIPTION
Found some old script that uses `scale_factor` in NetCDF extensively. This PR implements scaling of cell lengths, angles, coordinates and velocities by `scale_factor`.
Fixes #268.