### PR TITLE
PDB Write changes

### DIFF
--- a/include/chemfiles/Residue.hpp
+++ b/include/chemfiles/Residue.hpp
@@ -33,7 +33,7 @@ public:
     /// Create a new residue with a given `name` and residue id `resid`.
     ///
     /// @example{residue/residue-2.cpp}
-    Residue(std::string name, uint64_t resid);
+    Residue(std::string name, int64_t resid);
 
     ~Residue() = default;
     Residue(const Residue&) = default;
@@ -51,7 +51,7 @@ public:
     /// Get the residue identifier, or `nullopt` if it does not exist.
     ///
     /// @example{residue/id.cpp}
-    optional<uint64_t> id() const {
+    optional<int64_t> id() const {
         return id_;
     }
 
@@ -128,7 +128,7 @@ private:
     /// Name of the residue
     std::string name_;
     /// Index of the residue in the initial topology file
-    optional<uint64_t> id_;
+    optional<int64_t> id_;
     /// Indexes of the atoms in this residue. These indexes refers to the
     /// associated topology.
     sorted_set<size_t> atoms_;

--- a/include/chemfiles/capi/residue.h
+++ b/include/chemfiles/capi/residue.h
@@ -32,7 +32,7 @@ CHFL_EXPORT CHFL_RESIDUE* chfl_residue(const char* name);
 /// @example{capi/chfl_residue/with_id.c}
 /// @return A pointer to the residue, or NULL in case of error.
 ///         You can use `chfl_last_error` to learn about the error.
-CHFL_EXPORT CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid);
+CHFL_EXPORT CHFL_RESIDUE* chfl_residue_with_id(const char* name, int64_t resid);
 
 /// Get access to the residue at index `i` in a `topology`.
 ///
@@ -134,7 +134,7 @@ CHFL_EXPORT chfl_status chfl_residue_atoms(
 /// @return The operation status code. You can use `chfl_last_error` to learn
 ///         about the error if the status code is not `CHFL_SUCCESS`.
 CHFL_EXPORT chfl_status chfl_residue_id(
-    const CHFL_RESIDUE* residue, uint64_t* id
+    const CHFL_RESIDUE* residue, int64_t* id
 );
 
 /// Get the name of a `residue` in the string buffer `name`.

--- a/include/chemfiles/formats/GRO.hpp
+++ b/include/chemfiles/formats/GRO.hpp
@@ -35,7 +35,7 @@ public:
 
 private:
     /// Map of residues, indexed by residue id.
-    std::map<size_t, Residue> residues_;
+    std::map<int64_t, Residue> residues_;
 };
 
 template<> FormatInfo format_information<GROFormat>();

--- a/include/chemfiles/formats/MOL2.hpp
+++ b/include/chemfiles/formats/MOL2.hpp
@@ -44,7 +44,7 @@ private:
     void read_bonds(Frame& frame, size_t nbonds);
 
     /// Map of residues, indexed by residue id.
-    std::unordered_map<size_t, Residue> residues_;
+    std::unordered_map<int64_t, Residue> residues_;
 };
 
 template<> FormatInfo format_information<MOL2Format>();

--- a/include/chemfiles/formats/PDB.hpp
+++ b/include/chemfiles/formats/PDB.hpp
@@ -64,7 +64,7 @@ private:
 
     /// This typedef represent the 'full' name of a residue, this means the
     /// chainid, the residue sequence id, and the residue insertion code
-    using residue_info = std::tuple<char, size_t, char>;
+    using residue_info = std::tuple<char, int64_t, char>;
 
     /// Map where the key is the residue_info and the value is a residue object
     std::map<residue_info, Residue> residues_;

--- a/include/chemfiles/formats/mmCIF.hpp
+++ b/include/chemfiles/formats/mmCIF.hpp
@@ -46,7 +46,7 @@ private:
     /// Map of STAR records to their index
     std::map<std::string, size_t> atom_site_map_;
     /// Map of residues, indexed by residue id and chainid.
-    std::map<std::pair<std::string, size_t>, Residue> residues_;
+    std::map<std::pair<std::string, int64_t>, Residue> residues_;
     /// Set to true if the file is based on fractional coordinates.
     /// Set to false if the file is based on cartn coordinates.
     bool uses_fract_;

--- a/include/chemfiles/parse.hpp
+++ b/include/chemfiles/parse.hpp
@@ -183,6 +183,17 @@ inline size_t scan(string_view input, Args& ...args) {
     return iterator.read_count();
 }
 
