### PR TITLE
Set higher precedence for 'not' than 'and'/'or' in selections

### DIFF
--- a/src/selections/parser.cpp
+++ b/src/selections/parser.cpp
@@ -246,7 +246,7 @@ Ast Parser::selector() {
         }
 
     } else if (match(Token::NOT)) {
-        auto ast = expression();
+        auto ast = selector();
         return chemfiles::make_unique<Not>(std::move(ast));
     } else if (match(Token::LBRACKET)) {
         auto index = current_ - 1;

--- a/tests/selections/parser.cpp
+++ b/tests/selections/parser.cpp
@@ -46,6 +46,9 @@ TEST_CASE("Parsing") {
         ast = "and -> index(#1) == 1\n    -> or -> index(#1) == 1\n          -> index(#1) == 1";
         CHECK(parse("index == 1 and (index == 1 or index == 1)")->print() == ast);
 
+        ast = "or -> not index(#1) == 1\n   -> index(#1) == 3";
+        CHECK(parse("not index 1 or index 3")->print() == ast);
+
         CHECK_THROWS_WITH(parse("name H and"), "expected content after 'and'");
         CHECK_THROWS_WITH(parse("and name H"), "unexpected content: 'and'");
         CHECK_THROWS_WITH(parse("name H or"), "expected content after 'or'");


### PR DESCRIPTION
Fix #349 