### PR TITLE
Expose {Frame,Topology}::clear_bonds to the C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next Release (current master)
 
+### New features
+
 * Added ability to read and write files directly in-memory. See
   `Trajectory::memory_reader`; `Trajectory::memory_writer`;
   `Trajectory::memory_buffer`; `chfl_trajectory_memory_reader`;
   `chfl_trajectory_memory_writer` and `chfl_trajectory_memory_buffer`.
 * Added support for appending to gzip (.gz) compressed trajectories.
+
+### Changes to the C API
+
+* Added missing `chfl_frame_clear_bonds` and `chfl_topology_clear_bonds`
+  functions.
 
 ## 0.9.3 (5 Feb 2020)
 
@@ -91,7 +98,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added `Cambridge Structure Search and Retrieval (CSSR)` support, reading and writing.
 * `LAMMPS Data` format now support triclinic unit cells.
 
-###  C API changes
+### Changes to the C API
 
 * Added `chfl_residue_get_property` and `chfl_residue_set_property` to provide
   access to residue properties.
@@ -151,7 +158,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [LAMMPS data files]: http://lammps.sandia.gov/doc/read_data.html
 
-### C API changes
+### Changes to the C API
 
 * Added `chfl_add_configuration` to add more configuration files.
 * Renamed `chfl_vector_t` to `chfl_vector3d`, `chfl_match_t` to `cfl_match`; and
@@ -212,7 +219,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Add read support for TNG files, an new portable and compressed binary format
   used by GROMACS.
 
-### C API changes
+### Changes to the C API
 
 * All the integers at C boundary have a fixed size, most of the time using
   `uint64_t`.

--- a/doc/src/capi/chfl_frame.rst
+++ b/doc/src/capi/chfl_frame.rst
@@ -24,6 +24,7 @@
     - :cpp:func:`chfl_frame_add_bond`
     - :cpp:func:`chfl_frame_bond_with_order`
     - :cpp:func:`chfl_frame_remove_bond`
+    - :cpp:func:`chfl_frame_clear_bonds`
     - :cpp:func:`chfl_frame_add_residue`
     - :cpp:func:`chfl_frame_step`
     - :cpp:func:`chfl_frame_set_step`
@@ -68,6 +69,8 @@
 .. doxygenfunction:: chfl_frame_bond_with_order
 
 .. doxygenfunction:: chfl_frame_remove_bond
+
+.. doxygenfunction:: chfl_frame_clear_bonds
 
 .. doxygenfunction:: chfl_frame_add_residue
 

--- a/doc/src/capi/chfl_topology.rst
+++ b/doc/src/capi/chfl_topology.rst
@@ -18,6 +18,7 @@
     - :cpp:func:`chfl_topology_remove`
     - :cpp:func:`chfl_topology_add_bond`
     - :cpp:func:`chfl_topology_remove_bond`
+    - :cpp:func:`chfl_topology_clear_bonds`
     - :cpp:func:`chfl_topology_bonds_count`
     - :cpp:func:`chfl_topology_angles_count`
     - :cpp:func:`chfl_topology_dihedrals_count`
@@ -52,6 +53,8 @@
 .. doxygenfunction:: chfl_topology_add_bond
 
 .. doxygenfunction:: chfl_topology_remove_bond
+
+.. doxygenfunction:: chfl_topology_clear_bonds
 
 .. doxygenfunction:: chfl_topology_bonds_count
 

--- a/include/chemfiles/capi/frame.h
+++ b/include/chemfiles/capi/frame.h
@@ -322,6 +322,14 @@ CHFL_EXPORT chfl_status chfl_frame_remove_bond(
     CHFL_FRAME* frame, uint64_t i, uint64_t j
 );
 
+/// Remove all existing bonds, angles, dihedral angles and improper dihedral
+/// angles in the `frame`.
+///
+/// @example{capi/chfl_frame/clear_bonds.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_frame_clear_bonds(CHFL_FRAME* frame);
+
 /// Add a copy of `residue` to this `frame`.
 ///
 /// The residue id must not already be in this frame's topology, and the residue

--- a/include/chemfiles/capi/topology.h
+++ b/include/chemfiles/capi/topology.h
@@ -198,6 +198,14 @@ CHFL_EXPORT chfl_status chfl_topology_remove_bond(
     CHFL_TOPOLOGY* topology, uint64_t i, uint64_t j
 );
 
+/// Remove all existing bonds, angles, dihedral angles and improper dihedral
+/// angles in the `topology`.
+///
+/// @example{capi/chfl_topology/clear_bonds.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_topology_clear_bonds(CHFL_TOPOLOGY* topology);
+
 /// Get the number of residues in the `topology` in the integer pointed to by
 /// `count`.
 ///

--- a/src/capi/frame.cpp
+++ b/src/capi/frame.cpp
@@ -279,6 +279,13 @@ extern "C" chfl_status chfl_frame_remove_bond(CHFL_FRAME* const frame, uint64_t 
     )
 }
 
