### PR TITLE
New DCD importer/exporter

### DIFF
--- a/include/chemfiles/files/DCDFile.hpp
+++ b/include/chemfiles/files/DCDFile.hpp
@@ -1,0 +1,91 @@
+#ifndef CHEMFILES_DCD_FILE_HPP
+#define CHEMFILES_DCD_FILE_HPP
+
+#include "chemfiles/File.hpp"
+#include <cstdint>
+#include <fstream>
+#include <string>
+ 
+namespace chemfiles {
+
+   /// Handle the creation and destruction of the file as needed.
+   /// Reads the file header and stores the offsets for individual frames.
+   class DCDFile {
+   public:
+
+      DCDFile(std::string path, File::Mode mode);
+      ~DCDFile();
+
+      void                          readHeader();
+      void                          readFrame(std::vector<float>& X, std::vector<float>& Y,
+                                                std::vector<float>& Z, int toFrame = NULL);
+      void                          writeHeader();
+      void                          writeFrame(std::vector<float>& x, std::vector<float>& y, 
+                                                std::vector<float>& z);
+
+      void                          setHDR(std::string hdr);
+      void                          setProperties(std::vector<int>& properties);
+
+      int                           getNumFrames() const;
+      
+      //Information on the periodic boundary conditions of the system
+      bool                          hasCrystal() const;
+      const double*                 getPbc() const;
+      void                          setPbc(double* pbc);
+
+      //
+      bool                          hasFrozenAtoms();
+      int                           getNumFreeAtoms() const;
+      void                          setNumFreeAtoms(int freeAtomsNum);
+      void                          setFreeAtoms(std::vector<int>& freeAtomsIndexes);
+      
+      //Number of atoms in the system 
+      int                           getNumAtoms() const;
+      void                          setNumAtoms(size_t atomNum);
+
+      bool                          hasPositions() const;
+      
+      //Navigate in the file stream
+      virtual size_t                getPos();
+      void                          setPos(size_t frameNum);
+
+      //Read title information 
+      int                           getNumTitles();
+      void                          setNumTitles(int titlesNumber);
+      char*                         getTitle();
+      void                          setTitle(std::string title);
+      
+   protected:
+      
+      std::fstream                  fileStream;    //File stream for opening and reading dcd file
+      
+      //content of ICNTRL : non detailed ones are 0
+      //ICNTRL(0)  number of frames in this dcd
+      //ICNTRL(1)  if restart, total number of frames before first print
+      //ICNTRL(2)  frequency of writting dcd
+      //ICNTRL(3)  number of steps ; note that NSTEP/NSAVC = numFrames
+      //ICNTRL(7)  number of degrees of freedom
+      //ICNTRL(8)  is numAtoms - NumberOfFreeAtoms : it is the number of frozen (i.e. not moving atoms)
+      //ICNTRL(9) timestep in AKMA units but stored as a 32 bits integer !!!
+      //ICNTRL(10) is 1 if CRYSTAL used
+      //ICNTRL(19) is charmm version
+      int                           ICNTRL[20];
+      char                          HDR[5];    //CORD (coordinates) or VEL (velocities). Velocities not supported yet
+      
+      int                           NTITLE;        //Number of "title lines" in the dcd file
+      char*                         TITLE;         //Each "title line" is 80 char long.
+      double                        pbc[6];        //6 real matrix defining the periodic boundary conditions : only useful if QCRYS is not 0
+
+      int                           numAtoms;      // Number of atoms
+      int                           numFreeAtoms;  // Number of free (moving) atoms
+      int*                          freeAtoms;     // Array storing indexes of moving atoms
+      long                          headByteNum;   //Bytes number of the DCD header
+      int                           frameNumber = 0;
+      int                           frameNumAtoms;
+
+   private:
+      bool                          checkFortranIOerror(const char file[], const int line,
+                                             const size_t fortcheck1, const size_t fortcheck2) const;
+   };
+} // namespace chemfiles
+#endif

--- a/include/chemfiles/formats/DCD.hpp
+++ b/include/chemfiles/formats/DCD.hpp
@@ -1,0 +1,42 @@
+#ifndef CHEMFILES_FORMAT_DCD_HPP
+#define CHEMFILES_FORMAT_DCD_HPP
+ 
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "chemfiles/File.hpp"
+#include "chemfiles/Format.hpp"
+#include "chemfiles/files/DCDFile.hpp"
+
+using matrix = float[3][3];
+
+namespace chemfiles {
+   class Frame;
+
+   /// [DCD][DCD] file format reader and writer.
+   ///
+   /// [DCD]: 
+   class DCDFormat final : public Format {
+   public:
+      // public methods
+      DCDFormat(std::string path, File::Mode mode, File::Compression compression);
+
+      void read_step(size_t step, Frame& frame) override;
+      void read(Frame& frame) override;
+      void write(const Frame& frame) override;
+      size_t nsteps() override;
+  
+   private:
+      /// Associated dcd file
+      DCDFile* file_;
+      /// The next step to read
+      size_t step_ = 0;
+   };
+   
+   template<> const FormatMetadata& format_metadata<DCDFormat>();
+} // namespace chemfiles
+
+#endif

