### PR TITLE
Unify chfl_trajectory_path with other functions getting string values

### DIFF
--- a/include/chemfiles/capi/trajectory.h
+++ b/include/chemfiles/capi/trajectory.h
@@ -75,17 +75,16 @@ CHFL_EXPORT CHFL_TRAJECTORY* chfl_trajectory_memory_writer(
     const char* format
 );
 
-/// Get the path used to open the `trajectory` in `path`.
+/// Get the path used to open the `trajectory` in the `path` buffer.
 ///
-/// The `path` will point to memory allocated inside the `trajectory`, and it is
-/// only valid until the trajectory is closed (`chfl_trajectory_close`). There
-/// is no need to `free` the corresponding memory
+/// The buffer size must be passed in `buffsize`. This function will truncate
+/// the selection string to fit in the buffer.
 ///
 /// @example{capi/chfl_trajectory/path.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn
 ///         about the error if the status code is not `CHFL_SUCCESS`.
 CHFL_EXPORT chfl_status chfl_trajectory_path(
-    const CHFL_TRAJECTORY* trajectory, const char** path
+    const CHFL_TRAJECTORY* trajectory, char* path, uint64_t buffsize
 );
 
 /// Read the next step of the `trajectory` into a `frame`.

--- a/src/capi/trajectory.cpp
+++ b/src/capi/trajectory.cpp
@@ -71,11 +71,12 @@ error:
     return nullptr;
 }
 
-extern "C" chfl_status chfl_trajectory_path(const CHFL_TRAJECTORY* const trajectory, const char** const path) {
+extern "C" chfl_status chfl_trajectory_path(const CHFL_TRAJECTORY* const trajectory, char* const path, uint64_t buffsize) {
     CHECK_POINTER(trajectory);
     CHECK_POINTER(path);
     CHFL_ERROR_CATCH(
-        *path = trajectory->path().c_str();
+        strncpy(path, trajectory->path().c_str(), checked_cast(buffsize) - 1);
+        path[buffsize - 1] = '\0';
     )
 }
 

--- a/tests/capi/trajectory.cpp
+++ b/tests/capi/trajectory.cpp
@@ -23,8 +23,8 @@ TEST_CASE("Read trajectory") {
         CHFL_TRAJECTORY* trajectory = chfl_trajectory_open("data/xyz/water.xyz", 'r');
         REQUIRE(trajectory);
 
-        const char* path = nullptr;
-        CHECK_STATUS(chfl_trajectory_path(trajectory, &path));
+        char path[256] = {0};
+        CHECK_STATUS(chfl_trajectory_path(trajectory, path, sizeof(path)));
         CHECK(std::string(path) == "data/xyz/water.xyz");
 
         chfl_trajectory_close(trajectory);

--- a/tests/doc/capi/chfl_trajectory/memory_buffer.c
+++ b/tests/doc/capi/chfl_trajectory/memory_buffer.c
@@ -15,7 +15,7 @@ int main() {
     }
 
     const char* result = NULL;
-    size_t size_of_result;
+    uint64_t size_of_result;
     chfl_trajectory_memory_buffer(trajectory, &result, &size_of_result);
 
     chfl_trajectory_close(trajectory);

--- a/tests/doc/capi/chfl_trajectory/path.c
+++ b/tests/doc/capi/chfl_trajectory/path.c
@@ -11,8 +11,8 @@ int main() {
     // [example] [no-run]
     CHFL_TRAJECTORY* trajectory = chfl_trajectory_open("water.xyz", 'r');
 
-    const char* path = NULL;
-    chfl_trajectory_path(trajectory, &path);
+    char path[256] = {0};
+    chfl_trajectory_path(trajectory, path, sizeof(path));
     assert(strcmp(path, "water.xyz") == 0);
 
     chfl_trajectory_close(trajectory);


### PR DESCRIPTION
All the other functions make a copy of the string (chfl_atom_name, chfl_selection_string), this one did it differently for no good reason (it is not a performance sensitive function)