### PR TITLE
fix(mmtf): chain and group indices are consecutive

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -140,3 +140,9 @@ latex_documents = [
     ('index', 'chemfiles.tex', u'Chemfiles Documentation',
      u'Guillaume Fraux', 'howto'),
 ]
+
+
+# -- Options for Linkcheck -------------------------------------------------
+
+# do not try to check archive.org, it can timeout a lot
+linkcheck_ignore = [r'https://web.archive.org/']

--- a/include/chemfiles/formats/MMTF.hpp
+++ b/include/chemfiles/formats/MMTF.hpp
@@ -102,7 +102,8 @@ private:
     // stores the association from chemfiles index to MMTF index to be able to
     // add the right bonds.
     //
-    // This is only used when writing
+    // This is only used when writing files, or reading files
+    // with unordered or incomplete ids (e.g. reduced representation).
     std::vector<int32_t> new_atom_indexes_;
 
     /// Have we written the unitcell data?

--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -124,19 +124,17 @@ void MMTFFormat::read_step(const size_t step, Frame& frame) {
     // Fast-forward, keeping all indexes updated
     while(modelIndex_ != step) {
         auto chainsPerModel = static_cast<size_t>(structure_.chainsPerModel[modelIndex_]);
-        while(chainIndex_ != chainsPerModel) {
+        for (size_t j = 0; j < chainsPerModel; ++j) {
             auto groupsPerChain = static_cast<size_t>(structure_.groupsPerChain[chainIndex_]);
-            while(groupIndex_ != groupsPerChain) {
+            for (size_t k = 0; k < groupsPerChain; ++k) {
                 auto groupType = static_cast<size_t>(structure_.groupTypeList[groupIndex_]);
-                auto group = structure_.groupList[groupType];
+                const auto& group = structure_.groupList[groupType];
                 auto atomCount = group.atomNameList.size();
                 atomIndex_ += atomCount;
                 groupIndex_++;
             }
-            groupIndex_ = 0;
             chainIndex_++;
         }
-        chainIndex_ = 0;
         modelIndex_++;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "b3401da4fcf4273a936b7685561737a7ea5f504b")
+set(TESTS_DATA_GIT "8a1a48e368bc0f9611fcf8c153b3230cf5f51f8b")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=4a964537de3e4299eefe02579bd4efc583cb934d
+        EXPECTED_HASH SHA1=dcfb388b4ec6544c94b3b63aa7cb32d7dddbe7b9
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "91e2b541878d6d62eabf3a76573b0726d2646b5b")
+set(TESTS_DATA_GIT "b3401da4fcf4273a936b7685561737a7ea5f504b")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=650525331ee5555c57a13af9b5fdf7a2f8d4cb86
+        EXPECTED_HASH SHA1=4a964537de3e4299eefe02579bd4efc583cb934d
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(topology.are_linked(topology.residue(0), topology.residue(1)));
         CHECK(!topology.are_linked(topology.residue(0), topology.residue(2)));
 
-        auto frame3= file.read();
+        auto frame3 = file.read();
     }
 
     SECTION("Alternative locations and symmetry operations") {
@@ -192,6 +192,23 @@ TEST_CASE("Read files in MMTF format") {
 
         const auto& last_residue = residues[residues.size() - 1];
         CHECK(last_residue.get("chainindex")->as_double() == -1.0);
+    }
+
+    SECTION("Read reduced representation") {
+        auto file = Trajectory("data/mmtf/1HTQ_reduced.mmtf");
+        CHECK(file.nsteps() == 10);
+
+        auto frame = file.read_step(9);
+        CHECK(frame.size() == 12336);
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(104.656, 52.957, 138.038), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(66.292, -29.336, 158.267), 1e-3));
+
+        frame = file.read_step(1);
+        CHECK(frame.size() == 12336);
+        positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(105.482, 51.793, 140.282), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(66.033, -29.676, 158.009), 1e-3));
     }
 
     SECTION("GZ Files") {

--- a/tests/formats/mmtf.cpp
+++ b/tests/formats/mmtf.cpp
@@ -130,6 +130,24 @@ TEST_CASE("Read files in MMTF format") {
         CHECK(topology.residue(10).get("secondary_structure")->as_string() == "extended");
     }
 
+    SECTION("Bug in 1HTQ") {
+        // Fast-forward in `read_step` calculates wrong indices
+        // https://github.com/chemfiles/chemfiles/issues/344
+        auto file = Trajectory("data/mmtf/1HTQ.mmtf");
+
+        auto frame = file.read_step(9);
+        CHECK(frame.size() == 97872);
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(103.657, 52.540, 137.019), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(73.297, 19.998, 146.804), 1e-3));
+
+        frame = file.read_step(1);
+        CHECK(frame.size() == 97872);
+        positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(104.485, 52.282, 139.288), 1e-3));
+        CHECK(approx_eq(positions[1401], Vector3D(73.385, 19.914, 146.528), 1e-3));
+    }
+
     SECTION("Successive steps") {
         auto file = Trajectory("data/mmtf/1J8K.mmtf");
 


### PR DESCRIPTION
I have not read the full spec but these examples [[1]](https://github.com/rcsb/mmtf/blob/master/spec.md#chainspermodel) [[2]](https://github.com/rcsb/mmtf/blob/master/spec.md#groupsperchain) indicate that chains and groups are indexed consecutively. This is also aparent when looking at [`StructureData::print`](https://github.com/rcsb/mmtf-cpp/blob/ee4b855cf53b4a3ee7a40cc62d57195875fe84a5/include/mmtf/structure_data.hpp#L1028). When skipping, chemfiles wrongfully starts at 0 again for every model.

Fixes #344.