### PR TITLE
fix(file): update position of cursor when writing

### DIFF
--- a/src/File.cpp
+++ b/src/File.cpp
@@ -208,6 +208,7 @@ void TextFile::vprint(fmt::string_view format, fmt::format_args args) {
         return;
     }
     file_->write(buffer.data(), buffer.size());
+    position_ += buffer.size();
 }
 
 std::string TextFile::readall() {

--- a/tests/files/bz2-file.cpp
+++ b/tests/files/bz2-file.cpp
@@ -81,6 +81,7 @@ TEST_CASE("Write a bzip2 file") {
         TextFile file(filename, File::WRITE, File::BZIP2);
         file.print("Test\n");
         file.print("{}\n", 5467);
+        CHECK(file.tellpos() == 10);
     }
 
     std::ifstream checking(filename, std::ios::binary);

--- a/tests/files/gz-file.cpp
+++ b/tests/files/gz-file.cpp
@@ -76,6 +76,7 @@ TEST_CASE("Write a gz file") {
         TextFile file(filename, File::WRITE, File::GZIP);
         file.print("Test\n");
         file.print("{}\n", 5467);
+        CHECK(file.tellpos() == 10);
     }
 
     std::ifstream checking(filename, std::ios::binary);

--- a/tests/files/memory-file.cpp
+++ b/tests/files/memory-file.cpp
@@ -93,6 +93,7 @@ TEST_CASE("Write to files in memory") {
         CHECK(std::string(result.data(), result.size()) == "Test\n");
 
         file.print("JUNKJUNK");
+        CHECK(file.tellpos() == 13);
         result = buffer->write_memory_as_string();
         CHECK(std::string(result.data(), result.size()) == "Test\nJUNKJUNK");
 

--- a/tests/files/plain-file.cpp
+++ b/tests/files/plain-file.cpp
@@ -165,6 +165,7 @@ TEST_CASE("Write a text file") {
         TextFile file(filename, File::WRITE, File::DEFAULT);
         file.print("Test\n");
         file.print("{}\n", 5467);
+        CHECK(file.tellpos() == 10);
     }
 
     std::ifstream verification(filename);

--- a/tests/files/xz-file.cpp
+++ b/tests/files/xz-file.cpp
@@ -73,6 +73,7 @@ TEST_CASE("Write an xz file") {
         auto file = TextFile(filename, File::WRITE, File::LZMA);
         file.print("Test\n");
         file.print("{}\n", 5467);
+        CHECK(file.tellpos() == 10);
     }
 
     std::ifstream verification(filename, std::ios::binary);

--- a/tests/formats/cssr.cpp
+++ b/tests/formats/cssr.cpp
@@ -90,6 +90,9 @@ R"( REFERENCE STRUCTURE = 00000   A,B,C =  10.000  10.000  12.000
     frame.set_cell(UnitCell(10, 10, 12));
     auto t = Trajectory(tmpfile, 'w');
     t.write(frame);
+
+    CHECK_THROWS_WITH(t.write(frame), "CSSR format only supports writing one frame");
+
     t.close();
 
     std::ifstream checking(tmpfile);


### PR DESCRIPTION
Currently one is able to write multiple frames to CSSR files. Chemfiles is able to read back only one and I guess the standard allows only one frame anyway. This is because the checks rely on the cursor position which is currently not updated when writing. So one can write multiple frames without triggering those checks.
Technically this also applies for appending, but this would require an implementation of `tell` for all different files. Since CSSR does not support appending (and it would not be sensible to support appending for any other one-frame format) we can safely ignore appending for now.