+extern "C" chfl_status chfl_frame_clear_bonds(CHFL_FRAME* const frame) {
+    CHECK_POINTER(frame);
+    CHFL_ERROR_CATCH(
+        frame->clear_bonds();
+    )
+}
+
 extern "C" chfl_status chfl_frame_add_residue(CHFL_FRAME* const frame, const CHFL_RESIDUE* const residue) {
     CHECK_POINTER(frame);
     CHECK_POINTER(residue);

--- a/src/capi/topology.cpp
+++ b/src/capi/topology.cpp
@@ -202,6 +202,13 @@ extern "C" chfl_status chfl_topology_remove_bond(CHFL_TOPOLOGY* const topology, 
     )
 }
 
+extern "C" chfl_status chfl_topology_clear_bonds(CHFL_TOPOLOGY* const topology) {
+    CHECK_POINTER(topology);
+    CHFL_ERROR_CATCH(
+        topology->clear_bonds();
+    )
+}
+
 extern "C" chfl_status chfl_topology_residues_count(const CHFL_TOPOLOGY* const topology, uint64_t* const count) {
     CHECK_POINTER(topology);
     CHECK_POINTER(count);

--- a/tests/capi/frame.cpp
+++ b/tests/capi/frame.cpp
@@ -287,9 +287,13 @@ TEST_CASE("chfl_frame") {
         CHECK_STATUS(chfl_frame_set_topology(frame, new_topology));
         chfl_free(new_topology);
 
-        // Topology changed
+        // Topology changed, but its address did not
         CHECK_STATUS(chfl_topology_bonds_count(topology, &nbonds));
         CHECK(nbonds == 2);
+
+        CHECK_STATUS(chfl_frame_clear_bonds(frame));
+        CHECK_STATUS(chfl_topology_bonds_count(topology, &nbonds));
+        CHECK(nbonds == 0);
 
         chfl_free(topology);
         chfl_free(frame);

--- a/tests/capi/topology.cpp
+++ b/tests/capi/topology.cpp
@@ -111,6 +111,10 @@ TEST_CASE("chfl_topology") {
         CHECK_STATUS(chfl_topology_bonds_count(topology, &n));
         CHECK(n == 2);
 
+        CHECK_STATUS(chfl_topology_clear_bonds(topology));
+        CHECK_STATUS(chfl_topology_bonds_count(topology, &n));
+        CHECK(n == 0);
+
         chfl_free(topology);
     }
 

--- a/tests/doc/capi/chfl_frame/clear_bonds.c
+++ b/tests/doc/capi/chfl_frame/clear_bonds.c
@@ -1,0 +1,34 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <stdlib.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    CHFL_FRAME* frame = chfl_frame();
+    CHFL_ATOM* atom = chfl_atom("C");
+
+    chfl_frame_add_atom(frame, atom, (chfl_vector3d){0, 0, 0}, NULL);
+    chfl_frame_add_atom(frame, atom, (chfl_vector3d){1, 0, 0}, NULL);
+    chfl_frame_add_atom(frame, atom, (chfl_vector3d){0, 1, 0}, NULL);
+
+    chfl_frame_add_bond(frame, 0, 1);
+    chfl_frame_add_bond(frame, 2, 1);
+
+    const CHFL_TOPOLOGY* topology = chfl_topology_from_frame(frame);
+    uint64_t bonds = 0;
+    chfl_topology_bonds_count(topology, &bonds);
+    assert(bonds == 2);
+
+    chfl_frame_clear_bonds(frame);
+    chfl_topology_bonds_count(topology, &bonds);
+    assert(bonds == 0);
+
+    chfl_free(atom);
+    chfl_free(topology);
+    chfl_free(frame);
+    // [example]
+    return 0;
+}

--- a/tests/doc/capi/chfl_topology/clear_bonds.c
+++ b/tests/doc/capi/chfl_topology/clear_bonds.c
@@ -1,0 +1,32 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <stdlib.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    CHFL_TOPOLOGY* topology = chfl_topology();
+    CHFL_ATOM* atom = chfl_atom("C");
+
+    chfl_topology_add_atom(topology, atom);
+    chfl_topology_add_atom(topology, atom);
+    chfl_topology_add_atom(topology, atom);
+
+    chfl_topology_add_bond(topology, 0, 1);
+    chfl_topology_add_bond(topology, 2, 1);
+
+    uint64_t bonds = 0;
+    chfl_topology_bonds_count(topology, &bonds);
+    assert(bonds == 2);
+
+    chfl_topology_clear_bonds(topology);
+    chfl_topology_bonds_count(topology, &bonds);
+    assert(bonds == 0);
+
+    chfl_free(atom);
+    chfl_free(topology);
+    // [example]
+    return 0;
+}


### PR DESCRIPTION
They are part of the public C++ API, so I think they should be part of the public C API too. No idea why they were left out initially.