### PR TITLE
Speedup OS X gcc CI build by not re-installing everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,6 @@ matrix:
       os: osx
       compiler: gcc
       osx_image: xcode9.4
-      addons:
-        homebrew:
-          packages:
-            - gcc@5
-          update: true
     - name: MSVC 64-bit
       os: windows
       env: CMAKE_GENERATOR="Visual Studio 14 2015 Win64"

--- a/scripts/ci/setup-travis.sh
+++ b/scripts/ci/setup-travis.sh
@@ -66,6 +66,9 @@ fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then
+        export HOMEBREW_NO_INSTALL_CLEANUP=1
+        export HOMEBREW_NO_AUTO_UPDATE=1
+        brew install gcc@5
         export CC=gcc-5
         export CXX=g++-5
 


### PR DESCRIPTION
It is much slower than other builders for an unknown reason