### PR TITLE
Make sure CHEMFILES_WINDOWS is defined on chemfiles installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CHEMFILES_SANITIZERS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CHEMFILES_SANITIZERS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CHEMFILES_SANITIZERS}")
 
-if(WIN32)
-    add_definitions("-DCHEMFILES_WINDOWS")
-endif()
-
-if(MSVC)
-    add_definitions("-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS")
-endif()
-
 add_subdirectory(external)
 
 # We need to use a separated library for non-dll-exported classes that have an
@@ -121,6 +113,11 @@ target_compile_definitions(chemfiles_objects PRIVATE -D_FILE_OFFSET_BITS=64)
 # Required for zlib 64-bit support:
 target_compile_definitions(chemfiles_objects PRIVATE -D_LARGEFILE64_SOURCE=1)
 target_compile_definitions(chemfiles_objects PRIVATE -D_LFS64_LARGEFILE=1)
+
+if(MSVC)
+    target_compile_definitions(chemfiles_objects PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(chemfiles_objects PRIVATE -D_SCL_SECURE_NO_WARNINGS)
+endif()
 
 target_use_clang_tidy(chemfiles_objects)
 target_use_include_what_you_use(chemfiles_objects)
@@ -163,6 +160,10 @@ target_link_libraries(chemfiles
 )
 if(WIN32)
     target_link_libraries(chemfiles ws2_32)
+endif()
+
+if(WIN32)
+    set(CHEMFILES_WINDOWS ON)
 endif()
 
 configure_file (

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -37,7 +37,6 @@ if(${COMPILER_SUPPORTS_C99})
 endif()
 
 if(MSVC)
-    add_definitions("/D NOMINMAX")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
     set(CMAKE_SHARED_LINKER_FLAGS "/SUBSYSTEM:CONSOLE")
 endif()

--- a/include/chemfiles/UnitCell.hpp
+++ b/include/chemfiles/UnitCell.hpp
@@ -6,6 +6,7 @@
 
 #include "chemfiles/types.hpp"
 #include "chemfiles/exports.h"
+#include "chemfiles/config.h"
 
 #ifdef CHEMFILES_WINDOWS
 #undef INFINITE

--- a/include/chemfiles/config.in.h
+++ b/include/chemfiles/config.in.h
@@ -14,6 +14,9 @@
 /// The full version of chemfiles ("x.y.z"), as a string
 #define CHEMFILES_VERSION "@CHEMFILES_VERSION@"
 
+/// Are we building code on Windows?
+#cmakedefine CHEMFILES_WINDOWS
+
 /// thread_local implementation
 #ifdef __cplusplus
     #if @CHFL_HAS_THREAD_LOCAL@

--- a/include/chemfiles/files/Bz2File.hpp
+++ b/include/chemfiles/files/Bz2File.hpp
@@ -10,9 +10,17 @@
 #include <vector>
 #include <functional>
 
-#include <bzlib.h>
-
+#include "chemfiles/config.h"
 #include "chemfiles/File.hpp"
+
+// bzlib.h includes windows.h on Windows platforms, which defines `min` and
+// `max` symbols, failing compilation below.
+#ifdef CHEMFILES_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#endif
+
+#include <bzlib.h>
 
 namespace chemfiles {
 

--- a/src/files/Bz2File.cpp
+++ b/src/files/Bz2File.cpp
@@ -10,11 +10,11 @@
 #include <vector>
 #include <functional>
 
-#include <bzlib.h>
-
 #include "chemfiles/File.hpp"
 #include "chemfiles/files/Bz2File.hpp"
 #include "chemfiles/error_fmt.hpp"
+
+#include <bzlib.h>
 
 using namespace chemfiles;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "chemfiles/config.h"
 #include "chemfiles/utils.hpp"
 
 #ifdef CHEMFILES_WINDOWS


### PR DESCRIPTION
Instead of relying on cmake to set `CHEMFILES_WINDOWS`, set it in `include/chemfiles/config.h` when installing the library.

This should fix #333.