--- a/include/chemfiles/formats/Molfile.hpp
+++ b/include/chemfiles/formats/Molfile.hpp
@@ -5,16 +5,16 @@
 #define CHEMFILES_FORMAT_MOLFILE_HPP
 
 extern "C" {
-    #include "vmdplugin.h"
     #include "molfile_plugin.h"
+    #include "vmdplugin.h"
 }
 
 #include <string>
 #include <vector>
 
 #include "chemfiles/File.hpp"
-#include "chemfiles/Frame.hpp"
 #include "chemfiles/Format.hpp"
+#include "chemfiles/Frame.hpp"
 #include "chemfiles/Topology.hpp"   // IWYU pragma: keep
 #include "chemfiles/external/optional.hpp"
 
@@ -25,7 +25,6 @@ class FormatMetadata;
 /// molfile plugins, please see:
 /// http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/
 enum MolfileFormat {
-    DCD,                ///< DCD binary file format
     TRJ,                ///< Gromacs .trj file format
     LAMMPS,             ///< LAMMPS trajectory files
     MOLDEN,             ///< Molden file format
@@ -86,7 +85,6 @@ private:
     std::vector<Frame> frames_;
 };
 
-template<> const FormatMetadata& format_metadata<Molfile<DCD>>();
 template<> const FormatMetadata& format_metadata<Molfile<TRJ>>();
 template<> const FormatMetadata& format_metadata<Molfile<LAMMPS>>();
 template<> const FormatMetadata& format_metadata<Molfile<MOLDEN>>();

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -1,45 +1,47 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
 
+#include <algorithm>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <functional>
 
 #include <fmt/ostream.h>
 
-#include "chemfiles/misc.hpp"
 #include "chemfiles/File.hpp"
 #include "chemfiles/FormatMetadata.hpp"
+#include "chemfiles/misc.hpp"
 
 #include "chemfiles/FormatFactory.hpp"
 
-#include "chemfiles/utils.hpp"
-#include "chemfiles/mutex.hpp"
+#include "chemfiles/config.h"
 #include "chemfiles/error_fmt.hpp"
-#include "chemfiles/string_view.hpp"
 #include "chemfiles/external/optional.hpp"
+#include "chemfiles/mutex.hpp"
+#include "chemfiles/string_view.hpp"
+#include "chemfiles/utils.hpp"
 
-#include "chemfiles/formats/Molfile.hpp"
 #include "chemfiles/formats/AmberNetCDF.hpp"
-#include "chemfiles/formats/LAMMPSData.hpp"
-#include "chemfiles/formats/Tinker.hpp"
-#include "chemfiles/formats/PDB.hpp"
-#include "chemfiles/formats/XYZ.hpp"
-#include "chemfiles/formats/SDF.hpp"
-#include "chemfiles/formats/TNG.hpp"
-#include "chemfiles/formats/MMTF.hpp"
-#include "chemfiles/formats/CSSR.hpp"
-#include "chemfiles/formats/GRO.hpp"
-#include "chemfiles/formats/MOL2.hpp"
-#include "chemfiles/formats/mmCIF.hpp"
-#include "chemfiles/formats/CML.hpp"
-#include "chemfiles/formats/SMI.hpp"
-#include "chemfiles/formats/TRR.hpp"
-#include "chemfiles/formats/XTC.hpp"
 #include "chemfiles/formats/CIF.hpp"
+#include "chemfiles/formats/CML.hpp"
+#include "chemfiles/formats/CSSR.hpp"
+#include "chemfiles/formats/DCD.hpp"
+#include "chemfiles/formats/GRO.hpp"
+#include "chemfiles/formats/LAMMPSData.hpp"
+#include "chemfiles/formats/MMTF.hpp"
+#include "chemfiles/formats/MOL2.hpp"
+#include "chemfiles/formats/Molfile.hpp"
+#include "chemfiles/formats/PDB.hpp"
+#include "chemfiles/formats/SDF.hpp"
+#include "chemfiles/formats/SMI.hpp"
+#include "chemfiles/formats/TNG.hpp"
+#include "chemfiles/formats/TRR.hpp"
+#include "chemfiles/formats/Tinker.hpp"
+#include "chemfiles/formats/XTC.hpp"
+#include "chemfiles/formats/XYZ.hpp"
+#include "chemfiles/formats/mmCIF.hpp"
 
 #define SENTINEL_INDEX (static_cast<size_t>(-1))
 
