### PR TITLE
Implement Amber Restart Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changes in supported formats
 
+- Added read and write support for Amber Restart (.ncrst) files.
+
 ### Changes to the C API
 
 ## 0.10.0 (14 Feb 2021)

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -1,6 +1,8 @@
 [name]
 type = "string"
 
+"Amber NetCDF" = "The global attribute ``title`` is used as the frame **name** when reading."
+"Amber Restart" = "The global attribute ``title`` is used as the frame **name** when reading."
 CML = "The text in the ``name`` node of a molecule. Only set if the node is present."
 PDB = "The text described by the ``TITLE`` record is used as the frame **name** when reading."
 GRO = "The first line of a GRO file is used as the frame **name** when reading."

--- a/include/chemfiles/files/NcFile.hpp
+++ b/include/chemfiles/files/NcFile.hpp
@@ -134,6 +134,8 @@ public:
         return file_id_;
     }
 
+    /// Check if a global string attribut exists
+    bool global_attribute_exists(const std::string& name) const;
     /// Get a global string attribute from the file
     std::string global_attribute(const std::string& name) const;
     /// Create a global attribute in the file_

--- a/include/chemfiles/files/NcFile.hpp
+++ b/include/chemfiles/files/NcFile.hpp
@@ -73,7 +73,16 @@ namespace nc {
         /// Get `count` values starting at `start` from this variable
         std::vector<float> get(count_t start, count_t count) const;
         /// Add `cout` values from `data` starting at `start` in this variable
-        void add(count_t start, count_t count, std::vector<float> data);
+        void add(count_t start, count_t count, const std::vector<float>& data);
+    };
+
+    class NcDouble final: public NcVariable {
+    public:
+        NcDouble(NcFile& file, netcdf_id_t var) : NcVariable(file, var) {}
+        /// Get `count` values starting at `start` from this variable
+        std::vector<double> get(count_t start, count_t count) const;
+        /// Add `cout` values from `data` starting at `start` in this variable
+        void add(count_t start, count_t count, const std::vector<double>& data);
     };
 
     class NcChar final: public NcVariable {
@@ -87,6 +96,7 @@ namespace nc {
 
     template<typename NcType> struct nc_type;
     template<> struct nc_type<NcFloat> {static constexpr auto value = NC_FLOAT;};
+    template<> struct nc_type<NcDouble> {static constexpr auto value = NC_DOUBLE;};
     template<> struct nc_type<NcChar> {static constexpr auto value = NC_CHAR;};
 } // namespace nc
 
@@ -96,7 +106,7 @@ namespace nc {
 /// format. All the operation are guaranteed to return a valid value or throw an
 /// error.
 ///
-/// The template functions are manually specialized for float and char data types.
+/// The template functions are manually specialized for float, double and char data types.
 class NcFile final: public File {
 public:
     NcFile(std::string path, File::Mode mode);

--- a/include/chemfiles/formats/AmberNetCDF.hpp
+++ b/include/chemfiles/formats/AmberNetCDF.hpp
@@ -21,10 +21,16 @@ class FormatMetadata;
 
 template <class T> class span;
 
+enum AmberFormat {
+    AMBER_NC_RESTART,     ///< AMBER Restart
+    AMBER_NC_TRAJECTORY,  ///< AMBER NetCDF Trajectory
+};
+
 /// Amber NetCDF file format reader.
-class AmberNetCDFFormat final: public Format {
+template <AmberFormat F>
+class Amber final: public Format {
 public:
-    AmberNetCDFFormat(std::string path, File::Mode mode, File::Compression compression);
+    Amber(std::string path, File::Mode mode, File::Compression compression);
 
     void read_step(size_t step, Frame& frame) override;
     void read(Frame& frame) override;
@@ -32,6 +38,10 @@ public:
 
     size_t nsteps() override;
 private:
+    /// Generate the range of indices [start, stop] for a 3D vector at the current step.
+    std::array<std::vector<size_t>, 2> vec3d_range();
+    /// Generate the range of indices [start, stop] for multiple 3D vectors at the current step.
+    std::array<std::vector<size_t>, 2> vec3d_n_range(size_t n);
     /// Read the unit cell at the current internal step, the file is assumed to
     /// be valid.
     UnitCell read_cell();
@@ -53,7 +63,11 @@ private:
     bool validated_;
 };
 
-template<> const FormatMetadata& format_metadata<AmberNetCDFFormat>();
+template<> size_t Amber<AMBER_NC_RESTART>::nsteps();
+template<> size_t Amber<AMBER_NC_TRAJECTORY>::nsteps();
+
+template<> const FormatMetadata& format_metadata<Amber<AMBER_NC_RESTART>>();
+template<> const FormatMetadata& format_metadata<Amber<AMBER_NC_TRAJECTORY>>();
 
 } // namespace chemfiles
 

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -48,6 +48,8 @@ namespace chemfiles {
     class MemoryBuffer;
     class Format;
 
+    extern template class Amber<AMBER_NC_RESTART>;
+    extern template class Amber<AMBER_NC_TRAJECTORY>;
     extern template class Molfile<DCD>;
     extern template class Molfile<TRJ>;
     extern template class Molfile<MOLDEN>;
@@ -61,7 +63,8 @@ static size_t find_by_extension(const std::vector<RegisteredFormat>& formats, st
 
 FormatFactory::FormatFactory() {
     // add formats in alphabetic order
-    this->add_format<AmberNetCDFFormat>();
+    this->add_format<Amber<AMBER_NC_RESTART>>();
+    this->add_format<Amber<AMBER_NC_TRAJECTORY>>();
 #ifndef CHFL_DISABLE_GEMMI
     this->add_format<CIFFormat>();
 #endif

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -193,6 +193,12 @@ NcFile::NcMode NcFile::nc_mode() const {
     return nc_mode_;
 }
 
+bool NcFile::global_attribute_exists(const std::string& name) const {
+    size_t size = 0;
+    auto status = nc_inq_attlen(file_id_, NC_GLOBAL, name.c_str(), &size);
+    return status == NC_NOERR;
+}
+
 std::string NcFile::global_attribute(const std::string& name) const {
     size_t size = 0;
     auto status = nc_inq_attlen(file_id_, NC_GLOBAL, name.c_str(), &size);

--- a/src/files/NcFile.cpp
+++ b/src/files/NcFile.cpp
@@ -91,9 +91,31 @@ std::vector<float> nc::NcFloat::get(count_t start, count_t count) const {
     return result;
 }
 
-void nc::NcFloat::add(count_t start, count_t count, std::vector<float> data) {
+void nc::NcFloat::add(count_t start, count_t count, const std::vector<float>& data) {
     assert(data.size() == hyperslab_size(count));
     int status = nc_put_vara_float(
+        file_id_, var_id_,
+        start.data(), count.data(),
+        data.data()
+    );
+    nc::check(status, "could not put data in variable");
+}
+
+std::vector<double> nc::NcDouble::get(count_t start, count_t count) const {
+    auto size = hyperslab_size(count);
+    auto result = std::vector<double>(size, 0.0);
+    int status = nc_get_vara_double(
+        file_id_, var_id_,
+        start.data(), count.data(),
+        result.data()
+    );
+    nc::check(status, "could not read variable");
+    return result;
+}
+
+void nc::NcDouble::add(count_t start, count_t count, const std::vector<double>& data) {
+    assert(data.size() == hyperslab_size(count));
+    int status = nc_put_vara_double(
         file_id_, var_id_,
         start.data(), count.data(),
         data.data()

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -703,7 +703,7 @@ size_t DataTypes::improper_type_id(size_t type_i, size_t type_j, size_t type_k, 
 
 void LAMMPSDataFormat::write_next(const Frame& frame) {
     if (file_.tellpos() != 0) {
-        throw format_error("LAMMPS Data format only supports writting one frame");
+        throw format_error("LAMMPS Data format only supports writing one frame");
     }
 
     auto types = DataTypes(frame.topology());

--- a/tests/files/netcdf-file.cpp
+++ b/tests/files/netcdf-file.cpp
@@ -2,44 +2,86 @@
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
 #include "catch.hpp"
-#include "helpers.hpp"
 #include "chemfiles.hpp"
 #include "chemfiles/files/NcFile.hpp"
+#include "helpers.hpp"
 using namespace chemfiles;
 
-
 TEST_CASE("Read a NetCDF file") {
-    NcFile file("data/netcdf/water.nc", File::READ);
+    SECTION("Float variables") {
+        NcFile file("data/netcdf/water.nc", File::READ);
 
-    CHECK(file.global_attribute("Conventions") == "AMBER");
-    // Usual dimmensions
-    CHECK(file.dimension("atom") == 297);
-    // Unlimited dimension
-    CHECK(file.dimension("frame") == 100);
+        CHECK(file.global_attribute("Conventions") == "AMBER");
+        // Usual dimmensions
+        CHECK(file.dimension("atom") == 297);
+        // Unlimited dimension
+        CHECK(file.dimension("frame") == 100);
 
-    CHECK(file.variable<nc::NcFloat>("cell_lengths").string_attribute("units") == "Angstrom");
+        CHECK(file.variable<nc::NcFloat>("cell_lengths").string_attribute("units") == "Angstrom");
 
-    auto var = file.variable<nc::NcFloat>("coordinates");
-    auto dims = var.dimmensions();
-    CHECK(dims.size() == 3);
-    CHECK(dims[0] == 100);
-    CHECK(dims[1] == 297);
-    CHECK(dims[2] == 3);
+        auto var = file.variable<nc::NcFloat>("coordinates");
+        auto dims = var.dimmensions();
+        CHECK(dims.size() == 3);
+        CHECK(dims[0] == 100);
+        CHECK(dims[1] == 297);
+        CHECK(dims[2] == 3);
 
-    auto EPS = 1e-5f;
-    auto positions = var.get({0, 0, 0}, {1, 297, 3});
-    CHECK(std::abs(positions[0] - 0.4172191f) < EPS);
-    CHECK(std::abs(positions[1] - 8.303366f) < EPS);
-    CHECK(std::abs(positions[2] - 11.73717f) < EPS);
+        auto EPS = 1e-5f;
+        auto positions = var.get({0, 0, 0}, {1, 297, 3});
+        CHECK(std::abs(positions[0] - 0.4172191f) < EPS);
+        CHECK(std::abs(positions[1] - 8.303366f) < EPS);
+        CHECK(std::abs(positions[2] - 11.73717f) < EPS);
+    }
+
+    SECTION("Double variables") {
+        NcFile file("data/netcdf/water.ncrst", File::READ);
+
+        CHECK(file.global_attribute("Conventions") == "AMBERRESTART");
+        // Usual dimmensions
+        CHECK(file.dimension("atom") == 297);
+
+        CHECK(file.variable<nc::NcDouble>("cell_lengths").string_attribute("units") == "angstrom");
+
+        auto var = file.variable<nc::NcDouble>("coordinates");
+        auto dims = var.dimmensions();
+        CHECK(dims.size() == 2);
+        CHECK(dims[0] == 297);
+        CHECK(dims[1] == 3);
+
+        auto EPS = 1e-5;
+        auto positions = var.get({0, 0}, {297, 3});
+        CHECK(std::abs(positions[0] - 0.4172191) < EPS);
+        CHECK(std::abs(positions[1] - 8.303366) < EPS);
+        CHECK(std::abs(positions[2] - 11.73717) < EPS);
+    }
 }
 
 TEST_CASE("Errors in NetCDF files") {
-    NcFile file("data/netcdf/water.nc", File::READ);
+    SECTION("Float variables") {
+        NcFile file("data/netcdf/water.nc", File::READ);
 
-    CHECK_THROWS_AS(file.global_attribute("FOO"), FileError);
-    CHECK_THROWS_AS(file.dimension("FOO"), FileError);
-    CHECK_THROWS_AS(file.variable<nc::NcFloat>("cell_lengths").string_attribute("Bar"), FileError);
-    CHECK_THROWS_AS(file.variable<nc::NcFloat>("FOO"), FileError);
+        CHECK_THROWS_WITH(file.global_attribute("FOO"),
+                          "can not read attribute 'FOO': NetCDF: Attribute not found");
+        CHECK_THROWS_WITH(file.dimension("FOO"), "missing dimmension 'FOO' in NetCDF file");
+        CHECK_THROWS_WITH(
+            file.variable<nc::NcFloat>("cell_lengths").string_attribute("Bar"),
+            "can not read attribute id for attribute 'Bar': NetCDF: Attribute not found");
+        CHECK_THROWS_WITH(file.variable<nc::NcFloat>("FOO"),
+                          "can not get variable id for 'FOO: NetCDF: Variable not found");
+    }
+
+    SECTION("Double variables") {
+        NcFile file("data/netcdf/water.ncrst", File::READ);
+
+        CHECK_THROWS_WITH(file.global_attribute("FOO"),
+                          "can not read attribute 'FOO': NetCDF: Attribute not found");
+        CHECK_THROWS_WITH(file.dimension("FOO"), "missing dimmension 'FOO' in NetCDF file");
+        CHECK_THROWS_WITH(
+            file.variable<nc::NcDouble>("cell_lengths").string_attribute("Bar"),
+            "can not read attribute id for attribute 'Bar': NetCDF: Attribute not found");
+        CHECK_THROWS_WITH(file.variable<nc::NcDouble>("FOO"),
+                          "can not get variable id for 'FOO: NetCDF: Variable not found");
+    }
 }
 
 TEST_CASE("Write NetCDF files") {
@@ -51,17 +93,24 @@ TEST_CASE("Write NetCDF files") {
         file.add_global_attribute("global", "global.value");
         file.add_dimension("infinite");
         file.add_dimension("finite", 42);
+
         auto variable = file.add_variable<nc::NcFloat>("variable", "infinite", "finite");
         variable.add_string_attribute("attribute", "hello");
 
+        auto variable_d = file.add_variable<nc::NcDouble>("variable_d", "infinite", "finite");
+        variable_d.add_string_attribute("attribute", "world");
+
         file.set_nc_mode(NcFile::DATA);
         variable.add({0, 0}, {1, 42}, std::vector<float>(42, 38.2f));
+        variable_d.add({0, 0}, {1, 42}, std::vector<double>(42, 37.4));
     }
 
     {
         NcFile file(tmpfile, File::APPEND);
         auto variable = file.variable<nc::NcFloat>("variable");
         variable.add({1, 0}, {1, 42}, std::vector<float>(42, 55.1f));
+        auto variable_d = file.variable<nc::NcDouble>("variable_d");
+        variable_d.add({1, 0}, {1, 42}, std::vector<double>(42, 66.3));
     }
 
     {
@@ -70,10 +119,17 @@ TEST_CASE("Write NetCDF files") {
         CHECK(file.dimension("infinite") == 2);
         CHECK(file.dimension("finite") == 42);
         CHECK(file.variable_exists("variable"));
+        CHECK(file.variable_exists("variable_d"));
         CHECK_FALSE(file.variable_exists("bar"));
+
         auto variable = file.variable<nc::NcFloat>("variable");
         CHECK(variable.string_attribute("attribute") == "hello");
         CHECK(variable.get({0, 0}, {1, 42}) == std::vector<float>(42, 38.2f));
         CHECK(variable.get({1, 0}, {1, 42}) == std::vector<float>(42, 55.1f));
+
+        auto variable_d = file.variable<nc::NcDouble>("variable_d");
+        CHECK(variable_d.string_attribute("attribute") == "world");
+        CHECK(variable_d.get({0, 0}, {1, 42}) == std::vector<double>(42, 37.4));
+        CHECK(variable_d.get({1, 0}, {1, 42}) == std::vector<double>(42, 66.3));
     }
 }

--- a/tests/formats/amber-netcdf.cpp
+++ b/tests/formats/amber-netcdf.cpp
@@ -11,6 +11,7 @@ TEST_CASE("Read files in NetCDF format") {
         auto file = Trajectory("data/netcdf/water.nc");
         auto frame = file.read();
         CHECK(frame.size() == 297);
+        CHECK_FALSE(frame.get("name"));
         // Check positions
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.4172191, 8.303366, 11.73717), 1e-4));
@@ -23,6 +24,7 @@ TEST_CASE("Read files in NetCDF format") {
         frame = file.read();
         frame = file.read();
         CHECK(frame.size() == 297);
+        CHECK_FALSE(frame.get("name"));
 
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.2990952, 8.31003, 11.72146), 1e-4));
@@ -40,6 +42,7 @@ TEST_CASE("Read files in NetCDF format") {
         auto file = Trajectory("data/netcdf/no-cell.nc");
         auto frame = file.read();
         CHECK(frame.size() == 1989);
+        CHECK(frame.get("name").value() == "Cpptraj Generated trajectory");
         CHECK(frame.cell() == UnitCell());
     }
 
@@ -48,6 +51,7 @@ TEST_CASE("Read files in NetCDF format") {
         CHECK(file.nsteps() == 26);
         auto frame = file.read_step(12);
         CHECK(frame.size() == 1938);
+        CHECK_FALSE(frame.get("name"));
 
         auto cell = frame.cell();
         CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
@@ -68,6 +72,7 @@ TEST_CASE("Write files in NetCDF format") {
 
     auto file = Trajectory(tmpfile, 'w');
     Frame frame;
+    frame.set("name", "Test Title 123");
     frame.resize(4);
     auto positions = frame.positions();
     for(size_t i=0; i<4; i++) {
@@ -79,6 +84,7 @@ TEST_CASE("Write files in NetCDF format") {
 
     Trajectory check(tmpfile, 'r');
     frame = check.read();
+    CHECK(frame.get("name").value() == "Test Title 123");
     positions = frame.positions();
     CHECK(approx_eq(positions[0], {1, 2, 3}, 1e-4));
     CHECK(approx_eq(positions[1], {1, 2, 3}, 1e-4));

--- a/tests/formats/amber-restart.cpp
+++ b/tests/formats/amber-restart.cpp
@@ -12,6 +12,7 @@ TEST_CASE("Read files in Amber Restart format") {
         CHECK(file.nsteps() == 1);
         auto frame = file.read();
         CHECK(frame.size() == 297);
+        CHECK(frame.get("name").value() == "Cpptraj Generated Restart");
 
         // Check cell
         auto cell = frame.cell();
@@ -29,6 +30,7 @@ TEST_CASE("Read files in Amber Restart format") {
         // Check `read_step`
         auto frame = file.read_step(0);
         CHECK(frame.size() == 1989);
+        CHECK(frame.get("name").value() == "Cpptraj Generated Restart");
         CHECK(frame.cell() == UnitCell());
     }
 
@@ -36,6 +38,7 @@ TEST_CASE("Read files in Amber Restart format") {
         auto file = Trajectory("data/netcdf/scaled_traj.ncrst");
         auto frame = file.read();
         CHECK(frame.size() == 1938);
+        CHECK(frame.get("name").value() == "Cpptraj Generated Restart");
 
         // Check cell
         auto cell = frame.cell();
@@ -60,6 +63,7 @@ TEST_CASE("Write files in Amber Restart format") {
 
     auto file = Trajectory(tmpfile, 'w');
     Frame frame;
+    frame.set("name", "Test Title 123");
     frame.resize(4);
     auto positions = frame.positions();
     frame.add_velocities();
@@ -76,6 +80,7 @@ TEST_CASE("Write files in Amber Restart format") {
 
     Trajectory check(tmpfile, 'r');
     frame = check.read();
+    CHECK(frame.get("name").value() == "Test Title 123");
 
     positions = frame.positions();
     CHECK(approx_eq(positions[0], Vector3D(1, 2, 3), 1e-4));

--- a/tests/formats/amber-restart.cpp
+++ b/tests/formats/amber-restart.cpp
@@ -1,0 +1,92 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include "catch.hpp"
+#include "chemfiles.hpp"
+#include "helpers.hpp"
+using namespace chemfiles;
+
+TEST_CASE("Read files in Amber Restart format") {
+    SECTION("Water") {
+        auto file = Trajectory("data/netcdf/water.ncrst");
+        CHECK(file.nsteps() == 1);
+        auto frame = file.read();
+        CHECK(frame.size() == 297);
+
+        // Check cell
+        auto cell = frame.cell();
+        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+        CHECK(approx_eq(cell.lengths(), Vector3D(15.0, 15.0, 15.0), 1e-4));
+
+        // Check positions
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(0.4172191, 8.303366, 11.73717), 1e-4));
+        CHECK(approx_eq(positions[296], Vector3D(6.664049, 11.61418, 12.96149), 1e-4));
+    }
+
+    SECTION("Missing unit cell") {
+        auto file = Trajectory("data/netcdf/no-cell.ncrst");
+        // Check `read_step`
+        auto frame = file.read_step(0);
+        CHECK(frame.size() == 1989);
+        CHECK(frame.cell() == UnitCell());
+    }
+
+    SECTION("Scale factor") {
+        auto file = Trajectory("data/netcdf/scaled_traj.ncrst");
+        auto frame = file.read();
+        CHECK(frame.size() == 1938);
+
+        // Check cell
+        auto cell = frame.cell();
+        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+        CHECK(approx_eq(cell.lengths(), 1.765 * Vector3D(60.9682, 60.9682, 0), 1e-4));
+
+        // Check positions
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(1.39, 1.39, 0) * 0.455, 1e-4));
+        CHECK(approx_eq(positions[296], Vector3D(29.10, 37.41, 0) * 0.455, 1e-4));
+
+        // Check velocities
+        auto velocities = *frame.velocities();
+        CHECK(
+            approx_eq(velocities[1400], Vector3D(-0.042603, -0.146347, 12.803150) * -0.856, 1e-4));
+        CHECK(approx_eq(velocities[1600], Vector3D(0.002168, 0.125240, 4.188500) * -0.856, 1e-4));
+    }
+}
+
+TEST_CASE("Write files in Amber Restart format") {
+    auto tmpfile = NamedTempPath(".ncrst");
+
+    auto file = Trajectory(tmpfile, 'w');
+    Frame frame;
+    frame.resize(4);
+    auto positions = frame.positions();
+    frame.add_velocities();
+    auto velocities = *frame.velocities();
+    for (size_t i = 0; i < 4; i++) {
+        positions[i] = Vector3D(1, 2, 3);
+        velocities[i] = Vector3D(-3, -2, -1);
+    }
+    file.write(frame);
+
+    CHECK_THROWS_WITH(file.write(frame), "AMBER Restart format only supports writing one frame");
+
+    file.close();
+
+    Trajectory check(tmpfile, 'r');
+    frame = check.read();
+
+    positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(1, 2, 3), 1e-4));
+    CHECK(approx_eq(positions[1], Vector3D(1, 2, 3), 1e-4));
+    CHECK(approx_eq(positions[2], Vector3D(1, 2, 3), 1e-4));
+    CHECK(approx_eq(positions[3], Vector3D(1, 2, 3), 1e-4));
+
+    CHECK(frame.velocities());
+    velocities = *frame.velocities();
+    CHECK(approx_eq(velocities[0], Vector3D(-3, -2, -1), 1e-4));
+    CHECK(approx_eq(velocities[1], Vector3D(-3, -2, -1), 1e-4));
+    CHECK(approx_eq(velocities[2], Vector3D(-3, -2, -1), 1e-4));
+    CHECK(approx_eq(velocities[3], Vector3D(-3, -2, -1), 1e-4));
+}

--- a/tests/formats/lammps-data.cpp
+++ b/tests/formats/lammps-data.cpp
@@ -221,7 +221,10 @@ TEST_CASE("Write files in LAMMPS data format") {
     frame[0].set_mass(25);
     frame[2].set_charge(-2.4);
 
-    Trajectory(tmpfile, 'w', "LAMMPS Data").write(frame);
+    auto traj = Trajectory(tmpfile, 'w', "LAMMPS Data");
+    traj.write(frame);
+    CHECK_THROWS_WITH(traj.write(frame), "LAMMPS Data format only supports writing one frame");
+    traj.close();
 
     std::ifstream checking(tmpfile);
     std::string content((std::istreambuf_iterator<char>(checking)),


### PR DESCRIPTION
This enables chemfiles to read and write Amber Restart (.ncrst) files. Those files are pretty similar to Amber Trajectory files but use mostly doubles and contain only a single frame.
Closes #47.

Additional:
- ~fix link to specs of .gro files~
- added check in LAMMPS Data tests for writing multiple frames (see #352)
- read and write frame title property of Amber formats