### PR TITLE
More updates for 0.10

### DIFF
--- a/include/chemfiles/capi/misc.h
+++ b/include/chemfiles/capi/misc.h
@@ -62,8 +62,8 @@ CHFL_EXPORT chfl_status chfl_add_configuration(const char* path);
 ///
 /// This function allocate memory for all known formats, and set `metadata` to
 /// this new array. Users of this function are responsible with cleaning up
-/// this memory using the standard library `free`. The number of known formats
-/// (and thus the size of the metadata array) is set in `count`.
+/// this memory using `chfl_free`. The number of known formats (and thus the
+/// size of the metadata array) is set in `count`.
 ///
 /// @example{capi/chfl_formats_list.c}
 /// @return The operation status code. You can use `chfl_last_error` to learn

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -184,7 +184,7 @@ typedef struct {  // NOLINT: this is both a C and C++ file
 } chfl_match;
 
 
-/// A `chfl_format_metadata` contains metdata associated with one format
+/// A `chfl_format_metadata` contains metadata associated with one format
 typedef struct {
     /// Name of the format
     const char* name;

--- a/src/capi/misc.cpp
+++ b/src/capi/misc.cpp
@@ -67,7 +67,7 @@ extern "C" chfl_status chfl_formats_list(chfl_format_metadata** metadata, uint64
     CHFL_ERROR_CATCH(
         auto formats = formats_list();
         *count = static_cast<uint64_t>(formats.size());
-        *metadata = static_cast<chfl_format_metadata*>(malloc(*count * sizeof(chfl_format_metadata)));  // NOLINT: use malloc instead of chfl_allocator to allow users to call free
+        *metadata = shared_allocator::make_shared<chfl_format_metadata[]>(*count);
         for (uint64_t i=0; i<*count; i++) {
             // here we rely on the fact that only one instance of each matdata
             // exist, and that they come from static storage, allowing us to

--- a/src/capi/trajectory.cpp
+++ b/src/capi/trajectory.cpp
@@ -149,7 +149,7 @@ extern "C" chfl_status chfl_trajectory_memory_buffer(const CHFL_TRAJECTORY* traj
     CHFL_ERROR_CATCH(
         auto block = trajectory->memory_buffer();
         if (!block) {
-            throw Error("trajectory was not opened to write to a memory block");
+            throw Error("this trajectory was not opened to write to a memory buffer");
         }
         *data = block.value().data();
         *size = trajectory->memory_buffer().value().size();

--- a/tests/capi/shared_allocator.cpp
+++ b/tests/capi/shared_allocator.cpp
@@ -34,6 +34,25 @@ TEST_CASE("Shared allocator") {
         // Valgrind tests make sure all memory is released here
     }
 
+    SECTION("Allocation of array type") {
+        auto ptr = shared_allocator::make_shared<Dummy[]>(4);
+
+        // just checking that we can access all items in the array
+        ptr[0].data.push_back(4);
+        ptr[2].data.push_back(2);
+        ptr[3].data.push_back(65);
+
+        auto shared = shared_allocator::shared_ptr(ptr, &ptr[3].data[0]);
+
+        CHECK(*shared == 65);
+        shared_allocator::free(ptr);
+
+        *shared -= 20;
+        CHECK(*shared == 45);
+
+        shared_allocator::free(shared);
+    }
+
     SECTION("Internal re-allocation") {
         auto ptr = shared_allocator::make_shared<Dummy>();
         ptr->data.insert(std::end(ptr->data), {1, 2, 3});

--- a/tests/doc/capi/chfl_formats_list.c
+++ b/tests/doc/capi/chfl_formats_list.c
@@ -16,7 +16,7 @@ int main() {
     }
 
     // the user is responsible with freeing the memory
-    free(formats);
+    chfl_free(formats);
     // [example]
     return 0;
 }


### PR DESCRIPTION
The main one is the second commit, using `chfl_free` instead of `free` to manage memory for the format metadata list.