### PR TITLE
Rewrite the MemoryBuffer class

### DIFF
--- a/include/chemfiles/capi/trajectory.h
+++ b/include/chemfiles/capi/trajectory.h
@@ -165,16 +165,18 @@ CHFL_EXPORT chfl_status chfl_trajectory_nsteps(
     CHFL_TRAJECTORY* trajectory, uint64_t* nsteps
 );
 
-/// Obtain the memory buffer written to by the `trajectory`. The user is **not**
-/// responsible for freeing `data` and this will be done automatically when the
-/// trajectory is closed. It is guaranteed that `data` is null terminated. The
-/// maximum size of the buffer is given by `max_size`.
+/// Obtain the memory buffer written to by the `trajectory`.
+///
+/// The user is **not** responsible for freeing `data` and this will be done
+/// automatically when the trajectory is closed. It is guaranteed that `data` is
+/// null terminated, and the size of the buffer, **not including** the final
+/// `NULL` character, is passed in `size`
 ///
 /// @example{capi/chfl_trajectory/memory_buffer.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn
 ///         about the error if the status code is not `CHFL_SUCCESS`.
 CHFL_EXPORT chfl_status chfl_trajectory_memory_buffer(
-    const CHFL_TRAJECTORY* trajectory, const char** data, uint64_t* max_size
+    const CHFL_TRAJECTORY* trajectory, const char** data, uint64_t* size
 );
 
 /// Close a trajectory file, and free the associated memory.

--- a/include/chemfiles/files/Bz2File.hpp
+++ b/include/chemfiles/files/Bz2File.hpp
@@ -12,6 +12,7 @@
 
 #include "chemfiles/config.h"
 #include "chemfiles/File.hpp"
+#include "chemfiles/files/MemoryBuffer.hpp"
 
 // bzlib.h includes windows.h on Windows platforms, which defines `min` and
 // `max` symbols, failing compilation below.
@@ -53,7 +54,7 @@ private:
 };
 
 /// Inflates BZIP2 data from the `src` buffer
-std::vector<char> bz2inflate_in_place(const char* src, size_t size);
+MemoryBuffer decompress_bz2(const char* src, size_t size);
 
 }
 

--- a/include/chemfiles/files/GzFile.hpp
+++ b/include/chemfiles/files/GzFile.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "chemfiles/File.hpp"
+#include "chemfiles/files/MemoryBuffer.hpp"
 
 typedef struct gzFile_s *gzFile;
 
@@ -36,7 +37,7 @@ private:
 };
 
 /// Inflates GZipped data from the `src` buffer
-std::vector<char> gzinflate_in_place(const char* src, size_t size);
+MemoryBuffer decompress_gz(const char* src, size_t size);
 
 } // namespace chemfiles
 

--- a/include/chemfiles/files/MemoryBuffer.hpp
+++ b/include/chemfiles/files/MemoryBuffer.hpp
@@ -5,60 +5,91 @@
 #define CHEMFILES_MEMORY_BUFFER_HPP
 
 #include <vector>