@@ -47,7 +49,6 @@ namespace chemfiles {
     class MemoryBuffer;
     class Format;
 
-    extern template class Molfile<DCD>;
     extern template class Molfile<TRJ>;
     extern template class Molfile<LAMMPS>;
     extern template class Molfile<MOLDEN>;
@@ -67,7 +68,7 @@ FormatFactory::FormatFactory() {
 #endif
     this->add_format<CMLFormat>();
     this->add_format<CSSRFormat>();
-    this->add_format<Molfile<DCD>>();
+    this->add_format<DCDFormat>();
     this->add_format<GROFormat>();
     this->add_format<Molfile<LAMMPS>>();
     this->add_format<LAMMPSDataFormat>();

--- a/src/files/DCDFile.cpp
+++ b/src/files/DCDFile.cpp
@@ -1,0 +1,457 @@
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <string>
+
+#include "chemfiles/File.hpp"
+#include "chemfiles/files/DCDFile.hpp"
+
+#include "chemfiles/error_fmt.hpp"
+
+using namespace std;
+using namespace chemfiles;
+
+DCDFile::DCDFile(std::string path, File::Mode mode)
+{
+   const char* openmode;
+   if (mode == File::READ) {
+      openmode = "r";
+      fileStream.exceptions(ifstream::failbit);
+      try
+      {
+         fileStream.open(path, ios::in | ios::binary);
+      }
+      catch (ifstream::failure& e)
+      {
+         cerr << "Exception opening/reading file '" << path << "' : " << endl;
+         cerr << "Please chech the path of the file and if it exists." << endl;
+      }
+      //Read dcd file header 
+      readHeader();
+   }
+   else if (mode == File::WRITE) {
+      openmode = "w";
+      fileStream.exceptions(ofstream::failbit);
+      try
+      {
+         fileStream.open(path, ios::app | ios::binary);
+      }
+      catch (ofstream::failure& e)
+      {
+         cerr << "Exception creating file '" << path << "' : " << endl;
+         cerr << "Couldn't create the file." << endl;
+      }
+
+   }
+}
+
+void DCDFile::readHeader()
+{
+   unsigned int fortcheck1, fortcheck2;
+   long initialPos = fileStream.tellg();
+   //This is the trick for reading binary data from fortran file, see the method checkFortranIOerror for more details.
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));               //consistency check 1
+   fileStream.read((char*)HDR, sizeof(char) * 4);                       //first data block written by fortran  : a character array of length 4.
+   fileStream.read((char*)ICNTRL, sizeof(int) * 20);                    //second data block written by fortran : an integer(4) array of length 20.
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));         //consistency check 2
+
+   // if the 2 unsigned ints have a different value there was an error
+   if (!checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2))
+   {
+      return;
+   }
+
+   HDR[4] = '\0';
+
+   if (ICNTRL[10])
+   {
+      pbc[0] = pbc[1] = pbc[2] = pbc[3] = pbc[4] = pbc[5] = 0.0;
+   }
+    
+   /* Several "lines" of title of length 80 are written to the dcd file by CHARMM */
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+   fileStream.read((char*)&NTITLE, sizeof(int));
+   if (NTITLE == 0)
+   {
+      TITLE = new char[80 + 1];
+      TITLE[0] = '\0';
+   }
+   else
+   {
+      TITLE = new char[NTITLE * 80 + 1];
+      for (int it = 0; it < NTITLE; it++)
+      {
+         fileStream.read((char*)&TITLE[it * 80], sizeof(char) * 80);
+      }
+      TITLE[NTITLE * 80] = '\0';
+   }
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+   if (!checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2))
+   {
+      return;
+   }
+
+   // reading number of atoms
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+   fileStream.read((char*)&numAtoms, sizeof(int));
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+   if (!checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2))
+   {
+      return;
+   }
+
+   /* If some atoms of the MD or MC simulation are frozen (i.e. never moving ) it is useless to store their coordinates more than once.
+    * In that case a list of Free atoms (moving ones) is written at the end of the header part of the dcd.
+    * See ReadDcd::read_firstFrame() for more details.
+    */
+   numFreeAtoms = numAtoms - ICNTRL[8];
+   if (numFreeAtoms != numAtoms)
+   {
+      freeAtoms = new int[numFreeAtoms];
+      fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+      fileStream.read((char*)freeAtoms, sizeof(int) * numFreeAtoms);
+      fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+      if (!checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2))
+      {
+         return;
+      }
+   }
+
+   headByteNum = std::abs(initialPos - fileStream.tellg());
+}
+
+void DCDFile::writeHeader()
+{
+   if (fileStream.is_open())
+   {
+      unsigned int icntrlBlockSize = (sizeof(char) * 4) + (sizeof(int) * 20);
+      fileStream.write((char*)&icntrlBlockSize, sizeof(unsigned int));
+      fileStream.write((char*)&HDR, sizeof(char) * 4);                //first data block written by fortran  : a character array of length 4.
+      fileStream.write((char*)ICNTRL, sizeof(int) * 20);                    //second data block written by fortran : an integer(4) array of length 20.
+      fileStream.write((char*)&icntrlBlockSize, sizeof(unsigned int));
+
+
+      /* Several "lines" of title of length 80 are written to the dcd file by CHARMM */
+      unsigned int titlesBlockSize = sizeof(int) + (NTITLE * 80) + 1;
+      fileStream.write((char*)&titlesBlockSize, sizeof(unsigned int));
+      fileStream.write((char*)&NTITLE, sizeof(int));
+      for (int it = 0; it < NTITLE; it++)
+      {
+         fileStream.write((char*)&TITLE[it * 80], sizeof(char) * 80);
+      }
+      TITLE[NTITLE * 80] = '\0';
+      fileStream.write((char*)&titlesBlockSize, sizeof(unsigned int));
+
+      // writing number of atoms
+      unsigned int atomsNumBlockSize = numAtoms * sizeof(int);
+      fileStream.write((char*)&atomsNumBlockSize, sizeof(unsigned int));
+      fileStream.write((char*)&numAtoms, sizeof(int));
+      fileStream.write((char*)&atomsNumBlockSize, sizeof(unsigned int));
+
+      /* If some atoms of the MD or MC simulation are frozen (i.e. never moving ) it is useless to store their coordinates more than once.
+       * In that case a list of Free atoms (moving ones) is written at the end of the header part of the dcd.
+       */
+      if (numFreeAtoms != numAtoms)
+      {
+         unsigned int freeAtomsBlockSize = numFreeAtoms * sizeof(int);
+         fileStream.write((char*)&freeAtomsBlockSize, sizeof(unsigned int));
+         fileStream.write((char*)freeAtoms, sizeof(int) * numFreeAtoms);
+         fileStream.write((char*)&freeAtomsBlockSize, sizeof(unsigned int));
+      }
+   }
+}
+
+void DCDFile::readFrame(std::vector<float>& X, std::vector<float>& Y,
+   std::vector<float>& Z, int toFrame)
+{
+   //dcd files store all the atoms in the first frame (even if there are some frozen atoms)
+   //and only store free atoms in the other frames
+   int frameAtmNum;
+   if (ICNTRL[8] != 0 && frameNumber != 0)
+   {
+      frameAtmNum = numAtoms - ICNTRL[8];
+   }
+   else
+   {
+      frameAtmNum = numAtoms;
+   }
+
+   X.reserve(frameAtmNum);
+   Y.reserve(frameAtmNum);
+   Z.reserve(frameAtmNum);
+
+   unsigned int fortcheck1, fortcheck2;
+
+   float* tmpX = new float[frameAtmNum];
+   float* tmpY = new float[frameAtmNum];
+   float* tmpZ = new float[frameAtmNum];
+
+   if (ICNTRL[10])
+   {
+      fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+      fileStream.read((char*)pbc, sizeof(double) * 6);
+      fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+      checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2);
+   }
+
+   // X
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+   fileStream.read((char*)tmpX, sizeof(float) * frameAtmNum);
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+   checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2);
+
+   // Y
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+   fileStream.read((char*)tmpY, sizeof(float) * frameAtmNum);
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+   checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2);
+
+   // Z
+   fileStream.read((char*)&fortcheck1, sizeof(unsigned int));
+   fileStream.read((char*)tmpZ, sizeof(float) * frameAtmNum);
+   fileStream.read((char*)&fortcheck2, sizeof(unsigned int));
+   checkFortranIOerror(__FILE__, __LINE__, fortcheck1, fortcheck2);
+
+   for (int it = 0; it < frameAtmNum; it++)
+   {
+      X.emplace_back(tmpX[it]);
+      Y.emplace_back(tmpY[it]);
+      Z.emplace_back(tmpZ[it]);
+   }
+
+   delete[] tmpX;
+   delete[] tmpY;
+   delete[] tmpZ;
+   frameNumber++;
+}
+
+void DCDFile::writeFrame(std::vector<float>& x, std::vector<float>& y,
+   std::vector<float>& z)
+{
+   if (fileStream.is_open())
+   {
+      assert((x.size() == y.size()) && (y.size() == z.size()));
+
+      float* tmpX = new float[x.size()];
+      float* tmpY = new float[y.size()];
+      float* tmpZ = new float[z.size()];
+
+      //fill tmp pointer
+      for (size_t coord = 0; coord < x.size(); coord++)
+      {
+         tmpX[coord] = x[coord];
+         tmpY[coord] = y[coord];
+         tmpZ[coord] = z[coord];
+      }
+
+      if (ICNTRL[10])
+      {
+         unsigned int blockSize = sizeof(double) * 6;
+         fileStream.write((char*)&blockSize, sizeof(unsigned int));
+         fileStream.write((char*)pbc, sizeof(double) * 6);
+         fileStream.write((char*)&blockSize, sizeof(unsigned int));
+      }
+
+      // X
+      unsigned int xCoorBlock = sizeof(float) * x.size();
+      fileStream.write((char*)&xCoorBlock, sizeof(unsigned int));
+      fileStream.write((char*)tmpX, sizeof(float) * x.size());
+      fileStream.write((char*)&xCoorBlock, sizeof(unsigned int));
+
+      // Y
+      unsigned int yCoorBlock = sizeof(float) * y.size();
+      fileStream.write((char*)&yCoorBlock, sizeof(unsigned int));
+      fileStream.write((char*)tmpY, sizeof(float) * y.size());
+      fileStream.write((char*)&yCoorBlock, sizeof(unsigned int));
+
+      // Z
+      unsigned int zCoorBlock = sizeof(float) * z.size();
+      fileStream.write((char*)&zCoorBlock, sizeof(unsigned int));
+      fileStream.write((char*)tmpZ, sizeof(float) * z.size());
+      fileStream.write((char*)&zCoorBlock, sizeof(unsigned int));
+
+      delete[] tmpX;
+      delete[] tmpY;
+      delete[] tmpZ;
+   }
+}
+
+void DCDFile::setHDR(std::string hdr)
+{
+   if (hdr.size() == 4)
+   {
+      char* hdrChar = const_cast<char*>(hdr.c_str());
+      for (size_t ch = 0; ch < hdr.size(); ch++)
+      {
+         HDR[ch] = hdrChar[ch];
+      }
+      HDR[4] = '\0';
+   }
+}
+
+void DCDFile::setProperties(std::vector<int>& properties) {
+   if (properties.size() == 20)
+   {
+      for (size_t prop = 0; prop < properties.size(); prop++)
+      {
+         ICNTRL[prop] = properties[prop];
+      }
+   }
+}
+
+int DCDFile::getNumFrames() const {
+   return ICNTRL[0];
+}
+
+bool DCDFile::hasCrystal() const
+{
+   if (ICNTRL[10])
+      return true;
+   return false;
+}
+
+const double* DCDFile::getPbc() const
+{
+   return pbc;
+}
+
+void DCDFile::setPbc(double* periodicBoundaryConditions)
+{
+   pbc[0] = periodicBoundaryConditions[0];
+   pbc[1] = periodicBoundaryConditions[1];
+   pbc[2] = periodicBoundaryConditions[2];
+   pbc[3] = periodicBoundaryConditions[3];
+   pbc[4] = periodicBoundaryConditions[4];
+   pbc[5] = periodicBoundaryConditions[5];
+}
+
+size_t DCDFile::getPos()
+{
+   return fileStream.tellg();
+}
+
+void DCDFile::setPos(size_t frameNum)
+{
+   long frameOffset;
+   if (frameNum != 0)
+   {
+      if (hasFrozenAtoms())
+         frameOffset = (frameNum - 1) * (((sizeof(unsigned int)) + (sizeof(float) * numFreeAtoms) + (sizeof(unsigned int))) * 3);
+      else
+         frameOffset = (frameNum - 1) * (((sizeof(unsigned int)) + (sizeof(float) * numAtoms) + (sizeof(unsigned int))) * 3);
+
+      if (hasCrystal())
+         frameOffset += (frameNum - 1) * ((sizeof(unsigned int)) + (sizeof(double) * 6) + (sizeof(unsigned int)));
+
+      fileStream.seekg(headByteNum + frameOffset);
+   }
+   else
+   {
+      fileStream.seekg(headByteNum);
+   }
+}
+
+bool DCDFile::hasFrozenAtoms()
+{
+   if (numAtoms != numFreeAtoms)
+      return true;
+   return false;
+}
+
+int DCDFile::getNumAtoms() const
+{
+   return numAtoms;
+}
+
+void DCDFile::setNumAtoms(size_t atomNum)
+{
+   numAtoms = atomNum;
+}
+
+int DCDFile::getNumFreeAtoms() const
+{
+   return numFreeAtoms;
+}
+
+void DCDFile::setNumFreeAtoms(int freeAtomsNum)
+{
+   numFreeAtoms = freeAtomsNum;
+}
+
+void DCDFile::setFreeAtoms(std::vector<int>& freeAtomsIndexes)
+{
+   assert(numFreeAtoms == freeAtomsIndexes.size());
+   freeAtoms = new int[numFreeAtoms];
+   for (size_t atmIdx = 0; atmIdx < freeAtomsIndexes.size(); atmIdx++)
+   {
+      freeAtoms[atmIdx] = freeAtomsIndexes[atmIdx];
+   }
+}
+
+bool DCDFile::hasPositions() const
+{
+   if (getNumAtoms() != 0)
+   {
+      return true;
+   }
+
+   return false;
+}
+
+int DCDFile::getNumTitles() {
+   return NTITLE;
+}
+
+void DCDFile::setNumTitles(int titlesNumber) {
+   NTITLE = titlesNumber;
+}
+
+char* DCDFile::getTitle()
+{
+   return TITLE;
+}
+
+void DCDFile::setTitle(std::string title)
+{
+   TITLE = new char[NTITLE * 80 + 1];
+   char* allTitle = const_cast<char*>(title.c_str());
+   for (size_t ch = 0; ch < title.size(); ch++)
+   {
+      TITLE[ch] = allTitle[ch];
+   }
+   TITLE[NTITLE * 80] = '\0';
+}
+
+/*
+ * When writing a block of binary data to a file, Fortran adds 2 unsigned integer before and after the block : each one contains the total number of bytes of the block.
+ *
+ * For example for a fortran array of real(8) of size 10, 80 bytes of a data have to be written : so 3 things are written to the binary file :
+ *  1) An unsigned integer (4 bytes) , its value is 80
+ *  2) The fortran array (80 bytes)
+ *  3) A second unsigned integer (4 bytes), same value of 80.
+ * This corresponds to the fortran statement "write(file_descriptor) fortran_array"
+ *
+ * Now when writing several things at the same tine, i.e. "write(file_descriptor) fortran_array,an_integer"
+ * things are written as following:
+ * 1) unsigned int size
+ * 2) fortran array
+ * 3) an_integer
+ * 4) unsigned int size
+ * The value of the 2 unsigned ints is 84 : 80 for the array, 4 for the integer(4).
+ *
+ * The following method checkFortranIOerror check that the 2 unsigned ints have the same value: if not there was a probem when reading the binary fortran file.
+ */
+bool DCDFile::checkFortranIOerror(const char file[], const int line, const size_t fortcheck1, const size_t fortcheck2) const
+{
+   if (fortcheck1 != fortcheck2)
+   {
+      cout << "Error when reading data from dcd : quantities do not match." << endl;
+      cout << "fortcheck1 = " << fortcheck1 << " and fortcheck2 = " << fortcheck2 << endl;
+      cout << "in File " << file << " at Line " << line << endl;
+      return false;
+   }
+   return true;
+}

