### PR TITLE
Add some assertions to the MMTF reader

### DIFF
--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -447,6 +447,8 @@ void MMTFFormat::add_residue_to_structure(const Frame& frame, const Residue& res
 // the initial atom index if it exists.
 size_t MMTFFormat::atom_id(size_t mmtf_id) {
     if (!mmtf::isDefaultValue(structure_.atomIdList)) {
+        assert(mmtf_id < structure_.atomIdList.size());
+        assert(structure_.atomIdList[mmtf_id] > 0);
         auto id = static_cast<size_t>(structure_.atomIdList[mmtf_id]) - 1;
         assert(atomSkip_ <= id);
         return id - atomSkip_;

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -183,7 +183,7 @@ template <MolfileFormat F> void Molfile<F>::read(Frame& frame) {
     }
     molfile_to_frame(timestep, frame);
 
-    frames_.emplace_back(std::move(frame.clone()));
+    frames_.emplace_back(frame.clone());
 }
 
 template <MolfileFormat F> void Molfile<F>::read_step(size_t step, Frame& frame) {


### PR DESCRIPTION
While debugging for #344, I added the assertions below. I think they are a nice additional safety guard to have regardless of how we end up resolving the issue.