+
 #include "chemfiles/File.hpp"
 #include "chemfiles/external/span.hpp"
 
 namespace chemfiles {
+class MemoryBuffer;
+
+MemoryBuffer decompress_xz(const char*, size_t);
+MemoryBuffer decompress_gz(const char*, size_t);
+MemoryBuffer decompress_bz2(const char*, size_t);
 
 /// A class for handling memory passed directly instead of through a file
 /// handle. Unlike a `std::vector`, it does not assume ownership of the data
 /// when initialized through a pointer and size.
 class MemoryBuffer final {
 public:
+    /// Create a MemoryBuffer intended for writting with the given initial
+    /// capacity
+    MemoryBuffer(size_t initial);
 
-    /// Create a MemoryBuffer intended for writting.
-    MemoryBuffer(size_t initial_size = 20480)
-        : write_mem_(), begin_(nullptr), size_(0)
-    {
-        write_mem_.reserve(initial_size);
-        begin_ = write_mem_.data();
-    }
-
-    /// Create a MemoryBuffer intended for reading memory external to the class.
-    MemoryBuffer(const char* memory, size_t size)
-        : begin_(memory), size_(size) {}
+    /// Create a MemoryBuffer intended for reading external memory
+    MemoryBuffer(const char* memory, size_t size):
+        // const_cast is safe here because we still encode the const-ness
+        // through capacity == 0; meaning we will not try to write to this
+        // pointer
+        ptr_(const_cast<char*>(memory)), capacity_(0), len_(size) {}
 
 
-    span<char> write_memory_as_string() {
-        return span<char>(write_mem_.data(), write_mem_.size());
-    }
+    MemoryBuffer(const MemoryBuffer&) = delete;
+    MemoryBuffer(MemoryBuffer&&);
+    MemoryBuffer& operator=(const MemoryBuffer&) = delete;
+    MemoryBuffer& operator=(MemoryBuffer&&);
+    ~MemoryBuffer();
 
-    std::vector<char>& write_memory() {
-        return write_mem_;
-    }
-
+    /// Get the size of the buffer, i.e. the amount of data currently written
+    /// or readable from the buffer.
     size_t size() const {
-        return size_;
+        return len_;
+    }
+
+    /// Get the capacity of the buffer, i.e. size of the current allocation
+    size_t capacity() const {
+        return capacity_;
     }
 
     const char* data() const {
-        return begin_;
+        return ptr_;
     }
+
+    void write(const char* data, size_t size);
 
     /// Try to decompress the content of this buffer with the given
     /// `compression` format
     void decompress(File::Compression compression);
 
 private:
+    /// Do we own the memory managed by this class?
+    bool is_owned() const {
+        return capacity_ != 0;
+    }
 
-    /// Memory controlled by this class, typically used for writting
-    std::vector<char> write_mem_;
+    /// Reserve additional space for `extra` elements
+    void reserve_extra(size_t extra);
 
-    /// Read-only memory
-    const char* begin_;
+    /// Set the length of the buffer to the given value
+    void set_size(size_t len);
 
-    /// Size of read-only memory
-    size_t size_;
+    /// Get a non-const pointer to the data. This is not an overload of `data`
+    /// because otherwise this **private** overload would take precedence over
+    /// the public one for non-const `MemoryBuffer`.
+    char* data_mut() {
+        return ptr_;
+    }
+
+    friend MemoryBuffer chemfiles::decompress_xz(const char*, size_t);
+    friend MemoryBuffer chemfiles::decompress_gz(const char*, size_t);
+    friend MemoryBuffer chemfiles::decompress_bz2(const char*, size_t);
+
+    /// Start of the memory buffer
+    char* ptr_;
+    /// Size of the current allocation when writing / 0 when reading
+    size_t capacity_;
+    /// Amount of data written to the buffer when writing / total amount of
+    /// data in the buffer when reading
+    size_t len_;
 };
 
 }

--- a/include/chemfiles/files/XzFile.hpp
+++ b/include/chemfiles/files/XzFile.hpp
@@ -12,6 +12,7 @@
 #include <lzma.h>
 
 #include "chemfiles/File.hpp"
+#include "chemfiles/files/MemoryBuffer.hpp"
 
 namespace chemfiles {
 
@@ -46,7 +47,7 @@ private:
 };
 
 /// Inflates LZMA/XZ data from the `src` buffer
-std::vector<char> xzinflate_in_place(const char* src, size_t size);
+MemoryBuffer decompress_xz(const char* src, size_t size);
 
 }
 

--- a/src/Trajectory.cpp
+++ b/src/Trajectory.cpp
@@ -306,6 +306,5 @@ optional<span<const char>> Trajectory::memory_buffer() const {
         return nullopt;
     }
 
-    auto buffer_string = buffer_->write_memory_as_string();
-    return span<const char>(buffer_string.data(), buffer_string.data() + buffer_string.size());
+    return span<const char>(buffer_->data(), buffer_->data() + buffer_->size());
 }

--- a/src/capi/trajectory.cpp
+++ b/src/capi/trajectory.cpp
@@ -139,17 +139,17 @@ extern "C" chfl_status chfl_trajectory_nsteps(CHFL_TRAJECTORY* const trajectory,
     )
 }
 