+/// Encodes an integer using the [hybrid36] encoding scheme. Returns a string
+/// of `*` characters if the integer is out of range.
+///
+/// [hybrid36]: http://cci.lbl.gov/hybrid_36/
+std::string encode_hydrid36(uint64_t width, int64_t value);
+
+/// Decodes an integer using the [hybrid36] encoding scheme.
+///
+/// [hybrid36]: http://cci.lbl.gov/hybrid_36/
+int64_t decode_hybrid36(uint64_t width, string_view input);
+
 }
 
 #endif

--- a/include/chemfiles/parse.hpp
+++ b/include/chemfiles/parse.hpp
@@ -194,6 +194,12 @@ std::string encode_hydrid36(uint64_t width, int64_t value);
 /// [hybrid36]: http://cci.lbl.gov/hybrid_36/
 int64_t decode_hybrid36(uint64_t width, string_view input);
 
+/// Maximum value for a width 4 number
+constexpr auto MAX_HYBRID36_W4_NUMBER = 2436111;
+
+/// Maximum value for a width 5 number
+constexpr auto MAX_HYBRID36_W5_NUMBER = 87440031;
+
 }
 
 #endif

--- a/src/Residue.cpp
+++ b/src/Residue.cpp
@@ -8,7 +8,7 @@ using namespace chemfiles;
 
 Residue::Residue(std::string name): name_(std::move(name)), id_(nullopt) {}
 
-Residue::Residue(std::string name, uint64_t resid): name_(std::move(name)), id_(resid) {}
+Residue::Residue(std::string name, int64_t resid): name_(std::move(name)), id_(resid) {}
 
 void Residue::add_atom(size_t i) {
     atoms_.insert(i);

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -131,10 +131,10 @@ void Topology::add_residue(Residue residue) {
             );
         }
     }
-    auto resid = residues_.size();
+    auto res_index = residues_.size();
     residues_.emplace_back(std::move(residue));
     for (auto i: residues_.back()) {
-        residue_mapping_.insert({i, resid});
+        residue_mapping_.insert({i, res_index});
     }
 }
 

--- a/src/capi/residue.cpp
+++ b/src/capi/residue.cpp
@@ -31,7 +31,7 @@ error:
     return nullptr;
 }
 
