### PR TITLE
Check to ensure end IDs are greater than start IDs in the PDB reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,11 +72,11 @@ matrix:
     - name: osx clang
       os: osx
       compiler: clang
-      osx_image: xcode8.3
+      osx_image: xcode9.4
     - name: osx gcc
       os: osx
       compiler: gcc
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       addons:
         homebrew:
           packages:

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -232,6 +232,12 @@ void PDBFormat::read_HELIX(string_view line) {
         return;
     }
 
+    // Fix 1HTQ
+    if (start > end) {
+        warning("PDB reader", "HELIX starting residue {} is greater than ending id {}", start, end);
+        return;
+    }
+
     // Convert the code as a character to its numeric meaning.
     // See http://www.wwpdb.org/documentation/file-format-content/format23/sect5.html
     // for definitions of these numbers
@@ -294,6 +300,11 @@ void PDBFormat::read_secondary(string_view line, size_t i1, size_t i2, string_vi
             "error parsing line: '{}', check {} and {}",
             line, line.substr(i1 + 1, 4), line.substr(i2 + 1, 4)
         );
+        return;
+    }
+
+    if (resid1 >= resid2) {
+        warning("PDB reader", "SHEET starting residue {} is greater than ending id {}", resid1, resid2);
         return;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "53ddbfc5d79b09ec6f9dd80ae414898a9b6e5eb0")
+set(TESTS_DATA_GIT "f6c743b491343922ddae7b60d01b4911d11c0a46")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=f54b416a98d8b498d4f937641cd6e34f385099d5
+        EXPECTED_HASH SHA1=8abea08f45455e9cb949d432a099e16d251d674a
 
     )
 

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -313,6 +313,11 @@ TEST_CASE("Problematic PDB files") {
         CHECK(approx_eq(frame.positions()[0], {0.417, 8.303, 11.737}, 1e-5));
         CHECK(approx_eq(frame.positions()[5], {8.922, 9.426, 5.320}, 1e-5));
     }
+
+    SECTION("Bug in 1HTQ") {
+        auto file = Trajectory("data/pdb/1htq.pdb");
+        auto frame = file.read();
+    }
 }
 
 TEST_CASE("Write files in PDB format") {


### PR DESCRIPTION
Turns out the fix is really simple. The way to misrepresent PDB files will never cease to amaze me!