-extern "C" chfl_status chfl_trajectory_memory_buffer(const CHFL_TRAJECTORY* trajectory, const char** data, uint64_t* max_size) {
+extern "C" chfl_status chfl_trajectory_memory_buffer(const CHFL_TRAJECTORY* trajectory, const char** data, uint64_t* size) {
     CHECK_POINTER(trajectory);
     CHECK_POINTER(data);
-    CHECK_POINTER(max_size);
+    CHECK_POINTER(size);
     CHFL_ERROR_CATCH(
         auto block = trajectory->memory_buffer();
         if (!block) {
-            throw Error("trajectory not opened to write to a memory block");
+            throw Error("trajectory was not opened to write to a memory block");
         }
         *data = block.value().data();
-        *max_size = trajectory->memory_buffer().value().size();
+        *size = trajectory->memory_buffer().value().size();
     )
 }
 

--- a/src/files/MemoryBuffer.cpp
+++ b/src/files/MemoryBuffer.cpp
@@ -1,33 +1,115 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
+#include <cstdlib>
+
 #include "chemfiles/files/MemoryBuffer.hpp"
 
 #include "chemfiles/files/GzFile.hpp"
 #include "chemfiles/files/XzFile.hpp"
 #include "chemfiles/files/Bz2File.hpp"
 
-#include "chemfiles/unreachable.hpp"
 #include "chemfiles/error_fmt.hpp"
+#include "chemfiles/unreachable.hpp"
 
 using namespace chemfiles;
+
+MemoryBuffer::MemoryBuffer(size_t initial):
+    ptr_(nullptr),
+    capacity_(0),
+    len_(0)
+{
+    if (initial == 0) {
+        throw file_error("invalid initial size of 0 for MemoryBuffer");
+    }
+    /// use malloc/free instead of new/delete to also have access to calloc &
+    /// realloc
+    ptr_ = static_cast<char*>(std::calloc(initial, sizeof(char)));
+    if (ptr_ == nullptr) {
+        throw file_error("failed to allocate memory for MemoryBuffer");
+    }
+    capacity_ = initial;
+}
+
+
+MemoryBuffer::MemoryBuffer(MemoryBuffer&& other): MemoryBuffer(nullptr, 0) {
+    *this = std::move(other);
+}
+
+MemoryBuffer& MemoryBuffer::operator=(MemoryBuffer&& other) {
+    this->~MemoryBuffer();
+    this->ptr_ = other.ptr_;
+    this->len_ = other.len_;
+    this->capacity_ = other.capacity_;
+
+    other.ptr_ = nullptr;
+    other.len_ = 0;
+    other.capacity_ = 0;
+    return *this;
+}
+
+MemoryBuffer::~MemoryBuffer() {
+    if (this->is_owned()) {
+        std::free(ptr_);
+    }
+}
+
+void MemoryBuffer::write(const char* data, size_t size) {
+    if (!this->is_owned()) {
+        throw file_error("can not write to read-only MemoryBuffer");
+    }
+
+    // +1 to always ensure there is a NULL byte at the end of the buffer
+    if (size > (capacity_ - (len_ + 1))) {
+        auto extra = capacity_;
+        while (size > (capacity_ + extra - (len_ + 1))) {
+            extra *= 2;
+        }
+        this->reserve_extra(extra);
+    }
+
+    auto* start = ptr_ + len_;
+    std::copy(data, data + size, start);
+    len_ += size;
+}
+
+void MemoryBuffer::reserve_extra(size_t extra) {
+    if (!this->is_owned()) {
+        throw file_error("can not reserve additional memory for a read-only MemoryBuffer");
+    }
+
+    ptr_ = static_cast<char*>(std::realloc(ptr_, capacity_ + extra));
+    if (ptr_ == nullptr) {
+        std::free(ptr_);
+        throw file_error("failed to allocate memory for MemoryBuffer");
+    }
+    // set newly allocated memory to 0
+    std::memset(ptr_ + capacity_, 0, extra);
+    capacity_ += extra;
+}
+
+void MemoryBuffer::set_size(size_t len) {
+    if (!this->is_owned()) {
+        throw file_error("can not set the size of a read-only MemoryBuffer");
+    }
+
+    if (len >= capacity_) {
+        throw file_error("can not set the size of a MemoryBuffer larger than the capacity");
+    }
+
+    len_ = len;
+}
 
 void MemoryBuffer::decompress(File::Compression compression) {
     switch(compression) {
     case File::GZIP:
-        write_mem_ = gzinflate_in_place(this->data(), this->size());
-        begin_ = write_mem_.data();
-        size_ = write_mem_.size();
+        *this = decompress_gz(this->data(), this->size());
         break;
     case File::LZMA:
-        write_mem_ = xzinflate_in_place(this->data(), this->size());
-        begin_ = write_mem_.data();
-        size_ = write_mem_.size();
+        *this = decompress_xz(this->data(), this->size());
         break;
     case File::BZIP2:
-        write_mem_ = bz2inflate_in_place(this->data(), this->size());
-        begin_ = write_mem_.data();
-        size_ = write_mem_.size();
+        *this = decompress_bz2(this->data(), this->size());
         break;
     case File::DEFAULT:
         // nothing to do

--- a/src/files/MemoryFile.cpp
+++ b/src/files/MemoryFile.cpp
@@ -39,10 +39,8 @@ size_t MemoryFile::read(char* data, size_t count) {
     auto amount_to_read = count + current_location_ <= buffer_->size() ?
         count : buffer_->size() - current_location_;
 
-    std::copy(buffer_->data() + current_location_,
-              buffer_->data() + current_location_ + amount_to_read,
-              data);
-
+    const char* start = buffer_->data() + current_location_;
+    std::copy(start, start + amount_to_read, data);
     current_location_ += amount_to_read;
 
     return amount_to_read;
@@ -53,5 +51,5 @@ void MemoryFile::write(const char* data, size_t count) {
         throw file_error("cannot write to a memory file unless it is opened in write mode");
     }
 
-    std::copy(data, data + count, std::back_inserter(buffer_->write_memory()));
+    buffer_->write(data, count);
 }

--- a/src/files/XzFile.cpp
+++ b/src/files/XzFile.cpp
@@ -174,10 +174,10 @@ void XzFile::compress_and_write(lzma_action action) {
     } while (stream_.avail_in != 0 || (action == LZMA_FINISH && status != LZMA_STREAM_END));
 }
 
-std::vector<char> chemfiles::xzinflate_in_place(const char* src, size_t size) {
+MemoryBuffer chemfiles::decompress_xz(const char* src, size_t size) {
     // assume a 10% compression ratio, which should be plenty enough
     // (typical ratio is around 15-20%)
-    std::vector<char> output(10 * size);
+    auto output = MemoryBuffer(10 * size);
 
     lzma_stream stream = LZMA_STREAM_INIT;
     stream.next_in = reinterpret_cast<const uint8_t*>(src);
@@ -189,12 +189,12 @@ std::vector<char> chemfiles::xzinflate_in_place(const char* src, size_t size) {
     bool done = false;
     do {
 	    // if we need more space, resize the vector
-	    if (stream.total_out >= output.size()) {
-		    output.resize(2 * output.size());
+	    if (stream.total_out >= output.capacity()) {
+		    output.reserve_extra(output.capacity());
 	    }
 
-	    stream.next_out = reinterpret_cast<uint8_t*>(output.data() + stream.total_out);
-    	stream.avail_out = output.size() - stream.total_out;
+	    stream.next_out = reinterpret_cast<uint8_t*>(output.data_mut() + stream.total_out);
+    	stream.avail_out = output.capacity() - stream.total_out;
 
         auto status = lzma_code(&stream, LZMA_FINISH);
         if (status == LZMA_STREAM_END) {
@@ -207,6 +207,10 @@ std::vector<char> chemfiles::xzinflate_in_place(const char* src, size_t size) {
 
     lzma_end(&stream);
 
-    output.resize(stream.total_out);
+    if (stream.total_out >= output.capacity()) {
+        // make sure the buffer always contains a terminal NULL
+        output.reserve_extra(1);
+    }
+    output.set_size(stream.total_out);
     return output;
 }

--- a/tests/capi/trajectory.cpp
+++ b/tests/capi/trajectory.cpp
@@ -1,6 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
+#include <cstring>
 #include <fstream>
 #include <sstream>
 
@@ -301,19 +302,20 @@ TEST_CASE("Write trajectory to memory") {
 
     CHECK_STATUS(chfl_trajectory_write(trajectory, frame));
 
-    const char* result = nullptr;
-    uint64_t size_of_result;
-    CHECK_STATUS(chfl_trajectory_memory_buffer(trajectory, &result, &size_of_result));
-    CHECK(std::string(result, size_of_result) == EXPECTED_CONTENT);
+    const char* data = nullptr;
+    uint64_t size;
+    CHECK_STATUS(chfl_trajectory_memory_buffer(trajectory, &data, &size));
+    CHECK(size == std::strlen(EXPECTED_CONTENT));
+    CHECK(std::string(data) == EXPECTED_CONTENT);
 
     chfl_free(frame);
     chfl_trajectory_close(trajectory);
 
-    // Make sure that improper trajectories don't succeed with internal file
-    CHFL_TRAJECTORY* trajectory2 = chfl_trajectory_open("data/xyz/trajectory.xyz", 'r');
-    REQUIRE(trajectory2);
-    CHECK(chfl_trajectory_memory_buffer(trajectory2, &result, &size_of_result) != CHFL_SUCCESS);
-    chfl_free(trajectory2);
+    // Make sure that we can not access memory buffer on standard trajectories
+    trajectory = chfl_trajectory_open("data/xyz/trajectory.xyz", 'r');
+    REQUIRE(trajectory);
+    CHECK(chfl_trajectory_memory_buffer(trajectory, &data, &size) != CHFL_SUCCESS);
+    chfl_free(trajectory);
 }
 
 static CHFL_FRAME* testing_frame() {

--- a/tests/files/bz2-file.cpp
+++ b/tests/files/bz2-file.cpp
@@ -117,18 +117,18 @@ TEST_CASE("In-memory decompression") {
         0x8b, 0x59, 0xd4
     };
 
-    auto decompressed = bz2inflate_in_place(reinterpret_cast<const char*>(content.data()), content.size());
-    CHECK(std::string(decompressed.begin(), decompressed.end()) == "Test\n5467\n");
+    auto decompressed = decompress_bz2(reinterpret_cast<const char*>(content.data()), content.size());
+    CHECK(std::string(decompressed.data(), decompressed.size()) == "Test\n5467\n");
 
     content[23] = 0x00;
     CHECK_THROWS_WITH(
-        bz2inflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_bz2(reinterpret_cast<const char*>(content.data()), content.size()),
         "bzip2: corrupted file (code: -4)"
     );
 
     content[0] = 0x00;
     CHECK_THROWS_WITH(
-        bz2inflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_bz2(reinterpret_cast<const char*>(content.data()), content.size()),
         "bzip2: this file do not seems to be a bz2 file (code: -5)"
     );
 }

--- a/tests/files/gz-file.cpp
+++ b/tests/files/gz-file.cpp
@@ -164,18 +164,18 @@ TEST_CASE("In-memory decompression") {
         0x5e, 0x98, 0x0a, 0x00, 0x00, 0x00,
     };
 
-    auto decompressed = gzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size());
-    CHECK(std::string(decompressed.begin(), decompressed.end()) == "Test\n5467\n");
+    auto decompressed = decompress_gz(reinterpret_cast<const char*>(content.data()), content.size());
+    CHECK(std::string(decompressed.data(), decompressed.size()) == "Test\n5467\n");
 
     content[23] = 0x00;
     CHECK_THROWS_WITH(
-        gzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_gz(reinterpret_cast<const char*>(content.data()), content.size()),
         "error inflating gzipped memory: incorrect data check"
     );
 
     content[0] = 0x00;
     CHECK_THROWS_WITH(
-        gzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_gz(reinterpret_cast<const char*>(content.data()), content.size()),
         "error inflating gzipped memory: incorrect header check"
     );
 }

--- a/tests/files/xz-file.cpp
+++ b/tests/files/xz-file.cpp
@@ -106,18 +106,18 @@ TEST_CASE("In-memory decompression") {
         0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x59, 0x5a
     };
 
-    auto decompressed = xzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size());
-    CHECK(std::string(decompressed.begin(), decompressed.end()) == "Test\n5467\n");
+    auto decompressed = decompress_xz(reinterpret_cast<const char*>(content.data()), content.size());
+    CHECK(std::string(decompressed.data(), decompressed.size()) == "Test\n5467\n");
 
     content[23] = 0x00;
     CHECK_THROWS_WITH(
-        xzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_xz(reinterpret_cast<const char*>(content.data()), content.size()),
         "lzma: compressed file is corrupted (code: 9)"
     );
 
     content[0] = 0x00;
     CHECK_THROWS_WITH(
-        xzinflate_in_place(reinterpret_cast<const char*>(content.data()), content.size()),
+        decompress_xz(reinterpret_cast<const char*>(content.data()), content.size()),
         "lzma: input not in .xz format (code: 7)"
     );
 }


### PR DESCRIPTION
Fixes #378 

This ensures (a) that the size of the buffer is the actual amount of data written to it and no longer the available capacity; and (b) that the buffer is always NULL terminated