--- a/src/formats/DCD.cpp
+++ b/src/formats/DCD.cpp
@@ -1,0 +1,236 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "chemfiles/error_fmt.hpp"
+#include "chemfiles/external/optional.hpp"
+#include "chemfiles/parse.hpp"
+#include "chemfiles/string_view.hpp"
+#include "chemfiles/types.hpp"
+#include "chemfiles/utils.hpp"
+#include "chemfiles/warnings.hpp"
+
+#include "chemfiles/Atom.hpp"
+#include "chemfiles/File.hpp"
+#include "chemfiles/FormatMetadata.hpp"
+#include "chemfiles/Frame.hpp"
+#include "chemfiles/Property.hpp"
+#include "chemfiles/Residue.hpp"
+#include "chemfiles/Topology.hpp"
+#include "chemfiles/UnitCell.hpp"
+
+#include "chemfiles/files/DCDFile.hpp"
+#include "chemfiles/formats/DCD.hpp"
+
+using namespace chemfiles;
+ 
+template<> const FormatMetadata& chemfiles::format_metadata<DCDFormat>() {
+   static FormatMetadata metadata;
+   metadata.name = "DCD";
+   metadata.extension = ".dcd";
+   metadata.description = "DCD () single precision binary FORTRAN format";
+   metadata.reference = "";
+
+   metadata.read = true;
+   metadata.write = true;
+   metadata.memory = true;
+
+   metadata.positions = true;
+   metadata.velocities = true;
+   metadata.unit_cell = true;
+   metadata.atoms = true;
+   metadata.bonds = false;
+   metadata.residues = true;
+   return metadata;
+}
+
+static void set_positions(const std::vector<float>& x, const std::vector<float>& y,
+   const std::vector<float>& z, Frame& frame);
+static void get_positions(std::vector<float>& x, std::vector<float>& y,
+   std::vector<float>& z, const Frame& frame);
+static void set_cell(matrix box, Frame& frame);
+static void get_cell(matrix box, const Frame& frame);
+
+DCDFormat::DCDFormat(std::string path, File::Mode mode, File::Compression compression) {
+   if (compression != File::DEFAULT)
+      throw format_error("DCD format does not support compression");
+
+   file_ = new DCDFile(path, mode);
+}
+
+void DCDFormat::read_step(size_t frameNum, Frame& frame)
+{
+   assert(frameNum < file_->getNumFrames());
+   file_->setPos(frameNum);
+   step_ = frameNum;
+   read(frame);
+}
+
+void DCDFormat::read(Frame& frame)
+{
+   int natoms = file_->getNumAtoms();
+   int md_step = step_;
+   matrix box;
+
+   std::vector<float> x;
+   std::vector<float> y;
+   std::vector<float> z;
+
+   file_->readFrame(x, y, z);
+   bool has_box = file_->hasCrystal();
+   bool has_positions = file_->hasPositions();
+
+   frame.set_step(static_cast<size_t>(md_step));         // actual step of MD Simulation
+   frame.resize(static_cast<size_t>(natoms));
+
+   if (has_box) {
+      box[0][1] = file_->getPbc()[0];
+      box[0][2] = file_->getPbc()[1];
+      box[0][3] = file_->getPbc()[2];
+      box[1][1] = file_->getPbc()[3];
+      box[1][2] = file_->getPbc()[4];
+      box[1][3] = file_->getPbc()[5];
+      set_cell(box, frame);
+   }
+   if (has_positions) {
+      frame.set("has_positions", true);
+      set_positions(x, y, z, frame);
+   }
+
+   step_++;
+}
+
+void DCDFormat::write(const Frame& frame) {
+   int natoms = frame.size();
+
+   int md_step = static_cast<int>(frame.step());
+   float lambda = static_cast<float>(frame.get("trr_lambda").value_or(0.0).as_double());
+
+   matrix box;
+   std::vector<float> x;
+   std::vector<float> y;
+   std::vector<float> z;
+   bool has_box = frame.cell().shape() != UnitCell::INFINITE;
+   if (has_box) {
+      get_cell(box, frame);
+   }
+   if (frame.get("has_positions").value_or(true).as_bool()) {
+      x.resize(natoms);
+      y.resize(natoms);
+      z.resize(natoms);
+      get_positions(x, y, z, frame);
+   }
+
+   //write DCD header only at the begining of the trajectory
+   if (step_ == 0)
+   {
+      //only coordinates DCD files are handled for now (velocities will be done later) 
+      std::string type = "CORD";
+      std::vector<int> properties(20, 0);
+      properties[0] = static_cast<int>(frame.get("frames_number").value_or(0).as_double());
+      properties[1] = static_cast<int>(frame.get("frames_number_before_start").value_or(0).as_double());
+      properties[2] = static_cast<int>(frame.get("writing_frequency").value_or(0).as_double());
+      properties[3] = static_cast<int>(frame.get("steps_number").value_or(0).as_double());
+      properties[7] = static_cast<int>(frame.get("dof_number").value_or(0).as_double());
+      properties[8] = static_cast<int>(frame.get("frozen_atoms").value_or(0).as_double());
+      properties[9] = static_cast<int>(frame.get("AKMA_timestep").value_or(0).as_double());
+      properties[10] = static_cast<int>(frame.get("crystal").value_or(0).as_double());
+      properties[19] = static_cast<int>(frame.get("charmm_version").value_or(0).as_double());
+      file_->setProperties(properties);
+      file_->setHDR(type);
+      file_->setNumTitles(1);
+      file_->setTitle(frame.get("title").value_or(" ").as_string());
+      file_->setNumAtoms(frame.size());
+      file_->setNumFreeAtoms(frame.size() - properties[8]);
+      if (properties[8] != 0)
+      {
+         //TODO: if frozen atoms are present in the trajectory, export only the free atoms
+         //in the all the trajectory frames except for the first frame (where frozen and free atoms are exported) 
+         //file_->setFreeAtoms();
+      }
+      file_->writeHeader();
+   }
+
+   file_->writeFrame(x, y, z);
+
+   step_++;
+}
+
+void set_positions(const std::vector<float>& x, const std::vector<float>& y,
+   const std::vector<float>& z, Frame& frame) {
+   auto positions = frame.positions();
+   assert(x.size() == positions.size());
+   assert(y.size() == positions.size());
+   assert(z.size() == positions.size());
+
+   for (size_t i = 0; i < frame.size(); i++) {
+      positions[i][0] = static_cast<double>(x[i]);
+      positions[i][1] = static_cast<double>(y[i]);
+      positions[i][2] = static_cast<double>(z[i]);
+   }
+}
+
+void get_positions(std::vector<float>& x, std::vector<float>& y,
+   std::vector<float>& z, const Frame& frame) {
+   auto positions = frame.positions();
+   assert(x.size() == positions.size());
+   assert(y.size() == positions.size());
+   assert(z.size() == positions.size());
+
+   for (size_t i = 0; i < frame.size(); i++) {
+      x[i] = static_cast<float>(positions[i][0]);
+      y[i] = static_cast<float>(positions[i][1]);
+      z[i] = static_cast<float>(positions[i][2]);
+   }
+}
+
+void set_cell(matrix box, Frame& frame) {
+   auto a = Vector3D(static_cast<double>(box[0][0]), static_cast<double>(box[0][1]),
+      static_cast<double>(box[0][2]));
+   auto b = Vector3D(static_cast<double>(box[1][0]), static_cast<double>(box[1][1]),
+      static_cast<double>(box[1][2]));
+   auto c = Vector3D(static_cast<double>(box[2][0]), static_cast<double>(box[2][1]),
+      static_cast<double>(box[2][2]));
+
+   auto angle = [](const Vector3D& u, const Vector3D& v) {
+      constexpr double PI = 3.141592653589793238463;
+      auto cos = dot(u, v) / (u.norm() * v.norm());
+      cos = std::max(-1., std::min(1., cos));
+      return acos(cos) * 180.0 / PI;
+   };
+
+   double alpha = angle(b, c);
+   double beta = angle(a, c);
+   double gamma = angle(a, b);
+
+   auto matrix = Matrix3D(
+      static_cast<double>(box[0][0]), static_cast<double>(box[1][0]), static_cast<double>(alpha),
+      static_cast<double>(box[0][1]), static_cast<double>(box[1][1]), static_cast<double>(beta),
+      static_cast<double>(box[0][2]), static_cast<double>(box[1][2]), static_cast<double>(gamma)
+   );
+   frame.set_cell(UnitCell(matrix));
+}
+
+void get_cell(matrix box, const Frame& frame) {
+   auto matrix = frame.cell().matrix();
+   box[0][0] = static_cast<float>(matrix[0][0]);
+   box[0][1] = static_cast<float>(matrix[1][0]);
+   box[0][2] = static_cast<float>(matrix[2][0]);
+   box[1][0] = static_cast<float>(matrix[0][1]);
+   box[1][1] = static_cast<float>(matrix[1][1]);
+   box[1][2] = static_cast<float>(matrix[2][1]);
+   box[2][0] = static_cast<float>(matrix[0][2]);
+   box[2][1] = static_cast<float>(matrix[1][2]);
+   box[2][2] = static_cast<float>(matrix[2][2]);
+}
+
+size_t DCDFormat::nsteps()
+{
+   return file_->getNumFrames();
+}
+

