### PR TITLE
Fix Frame::out_of_plane for co-linear atoms

### DIFF
--- a/doc/src/properties/residue.toml
+++ b/doc/src/properties/residue.toml
@@ -1,7 +1,7 @@
 [is_standard_pdb]
 type = "bool"
 
-PDB = """When reading, **is_standard_pdb** is set to ``true`` for residues 
+PDB = """When reading, **is_standard_pdb** is set to ``true`` for residues
 defined with a ``ATOM`` record, and ``false`` for atoms defined with an
 ``HETATM`` record. When writing, **is_standard_pdb** is used to determine
 whether to emit an ``HETATM`` or an ``ATOM`` record. If the property is not set,
@@ -106,4 +106,4 @@ MMTF = """On reading, the **secondary_structure** is assigned via the
 descriptions by the *Define Secondary Strucutre of Proteins (DSSP)* algorithm.
 Examples include ``extended``, ``alpha helix``, ``pi helix``, ``turn`` and
 ``coil``. This property is not set for undefined secondary structures and is not
-used for writing.
+used for writing."""

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -211,5 +211,11 @@ double Frame::out_of_plane(size_t i, size_t j, size_t k, size_t m) const {
     auto rim = cell_.wrap(positions_[i] - positions_[m]);
 
     auto n = cross(rik, rim);
-    return dot(rji, n) / n.norm();
+    auto n_norm = n.norm();
+    if (n_norm < 1e-12) {
+        // if i, k, and m are colinear, then j is always inside the plane
+        return 0;
+    } else {
+        return dot(rji, n) / n_norm;
+    }
 }

--- a/tests/frame.cpp
+++ b/tests/frame.cpp
@@ -222,6 +222,14 @@ TEST_CASE("PBC functions") {
         frame.add_atom(Atom(), Vector3D(0, 1, 0));
 
         CHECK(frame.out_of_plane(0, 1, 2, 3) == 2);
+
+        frame = Frame();
+        frame.add_atom(Atom(), Vector3D(0, 0, 0));
+        frame.add_atom(Atom(), Vector3D(0, 1, 0));
+        frame.add_atom(Atom(), Vector3D(0, 0, 1));
+        frame.add_atom(Atom(), Vector3D(0, 0, -1));
+
+        CHECK(frame.out_of_plane(0, 1, 2, 3) == 0);
     }
 }
 


### PR DESCRIPTION
The code would return NaN if atoms `i, k, m` were colinear. I think 0 is a much more reasonable value here