-extern "C" CHFL_RESIDUE* chfl_residue_with_id(const char* name, uint64_t resid) {
+extern "C" CHFL_RESIDUE* chfl_residue_with_id(const char* name, int64_t resid) {
     CHFL_RESIDUE* residue = nullptr;
     CHECK_POINTER_GOTO(name);
     CHFL_ERROR_GOTO(
@@ -106,7 +106,7 @@ extern "C" chfl_status chfl_residue_atoms(const CHFL_RESIDUE* const residue, uin
     )
 }
 
-extern "C" chfl_status chfl_residue_id(const CHFL_RESIDUE* const residue, uint64_t* id) {
+extern "C" chfl_status chfl_residue_id(const CHFL_RESIDUE* const residue, int64_t* id) {
     CHECK_POINTER(residue);
     CHECK_POINTER(id);
     CHFL_ERROR_CATCH(

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -64,9 +64,9 @@ void GROFormat::read_next(Frame& frame) {
             );
         }
 
-        size_t resid = SIZE_MAX;
+        int64_t resid = std::numeric_limits<int64_t>::max();
         try {
-            resid = parse<size_t>(line.substr(0, 5));
+            resid = parse<int64_t>(line.substr(0, 5));
         } catch (const Error&) {
             // Invalid residue, we'll skip it
         }
@@ -87,7 +87,7 @@ void GROFormat::read_next(Frame& frame) {
         }
         frame.add_atom(Atom(name), {x, y, z}, {vx, vy, vz});
 
-        if (resid != SIZE_MAX) {
+        if (resid != std::numeric_limits<int64_t>::max()) {
             if (residues_.find(resid) == residues_.end()) {
                 Residue residue(resname, resid);
                 residue.add_atom(frame.size() - 1);
@@ -159,7 +159,7 @@ void GROFormat::write_next(const Frame& frame) {
     // Only use numbers bigger than the biggest residue id as "resSeq" for
     // atoms without associated residue, and start generated residue id at
     // 1
-    uint64_t max_resid = 1;
+    int64_t max_resid = 1;
     for (const auto& residue: frame.topology().residues()) {
         auto resid = residue.id();
         if (resid && resid.value() > max_resid) {
@@ -185,7 +185,7 @@ void GROFormat::write_next(const Frame& frame) {
 
         if (residue && residue->id()) {
             auto value = residue->id().value();
-            if (value <= 99999) {
+            if (value <= 99999 && value >= 0) {
                 resid = std::to_string(value);
             } else {
                 warning("GRO writer", "too many residues, removing residue id");

--- a/src/formats/GRO.cpp
+++ b/src/formats/GRO.cpp
@@ -64,7 +64,7 @@ void GROFormat::read_next(Frame& frame) {
             );
         }
 
-        int64_t resid = std::numeric_limits<int64_t>::max();
+        optional<int64_t> resid = nullopt;
         try {
             resid = parse<int64_t>(line.substr(0, 5));
         } catch (const Error&) {
@@ -87,16 +87,18 @@ void GROFormat::read_next(Frame& frame) {
         }
         frame.add_atom(Atom(name), {x, y, z}, {vx, vy, vz});
 
-        if (resid != std::numeric_limits<int64_t>::max()) {
-            if (residues_.find(resid) == residues_.end()) {
-                Residue residue(resname, resid);
-                residue.add_atom(frame.size() - 1);
+        if (!resid) {
+            continue;
+        }
 
-                residues_.insert({resid, residue});
-            } else {
-                // Just add this atom to the residue
-                residues_.at(resid).add_atom(frame.size() - 1);
-            }
+        if (residues_.find(*resid) == residues_.end()) {
+            Residue residue(resname, *resid);
+            residue.add_atom(frame.size() - 1);
+
+            residues_.insert({*resid, residue});
+        } else {
+            // Just add this atom to the residue
+            residues_.at(*resid).add_atom(frame.size() - 1);
         }
     }
 
@@ -185,7 +187,13 @@ void GROFormat::write_next(const Frame& frame) {
 
         if (residue && residue->id()) {
             auto value = residue->id().value();
-            if (value <= 99999 && value >= 0) {
+            if (value <= 0) {
+                warning("GRO writer", "the residue id '{}' should not be negative or zero, treating it as blank", value);
+                auto value = max_resid++;
+                if (value <= 99999) {
+                    resid = std::to_string(value);
+                }
+            } else if (value <= 99999) {
                 resid = std::to_string(value);
             } else {
                 warning("GRO writer", "too many residues, removing residue id");

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -394,7 +394,7 @@ void LAMMPSDataFormat::read_atoms(Frame& frame) {
             if (residue_iter != residues.end()) {
                 residue_iter->second.add_atom(data.index);
             } else {
-                auto residue = Residue("", data.molid);
+                auto residue = Residue("", static_cast<int64_t>(data.molid));
                 residue.add_atom(data.index);
                 residues.emplace(data.molid, std::move(residue));
             }

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -242,7 +242,7 @@ Residue MMTFFormat::create_residue(const std::string& current_assembly, size_t g
 
     const auto& group = structure_.groupList[group_type];
 
-    auto groupId = static_cast<size_t>(structure_.groupIdList[groupIndex_]);
+    auto groupId = static_cast<int64_t>(structure_.groupIdList[groupIndex_]);
     auto residue = Residue(group.groupName, groupId);
     residue.set("composition_type", group.chemCompType);
     residue.set("is_standard_pdb", !mmtf::is_hetatm(group.chemCompType.c_str()));

--- a/src/formats/MOL2.cpp
+++ b/src/formats/MOL2.cpp
@@ -100,7 +100,8 @@ void MOL2Format::read_atoms(Frame& frame, size_t natoms, bool charges) {
     for (size_t i=0; i<natoms; i++) {
         auto line = file_.readline();
 
-        unsigned long id, resid;
+        size_t id;
+        int64_t resid;
         std::string atom_name, sybyl_type, resname;
         double x, y, z;
         double charge = 0;
@@ -241,7 +242,7 @@ void MOL2Format::write_next(const Frame& frame) {
     file_.print("{}\n", frame.get<Property::STRING>("name").value_or(""));
 
     // Start after the maximal residue id for atoms without associated residue
-    uint64_t max_resid = 0;
+    int64_t max_resid = 0;
     for (const auto& residue: frame.topology().residues()) {
         auto resid = residue.id();
         if (resid && resid.value() > max_resid) {

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -268,7 +268,7 @@ template <MolfileFormat F> void Molfile<F>::read_topology() {
 
     topology_ = Topology();
 
-    auto residues = std::unordered_map<size_t, Residue>();
+    auto residues = std::unordered_map<int64_t, Residue>();
     size_t atom_id = 0;
     for (auto& molfile_atom : atoms) {
         Atom atom(molfile_atom.name, molfile_atom.type);
@@ -282,7 +282,7 @@ template <MolfileFormat F> void Molfile<F>::read_topology() {
         topology_->add_atom(std::move(atom));
 
         if (molfile_atom.resname != std::string("")) {
-            auto resid = static_cast<size_t>(molfile_atom.resid);
+            auto resid = static_cast<int64_t>(molfile_atom.resid);
             auto residue = Residue(molfile_atom.resname, resid);
             auto inserted = residues.insert({resid, std::move(residue)});
             inserted.first->second.add_atom(atom_id);

--- a/src/formats/PDB.cpp
+++ b/src/formats/PDB.cpp
@@ -628,13 +628,16 @@ Record get_record(string_view line) {
 }
 
 static std::string to_pdb_index(int64_t value, uint64_t width) {
-    if (value == 10000 + 2 * 26 * static_cast<int64_t>(std::pow(36, width - 1) + 0.5)) {
+    auto encoded = encode_hydrid36(width, value + 1);
+
+    if (encoded[0] == '*' && (value == MAX_HYBRID36_W4_NUMBER || value == MAX_HYBRID36_W5_NUMBER)) {
         auto type = width == 5 ?
             "atom" : "residue";
-        warning("PDB writer", "the value for a {} serial/id is too large, using '*' instead", type);
+
+        warning("PDB writer", "the value for a {} serial/id is too large, using '{}' instead", type, encoded);
     }
 
-    return encode_hydrid36(width, value + 1);
+    return encoded;
 }
 
 struct ResidueInformation {

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -323,14 +323,14 @@ void mmCIFFormat::read(Frame& frame) {
         }
 
         auto atom_id = frame.size() - 1;
-        size_t resid = 0;
+        int64_t resid = 0;
         auto resid_text = line_split[label_seq_id->second];
 
         try {
             if (resid_text == ".") { // In this case, we need to use the entity id
-                resid = parse<size_t>(line_split[label_entity_id->second]);
+                resid = parse<int64_t>(line_split[label_entity_id->second]);
             } else {
-                resid = parse<size_t>(line_split[label_seq_id->second]);
+                resid = parse<int64_t>(line_split[label_seq_id->second]);
             }
         } catch (const Error& e) {
             throw format_error("invalid CIF residue or entity numeric: {}", e.what());

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -220,7 +220,7 @@ template <> double chemfiles::parse(string_view input) {
 static const auto digits_upper = std::string("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 static const auto digits_lower = std::string("0123456789abcdefghijklmnopqrstuvwxyz");
 
-static uint8_t digit_to_value(char c) {
+static int32_t digit_to_value(char c) {
     if (c >= '0' && c <= '9') {
         return c - '0';
     }
@@ -233,16 +233,16 @@ static uint8_t digit_to_value(char c) {
     return c - 'a' + 10;
 }
 
-static std::string encode_pure(const std::string& digits, uint64_t value) {
+static std::string encode_pure(const std::string& digits, int64_t value) {
     if (value == 0) {
         return std::string(digits, 1);
     }
     
-    auto n = digits.length();
+    auto n = static_cast<int32_t>(digits.length());
     std::string result;
     while (value != 0) {
         auto rest = value / n;
-        result += digits[value - rest * n];
+        result += digits[static_cast<size_t>(value - rest * n)];
         value = rest;
     }
 
@@ -250,9 +250,9 @@ static std::string encode_pure(const std::string& digits, uint64_t value) {
     return result;
 }
 
-static uint64_t decode_pure(string_view s) {
-    uint64_t result = 0;
-    auto n = digits_upper.length();
+static int64_t decode_pure(string_view s) {
+    int64_t result = 0;
+    auto n = static_cast<int64_t>(digits_upper.length());
     for (auto c : s) {
         result *= n;
         result += digit_to_value(c);

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -13,6 +13,10 @@ using namespace chemfiles;
 
 static bool is_digit(char c) { return '0' <= c && c <= '9'; }
 
+static bool is_ascii_upper(char c) { return 'A' <= c && c <= 'Z'; }
+
+static bool is_ascii_lower(char c) { return 'a' <= c && c <= 'z'; }
+
 template <> int64_t chemfiles::parse(string_view input) {
     if (input.empty()) {
         throw error("can not parse an integer from an empty string");
@@ -260,6 +264,8 @@ static int64_t decode_pure(string_view s) {
     return result;
 }
 
+/// Evaluates base^(power) and casts the result to int64_t while addressing
+/// issues where the result maybe rounded down due to floating point errors
 static int64_t pow_int(uint64_t base, uint64_t power) {
     return static_cast<int64_t>(std::pow(base, power) + 0.5);
 }
@@ -304,7 +310,7 @@ int64_t chemfiles::decode_hybrid36(uint64_t width, string_view s) {
     }
 
     auto f = s[0];
-    if (f == '-' || f == ' ' || std::isdigit(f)) {
+    if (f == '-' || f == ' ' || is_digit(f)) {
         // Negative number, these are not encoded
         return parse<int64_t>(s);
     }
@@ -316,7 +322,7 @@ int64_t chemfiles::decode_hybrid36(uint64_t width, string_view s) {
 
     if (digits_upper.find(f) != std::string::npos) {
         auto is_valid = std::all_of(s.begin(), s.end(), [](unsigned char c) {
-            return std::isdigit(c) || std::isupper(c);
+            return is_digit(c) || is_ascii_upper(c);
         });
 
         if (!is_valid) {
@@ -328,7 +334,7 @@ int64_t chemfiles::decode_hybrid36(uint64_t width, string_view s) {
 
     if (digits_lower.find(f) != std::string::npos) {
         auto is_valid = std::all_of(s.begin(), s.end(), [](unsigned char c) {
-            return std::isdigit(c) || std::islower(c);
+            return is_digit(c) || is_ascii_lower(c);
          });
 
         if (!is_valid) {

--- a/tests/capi/residue.cpp
+++ b/tests/capi/residue.cpp
@@ -74,7 +74,7 @@ TEST_CASE("chfl_residue") {
         CHFL_RESIDUE* residue = chfl_residue_with_id("", 5426);
         REQUIRE(residue);
 
-        uint64_t resid = 0;
+        int64_t resid = 0;
         CHECK_STATUS(chfl_residue_id(residue, &resid));
         CHECK(resid == 5426);
 
@@ -140,7 +140,7 @@ TEST_CASE("chfl_residue") {
 
         const CHFL_RESIDUE* checking_residue = chfl_residue_from_topology(topology, 0);
         REQUIRE(checking_residue);
-        uint64_t resid = 0;
+        int64_t resid = 0;
         CHECK_STATUS(chfl_residue_id(checking_residue, &resid));
         CHECK(resid == 56);
         chfl_free(checking_residue);

--- a/tests/doc/capi/chfl_residue/id.c
+++ b/tests/doc/capi/chfl_residue/id.c
@@ -9,7 +9,7 @@ int main() {
     // [example]
     CHFL_RESIDUE* residue = chfl_residue_with_id("water", 3);
 
-    uint64_t id = 0;
+    int64_t id = 0;
     chfl_residue_id(residue, &id);
     assert(id == 3);
 

--- a/tests/formats/gro.cpp
+++ b/tests/formats/gro.cpp
@@ -251,7 +251,7 @@ TEST_CASE("GRO files with big values") {
             auto frame = Frame();
             for(size_t i=0; i<100001; i++) {
                 frame.add_atom(Atom("A"), {0, 0, 0});
-                Residue residue("ANA", i + 1);
+                Residue residue("ANA", static_cast<int64_t>(i + 1));
                 residue.add_atom(i);
                 frame.add_residue(std::move(residue));
             }

--- a/tests/formats/gro.cpp
+++ b/tests/formats/gro.cpp
@@ -140,7 +140,7 @@ TEST_CASE("Write files in GRO format") {
     "    3foo      B    2   0.100   0.200   0.300  0.0000  0.0000  0.0000\n"
     "    3foo      C    3   0.100   0.200   0.300  0.0000  0.0000  0.0000\n"
     "    5barba    D    4   0.100   0.200   0.300  0.0000  0.0000  0.0000\n"
-    "    6XXXXX    E    5   0.400   0.500   0.600  0.9000  1.0000  1.1000\n"
+    "    6baz      E    5   0.400   0.500   0.600  0.9000  1.0000  1.1000\n"
     "    7XXXXX    F    6   0.400   0.500   0.600  0.9000  1.0000  1.1000\n"
     "    8XXXXX    G    7   0.400   0.500   0.600  0.9000  1.0000  1.1000\n"
     "   2.20000   1.90526   4.40000 0.0 0.0  -1.10000 0.0   0.00000   0.00000\n";
@@ -170,6 +170,10 @@ TEST_CASE("Write files in GRO format") {
 
     residue = Residue("barbar"); // This will be truncated in output
     residue.add_atom(3);
+    frame.add_residue(residue);
+
+    residue = Residue("baz", -1);
+    residue.add_atom(4);
     frame.add_residue(residue);
 
     file.write(frame);

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -349,8 +349,8 @@ TEST_CASE("Write files in PDB format") {
     "ATOM      3 C    foo A   3       1.000   2.000   3.000  1.00  0.00           C\n"
     "HETATM    4 D    bar C  -1B      1.000   2.000   3.000  1.00  0.00           D\n"
     "HETATM    5 E    XXX X   5       4.000   5.000   6.000  1.00  0.00           E\n"
-    "HETATM    6 F    XXX X   6       4.000   5.000   6.000  1.00  0.00           F\n"
-    "HETATM    7 G    XXX X   7       4.000   5.000   6.000  1.00  0.00           G\n"
+    "HETATM    6 F    baz X  -2       4.000   5.000   6.000  1.00  0.00           F\n"
+    "HETATM    7 G    XXX X   6       4.000   5.000   6.000  1.00  0.00           G\n"
     "CONECT    1    2    7\n"
     "CONECT    2    1    7\n"
     "CONECT    3    7\n"
@@ -397,6 +397,10 @@ TEST_CASE("Write files in PDB format") {
     residue.add_atom(3);
     residue.set("chainid", "CB");
     residue.set("insertion_code", "BB");
+    frame.add_residue(residue);
+
+    residue = Residue("baz", -2);
+    residue.add_atom(5);
     frame.add_residue(residue);
 
     file.write(frame);

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -347,18 +347,19 @@ TEST_CASE("Write files in PDB format") {
     "HETATM    1 A   AXXX X   4       1.000   2.000   3.000  1.00  0.00           A\n"
     "ATOM      2 B   Bfoo A   3       1.000   2.000   3.000  1.00  0.00           B\n"
     "ATOM      3 C    foo A   3       1.000   2.000   3.000  1.00  0.00           C\n"
-    "HETATM    4 D    bar C  -1B      1.000   2.000   3.000  1.00  0.00           D\n"
-    "HETATM    5 E    XXX X   5       4.000   5.000   6.000  1.00  0.00           E\n"
-    "HETATM    6 F    baz X  -2       4.000   5.000   6.000  1.00  0.00           F\n"
-    "HETATM    7 G    XXX X   6       4.000   5.000   6.000  1.00  0.00           G\n"
-    "CONECT    1    2    7\n"
-    "CONECT    2    1    7\n"
-    "CONECT    3    7\n"
-    "CONECT    4    7\n"
-    "CONECT    5    6    7\n"
-    "CONECT    6    5    7\n"
-    "CONECT    7    1    2    3    4\n"
-    "CONECT    7    5    6\n"
+    "TER       4      foo A   3 \n"
+    "HETATM    5 D    bar C  -1B      1.000   2.000   3.000  1.00  0.00           D\n"
+    "HETATM    6 E    XXX X   5       4.000   5.000   6.000  1.00  0.00           E\n"
+    "HETATM    7 F    baz X  -2       4.000   5.000   6.000  1.00  0.00           F\n"
+    "HETATM    8 G    XXX X   6       4.000   5.000   6.000  1.00  0.00           G\n"
+    "CONECT    1    2    8\n"
+    "CONECT    2    1    8\n"
+    "CONECT    3    8\n"
+    "CONECT    5    8\n"
+    "CONECT    6    7    8\n"
+    "CONECT    7    6    8\n"
+    "CONECT    8    1    2    3    5\n"
+    "CONECT    8    6    7\n"
     "ENDMDL\n"
     "END\n";
 
@@ -391,6 +392,7 @@ TEST_CASE("Write files in PDB format") {
     residue.add_atom(2);
     residue.set("chainid", "A");
     residue.set("is_standard_pdb", true);
+    residue.set("composition_type", "L-PEPTIDE LINKING");
     frame.add_residue(residue);
 
     residue = Residue("barbar"); // This will be truncated in output

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -380,6 +380,7 @@ TEST_CASE("Write files in PDB format") {
     frame.add_bond(4, 5);
     frame.add_bond(0, 6);
     frame.add_bond(1, 6);
+    frame.add_bond(1, 2); // This bond will not be printed
     frame.add_bond(2, 6);
     frame.add_bond(3, 6);
     frame.add_bond(4, 6);

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -474,7 +474,7 @@ TEST_CASE("PDB files with big values") {
         auto frame = Frame();
         for(size_t i=0; i<3; i++) {
             frame.add_atom(Atom("A"), {0, 0, 0});
-            Residue residue("ANA", 2436110 + i);
+            Residue residue("ANA", static_cast<int64_t>(2436110 + i));
             residue.add_atom(i);
             frame.add_residue(std::move(residue));
         }

--- a/tests/formats/pdb.cpp
+++ b/tests/formats/pdb.cpp
@@ -329,7 +329,7 @@ TEST_CASE("Problematic PDB files") {
         REQUIRE(file.nsteps() == 156);
     }
 }
-#include <iostream>
+
 TEST_CASE("Write files in PDB format") {
     auto tmpfile = NamedTempPath(".pdb");
     const auto EXPECTED_CONTENT =
@@ -504,29 +504,6 @@ TEST_CASE("PDB files with big values") {
         auto residue3 = frame.topology().residue_for_atom(2);
         CHECK(residue3 == nullopt);
     }
-    
-    /*
-
-    This test is too expensive with the limits of hybrid36...
-
-    SECTION("CONNECT with too many atoms") {
-        if (!is_valgrind_and_travis()) {
-            auto tmpfile = NamedTempPath(".pdb");
-
-            auto frame = Frame();
-            frame.reserve(87440031 + 10);
-            for(size_t i=0; i< 87440031 + 10; i++) {
-                frame.add_atom(Atom("A"), {0.0, 0.0, 0.0});
-            }
-
-            frame.add_bond(87440035, 87440037);
-            Trajectory(tmpfile, 'w').write(frame);
-
-            // Re-read the file we just wrote
-            frame = Trajectory(tmpfile, 'r').read();
-            CHECK(frame.topology().bonds().empty());
-        }
-    }*/
 }
 
 TEST_CASE("Read and write files in memory") {

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -208,7 +208,7 @@ TEST_CASE("scan") {
     );
 }
 
-void recycle(uint64_t width, int64_t value, const std::string& hybrid) {
+static void recycle(uint64_t width, int64_t value, const std::string& hybrid) {
     CHECK(chemfiles::encode_hydrid36(width, value) == hybrid);
     CHECK(chemfiles::decode_hybrid36(width, hybrid) == value);
 }

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -207,3 +207,131 @@ TEST_CASE("scan") {
         "error while reading '4.2 4': can not parse '4.2' as an integer"
     );
 }
+
+void recycle(uint64_t width, int64_t value, const std::string& hybrid) {
+    CHECK(chemfiles::encode_hydrid36(width, value) == hybrid);
+    CHECK(chemfiles::decode_hybrid36(width, hybrid) == value);
+}
+
+TEST_CASE("hyrid encode and decode") {
+    CHECK(chemfiles::decode_hybrid36(4, "    ") == 0);
+    CHECK(chemfiles::decode_hybrid36(4, "  -0") == 0);
+    recycle(4, -999, "-999");
+    recycle(4, -78, "-78");
+    recycle(4, -6, "-6");
+    recycle(4, 0, "0");
+    recycle(4, 9999, "9999");
+    recycle(4, 10000, "A000");
+    recycle(4, 10001, "A001");
+    recycle(4, 10002, "A002");
+    recycle(4, 10003, "A003");
+    recycle(4, 10004, "A004");
+    recycle(4, 10005, "A005");
+    recycle(4, 10006, "A006");
+    recycle(4, 10007, "A007");
+    recycle(4, 10008, "A008");
+    recycle(4, 10009, "A009");
+    recycle(4, 10010, "A00A");
+    recycle(4, 10011, "A00B");
+    recycle(4, 10012, "A00C");
+    recycle(4, 10013, "A00D");
+    recycle(4, 10014, "A00E");
+    recycle(4, 10015, "A00F");
+    recycle(4, 10016, "A00G");
+    recycle(4, 10017, "A00H");
+    recycle(4, 10018, "A00I");
+    recycle(4, 10019, "A00J");
+    recycle(4, 10020, "A00K");
+    recycle(4, 10021, "A00L");
+    recycle(4, 10022, "A00M");
+    recycle(4, 10023, "A00N");
+    recycle(4, 10024, "A00O");
+    recycle(4, 10025, "A00P");
+    recycle(4, 10026, "A00Q");
+    recycle(4, 10027, "A00R");
+    recycle(4, 10028, "A00S");
+    recycle(4, 10029, "A00T");
+    recycle(4, 10030, "A00U");
+    recycle(4, 10031, "A00V");
+    recycle(4, 10032, "A00W");
+    recycle(4, 10033, "A00X");
+    recycle(4, 10034, "A00Y");
+    recycle(4, 10035, "A00Z");
+    recycle(4, 10036, "A010");
+    recycle(4, 10046, "A01A");
+    recycle(4, 10071, "A01Z");
+    recycle(4, 10072, "A020");
+    recycle(4, 10000 + 36 * 36 - 1, "A0ZZ");
+    recycle(4, 10000 + 36 * 36, "A100");
+    recycle(4, 10000 + 36 * 36 * 36 - 1, "AZZZ");
+    recycle(4, 10000 + 36 * 36 * 36, "B000");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 - 1, "ZZZZ");
+    recycle(4, 10000 + 26 * 36 * 36 * 36, "a000");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 35, "a00z");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 36, "a010");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 36 * 36 - 1, "a0zz");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 36 * 36, "a100");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 36 * 36 * 36 - 1, "azzz");
+    recycle(4, 10000 + 26 * 36 * 36 * 36 + 36 * 36 * 36, "b000");
+    recycle(4, 10000 + 2 * 26 * 36 * 36 * 36 - 1, "zzzz");
+
+    CHECK(chemfiles::decode_hybrid36(5, "    ") == 0);
+    CHECK(chemfiles::decode_hybrid36(5, "  -0") == 0);
+    recycle(5, -9999, "-9999");
+    recycle(5, -123, "-123");
+    recycle(5, -45, "-45");
+    recycle(5, -6, "-6");
+    recycle(5, 0, "0");
+    recycle(5, 12, "12");
+    recycle(5, 345, "345");
+    recycle(5, 6789, "6789");
+    recycle(5, 99999, "99999");
+    recycle(5, 100000, "A0000");
+    recycle(5, 100010, "A000A");
+    recycle(5, 100035, "A000Z");
+    recycle(5, 100036, "A0010");
+    recycle(5, 100046, "A001A");
+    recycle(5, 100071, "A001Z");
+    recycle(5, 100072, "A0020");
+    recycle(5, 100000 + 36 * 36 - 1, "A00ZZ");
+    recycle(5, 100000 + 36 * 36, "A0100");
+    recycle(5, 100000 + 36 * 36 * 36 - 1, "A0ZZZ");
+    recycle(5, 100000 + 36 * 36 * 36, "A1000");
+    recycle(5, 100000 + 36 * 36 * 36 * 36 - 1, "AZZZZ");
+    recycle(5, 100000 + 36 * 36 * 36 * 36, "B0000");
+    recycle(5, 100000 + 2 * 36 * 36 * 36 * 36, "C0000");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 - 1, "ZZZZZ");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36, "a0000");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 - 1, "a000z");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36, "a0010");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36 - 1, "a00zz");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36, "a0100");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36 * 36 - 1, "a0zzz");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36 * 36, "a1000");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36 * 36 * 36 - 1, "azzzz");
+    recycle(5, 100000 + 26 * 36 * 36 * 36 * 36 + 36 * 36 * 36 * 36, "b0000");
+    recycle(5, 100000 + 2 * 26 * 36 * 36 * 36 * 36 - 1, "zzzzz");
+
+    CHECK(chemfiles::encode_hydrid36(4, -99999) == "****");
+    CHECK(chemfiles::encode_hydrid36(4, 9999999) == "****");
+
+    CHECK_THROWS_WITH(
+        chemfiles::decode_hybrid36(5, "*0000"),
+        "the value '*0000' is not a valid hybrid 36 number"
+    );
+
+    CHECK_THROWS_WITH(
+        chemfiles::decode_hybrid36(5, "A*000"),
+        "the value 'A*000' is not a valid hybrid 36 number"
+    );
+
+    CHECK_THROWS_WITH(
+        chemfiles::decode_hybrid36(5, "a*000"),
+        "the value 'a*000' is not a valid hybrid 36 number"
+    );
+
+    CHECK_THROWS_WITH(
+        chemfiles::decode_hybrid36(2, "12345"),
+        "the length of '12345' is greater than the width '2', this is a bug in chemfiles"
+    );
+}


### PR DESCRIPTION
This PR stops the PDB writer from writing `CONECT` records for standard residues and writes `TER` records at the end of chains. It also attempts to convert some large residue IDs to see if they are actually negative numbers.