--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -3,29 +3,29 @@
 #define VMDCON_ERROR     3
 
 extern "C" {
-    #include <vmdplugin.h>
     #include <molfile_plugin.h>
+    #include <vmdplugin.h>
 }
 
+#include <array>
 #include <cassert>
 #include <cstdint>
-#include <array>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
+#include "chemfiles/error_fmt.hpp"
+#include "chemfiles/external/optional.hpp"
+#include "chemfiles/external/span.hpp"
 #include "chemfiles/types.hpp"
 #include "chemfiles/warnings.hpp"
-#include "chemfiles/error_fmt.hpp"
-#include "chemfiles/external/span.hpp"
-#include "chemfiles/external/optional.hpp"
 
-#include "chemfiles/File.hpp"
 #include "chemfiles/Atom.hpp"
+#include "chemfiles/File.hpp"
+#include "chemfiles/FormatMetadata.hpp"
 #include "chemfiles/Frame.hpp"
 #include "chemfiles/Residue.hpp"
 #include "chemfiles/Topology.hpp"
-#include "chemfiles/FormatMetadata.hpp"
 
 #include "chemfiles/formats/Molfile.hpp"
 
@@ -49,7 +49,6 @@ using namespace chemfiles;
     }
 
 namespace chemfiles {
-    PLUGINS_DATA(DCD,               dcdplugin,          dcd,            false);
     PLUGINS_DATA(TRJ,               gromacsplugin,      trj,            false);
     PLUGINS_DATA(LAMMPS,            lammpsplugin,       lammpstrj,      true);
     PLUGINS_DATA(MOLDEN,            moldenplugin,       molden,         false);
@@ -323,30 +322,9 @@ template <MolfileFormat F> void Molfile<F>::read_topology() {
 }
 
 // Instantiate all the templates
-template class chemfiles::Molfile<DCD>;
 template class chemfiles::Molfile<TRJ>;
 template class chemfiles::Molfile<LAMMPS>;
 template class chemfiles::Molfile<MOLDEN>;
-
-template<> const FormatMetadata& chemfiles::format_metadata<Molfile<DCD>>() {
-    static FormatMetadata metadata;
-    metadata.name = "DCD";
-    metadata.extension = ".dcd";
-    metadata.description = "DCD binary format";
-    metadata.reference = "http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/dcdplugin.html";
-
-    metadata.read = true;
-    metadata.write = false;
-    metadata.memory = false;
-
-    metadata.positions = true;
-    metadata.velocities = false;
-    metadata.unit_cell = false;
-    metadata.atoms = false;
-    metadata.bonds = false;
-    metadata.residues = false;
-    return metadata;
-}
 
 template<> const FormatMetadata& chemfiles::format_metadata<Molfile<TRJ>>() {
     static FormatMetadata metadata;


### PR DESCRIPTION
Added a DCD importer/exporter and removed the use of the DCD VMD plugin. This implementation should also address the limitations pointed out in #370 when using the VMD plugin for reading DCD trajectories.