### PR TITLE
Add a guess_format function returning the format we would use for a given filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - properties are now sorted, and iterating over properties will always yield
   them sorted by the associated key.
+- added `chemfiles::guess_format` and `chfl_guess_format` to get the format
+  chemfiles would use for a given file based on its filename
 
 ### Changes in supported formats
 

--- a/doc/src/capi/misc.rst
+++ b/doc/src/capi/misc.rst
@@ -17,6 +17,8 @@ chemfiles types); all the functions return a status code from the
 Format list and Metadata
 ------------------------
 
+.. doxygenfunction:: chfl_guess_format
+
 .. doxygenfunction:: chfl_formats_list
 
 .. doxygenstruct:: chfl_format_metadata

--- a/doc/src/classes/misc.rst
+++ b/doc/src/classes/misc.rst
@@ -17,6 +17,8 @@ Basic types
 Format list and Metadata
 ------------------------
 
+.. doxygenfunction:: chemfiles::guess_format
+
 .. doxygenfunction:: chemfiles::formats_list
 
 .. doxygenclass:: chemfiles::FormatMetadata

--- a/doc/src/classes/misc.rst
+++ b/doc/src/classes/misc.rst
@@ -70,9 +70,6 @@ nicely with any existing C++ error handling.
 .. doxygenstruct:: chemfiles::SelectionError
     :members:
 
-.. doxygenstruct:: chemfiles::ConfigurationError
-    :members:
-
 .. doxygenstruct:: chemfiles::OutOfBounds
     :members:
 

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -68,8 +68,6 @@ public:
     /// Get the atom mass.
     ///
     /// The default mass is set when constructing the atom from the atomic type.
-    /// To change the default value for a given type, you can use configuration
-    /// files.
     ///
     /// @example{atom/mass.cpp}
     double mass() const { return mass_; }
@@ -77,8 +75,7 @@ public:
     /// Get the atom charge.
     ///
     /// The default charge is set when constructing the atom from the atomic
-    /// type (usually to 0). To change the default value for a given type, you
-    /// can use configuration files.
+    /// type (usually to 0).
     ///
     /// @example{atom/charge.cpp}
     double charge() const { return charge_; }
@@ -109,8 +106,7 @@ public:
     /// atom type: for example, the full name for `He` is `"Helium"`. If no name
     /// can be found, this function returns `nullopt`. This check is executed
     /// with case-insensitive atom type: `Na`, `NA`, `nA` and `na` all get the
-    /// `Na` full name. To change the value returned for a given type, you can
-    /// use configuration files.
+    /// `Na` full name.
     ///
     /// @example{atom/full_name.cpp}
     optional<std::string> full_name() const;
@@ -121,8 +117,7 @@ public:
     /// current atom type: for example, the radius for `He` is 1.4 A. If no
     /// radius can be found, this function returns `nullopt`. This check is
     /// executed with case-insensitive atom type: `Na`, `NA`, `nA` and `na` all
-    /// get the `Na` radius. To change the value returned for a given type, you
-    /// can use configuration files.
+    /// get the `Na` radius.
     ///
     /// @example{atom/vdw_radius.cpp}
     optional<double> vdw_radius() const;
@@ -133,8 +128,7 @@ public:
     /// current atom type: for example, the radius for `He` is 0.32 A. If no
     /// radius can be found, this function returns `nullopt`. This check is
     /// executed with case-insensitive atom type: `Na`, `NA`, `nA` and `na` all
-    /// get the `Na` radius. To change the value returned for a given type, you
-    /// can use configuration files.
+    /// get the `Na` radius.
     ///
     /// @example{atom/covalent_radius.cpp}
     optional<double> covalent_radius() const;
@@ -145,8 +139,7 @@ public:
     /// current atom type: for example, the atomic number for `He` is 2. If no
     /// atomic number can be found, this function returns `nullopt`. This check
     /// is executed with case-insensitive atom type: `Na`, `NA`, `nA` and `na`
-    /// all get the `Na` atomic number. To change the value returned for a given
-    /// type, you can use configuration files.
+    /// all get the `Na` atomic number.
     ///
     /// @example{atom/atomic_number.cpp}
     optional<uint64_t> atomic_number() const;

--- a/include/chemfiles/Error.hpp
+++ b/include/chemfiles/Error.hpp
@@ -35,11 +35,6 @@ struct CHFL_EXPORT SelectionError: public Error {
     SelectionError(const std::string& err): Error(err) {}
 };
 
-/// Exception for errors in configuration files
-struct CHFL_EXPORT ConfigurationError: public Error {
-    ConfigurationError(const std::string& err): Error(err) {}
-};
-
 /// Exception for out of bounds error when accessing atoms or residues
 struct CHFL_EXPORT OutOfBounds: public Error {
     OutOfBounds(const std::string& err): Error(err) {}

--- a/include/chemfiles/FormatFactory.hpp
+++ b/include/chemfiles/FormatFactory.hpp
@@ -41,24 +41,17 @@ public:
     /// Get the instance of the `FormatFactory`
     static FormatFactory& get();
 
-    /// Get a `format_creator_t` from a format name.
+    /// Get a `RegisteredFormat` from a format name.
     ///
     /// @param name the format name
     /// @throws FormatError if the format can not be found
-    format_creator_t name(const std::string& name);
+    const RegisteredFormat& by_name(const std::string& name);
 
-    /// Get a `memory_stream_t` from a format name.
-    ///
-    /// @param name the format name
-    /// @throws FormatError if the format can not be found or does not support
-    ///                     reading / writing from memory
-    memory_stream_t memory_stream(const std::string& name);
-
-    /// Get a `format_creator_t` from a format extention.
+    /// Get a `RegisteredFormat` from a format extention.
     ///
     /// @param extension the format extention
     /// @throws FormatError if the format can not be found
-    format_creator_t extension(const std::string& extension);
+    const RegisteredFormat& by_extension(const std::string& extension);
 
     /// Register a given `Format` in the factory if it supports memory IO
     ///

--- a/include/chemfiles/Frame.hpp
+++ b/include/chemfiles/Frame.hpp
@@ -209,9 +209,7 @@ public:
     ///
     /// The bonds are guessed using a distance-based algorithm, and then angles,
     /// dihedrals and impropers are guessed from the bonds. The distance
-    /// criterion uses the Van der Waals radii of the atoms. If this
-    /// information is missing for a specific atoms, one can use configuration
-    /// files to provide it.
+    /// criterion uses the Van der Waals radii of the atoms.
     ///
     /// @throw Error if the Van der Waals radius in unknown for a given atom.
     ///

--- a/include/chemfiles/Trajectory.hpp
+++ b/include/chemfiles/Trajectory.hpp
@@ -24,25 +24,24 @@ class CHFL_EXPORT Trajectory final {
 public:
     /// Open a file, automatically gessing the file format from the extension.
     ///
-    /// The `format` parameter should be a string formatted as `"<format>"`,
-    /// `"<format>/<compression>"` or `"/<compression>"`. `<format>` should be
-    /// the format name (see the corresponding [documentation section][formats]
-    /// for the names) or an empty string. `<compression>` should be `GZ` for
-    /// gzip files, `BZ2` for bzip2 files, or `XZ` for lzma/.xz files. If
-    /// `<compression>` is present, it will determine which compression method
-    /// is used to read/write the file.
+    /// The `format` parameter should be a string formatted as `"<format>"` or
+    /// `"<format>/<compression>"`. `<format>` should be the format name (see
+    /// the corresponding [documentation section][formats] for the names) or an
+    /// empty string. `<compression>` should be `GZ` for gzip files, `BZ2` for
+    /// bzip2 files, or `XZ` for lzma/.xz files. If `<compression>` is present,
+    /// it will determine which compression method is used to read/write the
+    /// file.
     ///
     /// For example, `format = "XYZ"` will force usage of XYZ format regardless
     /// of the file extension; `format = "XYZ / GZ"` will additionally use gzip
-    /// compression; and ` format = "/ GZ"` will use the gzip compression, and
-    /// the file extension to guess the format.
+    /// compression.
     ///
-    /// If the `format` is an empty string, the file extension will be used
-    /// to guess the format. If `<compression>` is NOT present and the file path
-    /// ends with `.gz`, `.xz`, or `.bz2`; the file will be treated as a
-    /// compressed file and the next extension is used to guess the format. For
-    /// example `Trajectory("file.xyz.gz")` will open the file for reading
-    /// using the XYZ format and the gzip compression method.
+    /// If the `format` is an empty string, the file extension will be used to
+    /// guess the format. If the file path ends with `.gz`, `.xz`, or `.bz2`;
+    /// the file will be treated as a compressed file and the next extension is
+    /// used to guess the format. For example `Trajectory("file.xyz.gz")` will
+    /// open the file for reading using the XYZ format and the gzip compression
+    /// method.
     ///
     /// @example{trajectory/trajectory.cpp}
     ///

--- a/include/chemfiles/capi/misc.h
+++ b/include/chemfiles/capi/misc.h
@@ -54,6 +54,28 @@ CHFL_EXPORT chfl_status chfl_set_warning_callback(chfl_warning_callback callback
 ///         about the error if the status code is not `CHFL_SUCCESS`.
 CHFL_EXPORT chfl_status chfl_formats_list(chfl_format_metadata** metadata, uint64_t* count);
 
+/// Get the format that chemfiles would use to read a file at the given `path`
+/// in the string buffer `format`.
+///
+/// The buffer size must be passed in `buffsize`. This function will return
+/// `CHFL_MEMORY_ERROR` if the format does not fit in the buffer.
+///
+/// The format is only guessed from the filename extension, chemfiles does not
+/// currently read the file to guess the format. Opening the file using the
+/// returned format string might still fail. For example, it will fail if the
+/// file is not actually formatted according to the guessed format; or the
+/// format/compression combination is not supported (e.g. `XTC / GZ` will not
+/// work since the XTC reader does not support compressed files).
+///
+/// The format is represented in a way compatible with the various `Trajectory`
+/// constructors, i.e. `"<format name> [/ <compression>]"`, where compression is
+/// optional.
+///
+/// @example{capi/chfl_guess_format.c}
+/// @return The operation status code. You can use `chfl_last_error` to learn
+///         about the error if the status code is not `CHFL_SUCCESS`.
+CHFL_EXPORT chfl_status chfl_guess_format(const char* path, char* format, uint64_t buffsize);
+
 /// Free the memory associated with a chemfiles object.
 ///
 /// This function is NOT equivalent to the standard C function `free`, as memory

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -128,8 +128,7 @@ typedef enum {  // NOLINT: this is both a C and C++ file
     CHFL_FORMAT_ERROR = 3,
     /// Status code for invalid selection strings.
     CHFL_SELECTION_ERROR = 4,
-    /// Status code for configuration files errors.
-    CHFL_CONFIGURATION_ERROR = 5,
+    /* error code 5 used to be CHFL_CONFIGURATION_ERROR */
     /// Status code for out of bounds errors.
     CHFL_OUT_OF_BOUNDS = 6,
     /// Status code for errors related to properties.

--- a/include/chemfiles/capi/utils.hpp
+++ b/include/chemfiles/capi/utils.hpp
@@ -77,7 +77,6 @@ inline Vector3D vector3d(const chfl_vector3d vector) {
     CATCH_AND_RETURN(MemoryError, CHFL_MEMORY_ERROR)                           \
     CATCH_AND_RETURN(FormatError, CHFL_FORMAT_ERROR)                           \
     CATCH_AND_RETURN(SelectionError, CHFL_SELECTION_ERROR)                     \
-    CATCH_AND_RETURN(ConfigurationError, CHFL_CONFIGURATION_ERROR)             \
     CATCH_AND_RETURN(OutOfBounds, CHFL_OUT_OF_BOUNDS)                          \
     CATCH_AND_RETURN(PropertyError, CHFL_PROPERTY_ERROR)                       \
     CATCH_AND_RETURN(Error, CHFL_GENERIC_ERROR)                                \

--- a/include/chemfiles/error_fmt.hpp
+++ b/include/chemfiles/error_fmt.hpp
@@ -46,12 +46,6 @@ inline SelectionError selection_error(const char *format, Args && ... arguments)
     return SelectionError(fmt::format(format, std::forward<Args>(arguments)...));
 }
 
-/// Create a `ConfigurationError` using the given `format` and `arguments`.
-template <typename... Args>
-inline ConfigurationError configuration_error(const char *format, Args && ... arguments) {
-    return ConfigurationError(fmt::format(format, std::forward<Args>(arguments)...));
-}
-
 /// Create an `OutOfBounds` error using the given `format` and `arguments`.
 template <typename... Args>
 inline OutOfBounds out_of_bounds(const char *format, Args && ... arguments) {

--- a/include/chemfiles/misc.hpp
+++ b/include/chemfiles/misc.hpp
@@ -27,25 +27,6 @@ typedef std::function<void(const std::string& message)> warning_callback_t; // N
 /// @param callback callback function that will be called on each warning
 void CHFL_EXPORT set_warning_callback(warning_callback_t callback);
 
-/// Read configuration data from the file at `path`.
-///
-/// By default, chemfiles reads configuration from any file named
-/// `.chemfiles.toml` or `chemfiles.toml` in the current directory or any parent
-/// directory. This function can be used to add data from another configuration
-/// file.
-///
-/// This function will throw a `ConfigurationError` if there is no file at
-/// `path`, or if the file is incorrectly formatted. Data from the new
-/// configuration file will overwrite any existing data.
-///
-/// @example{add_configuration.cpp}
-///
-/// @param path path to the configuration file to add
-///
-/// @throws ConfigurationError if the file at `path` can not be read, or if it
-///                            is invalid.
-void CHFL_EXPORT add_configuration(const std::string& path);
-
 /// Get the list of formats chemfiles knows about, and all associated metadata
 ///
 /// @example{formats_list.cpp}

--- a/include/chemfiles/misc.hpp
+++ b/include/chemfiles/misc.hpp
@@ -32,6 +32,26 @@ void CHFL_EXPORT set_warning_callback(warning_callback_t callback);
 /// @example{formats_list.cpp}
 std::vector<std::reference_wrapper<const FormatMetadata>> CHFL_EXPORT formats_list();
 
+/// Get the format that chemfiles would use to read a file at the given path.
+///
+/// The format is only guessed from the filename extension, chemfiles does not
+/// currently read the file to guess the format. Opening the file using the
+/// returned format string might still fail. For example, it will fail if the
+/// file is not actually formatted according to the guessed format; or the
+/// format/compression combination is not supported (e.g. `XTC / GZ` will not
+/// work since the XTC reader does not support compressed files).
+///
+/// The format is represented in a way compatible with the various `Trajectory`
+/// constructors, i.e. `"<format name> [/ <compression>]"`, where compression is
+/// optional.
+///
+/// @param path path of the file we are trying to read
+/// @return guessed format of the file
+/// @throw FormatError if no format matching this filename is found.
+///
+/// @example{guess_format.cpp}
+std::string CHFL_EXPORT guess_format(std::string path);
+
 } // namespace chemfiles
 
 #endif

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -124,7 +124,7 @@ void FormatFactory::register_format(const FormatMetadata& metadata, format_creat
     );
 }
 
-format_creator_t FormatFactory::name(const std::string& name) {
+const RegisteredFormat& FormatFactory::by_name(const std::string& name) {
     auto guard = formats_.lock();
     auto& formats = *guard;
 
@@ -133,23 +133,10 @@ format_creator_t FormatFactory::name(const std::string& name) {
         auto suggestions = suggest_names(formats, name);
         throw FormatError(suggestions);
     }
-    return formats.at(idx).creator;
+    return formats.at(idx);
 }
 
-memory_stream_t FormatFactory::memory_stream(const std::string& name) {
-    auto guard = formats_.lock();
-    auto& formats = *guard;
-
-    auto idx = find_by_name(formats, name);
-    if (idx == SENTINEL_INDEX) {
-        auto suggestions = suggest_names(formats, name);
-        throw FormatError(suggestions);
-    }
-
-    return formats.at(idx).memory_stream_creator;
-}
-
-format_creator_t FormatFactory::extension(const std::string& extension) {
+const RegisteredFormat& FormatFactory::by_extension(const std::string& extension) {
     auto guard = formats_.lock();
     auto& formats = *guard;
 
@@ -159,7 +146,7 @@ format_creator_t FormatFactory::extension(const std::string& extension) {
             "can not find a format associated with the '{}' extension", extension
         );
     }
-    return formats.at(idx).creator;
+    return formats.at(idx);
 }
 
 std::vector<std::reference_wrapper<const FormatMetadata>> FormatFactory::formats() {

--- a/src/Trajectory.cpp
+++ b/src/Trajectory.cpp
@@ -106,9 +106,9 @@ Trajectory::Trajectory(std::string path, char mode, const std::string& format)
     auto info = file_open_info::parse(path_, format);
     format_creator_t format_creator;
     if (!info.format.empty()) {
-        format_creator = FormatFactory::get().name(info.format);
+        format_creator = FormatFactory::get().by_name(info.format).creator;
     } else if (!info.extension.empty()) {
-        format_creator = FormatFactory::get().extension(info.extension);
+        format_creator = FormatFactory::get().by_extension(info.extension).creator;
     } else {
         throw file_error(
             "file at '{}' does not have an extension, provide a format name to read it",
@@ -131,11 +131,12 @@ Trajectory Trajectory::memory_reader(const char* data, size_t size, const std::s
         throw format_error("format name '{}' is invalid", format);
     }
 
-    auto memory_creator = FormatFactory::get().memory_stream(info.format);
+    auto memory_creator = FormatFactory::get().by_name(info.format).memory_stream_creator;
     auto buffer = std::make_shared<MemoryBuffer>(data, size);
-    auto creator = memory_creator(buffer, File::READ, info.compression);
+    // if in-memory I/O is not supported, this call will throw
+    auto format_impl = memory_creator(buffer, File::READ, info.compression);
 
-    return Trajectory('r', std::move(creator), std::move(buffer));
+    return Trajectory('r', std::move(format_impl), std::move(buffer));
 }
 
 Trajectory Trajectory::memory_writer(const std::string& format) {
@@ -145,12 +146,12 @@ Trajectory Trajectory::memory_writer(const std::string& format) {
         throw format_error("format name '{}' is invalid", format);
     }
 
-    auto memory_creator = FormatFactory::get().memory_stream(info.format);
+    auto memory_creator = FormatFactory::get().by_name(info.format).memory_stream_creator;
     auto buffer = std::make_shared<MemoryBuffer>(8192);
+    // if in-memory I/O is not supported, this call will throw
+    auto format_impl = memory_creator(buffer, File::WRITE, info.compression);
 
-    auto format_ = memory_creator(buffer, File::WRITE, info.compression);
-
-    return Trajectory('w', std::move(format_), std::move(buffer));
+    return Trajectory('w', std::move(format_impl), std::move(buffer));
 }
 
 Trajectory::Trajectory(char mode, std::unique_ptr<Format> format, std::shared_ptr<MemoryBuffer> buffer)

--- a/src/Trajectory.cpp
+++ b/src/Trajectory.cpp
@@ -15,8 +15,10 @@
 #include "chemfiles/UnitCell.hpp"
 #include "chemfiles/Topology.hpp"
 #include "chemfiles/FormatFactory.hpp"
+#include "chemfiles/FormatMetadata.hpp"
 #include "chemfiles/files/MemoryBuffer.hpp"
 
+#include "chemfiles/misc.hpp"
 #include "chemfiles/utils.hpp"
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/string_view.hpp"
@@ -27,15 +29,64 @@ using namespace chemfiles;
 
 #define SENTINEL_VALUE (static_cast<size_t>(-1))
 
+std::string chemfiles::guess_format(std::string path) {
+    std::string extension;
+    std::string compression;
+
+    auto dot1 = path.rfind('.');
+    if (dot1 != std::string::npos) {
+        extension = path.substr(dot1);
+        bool new_extension = false;
+        // check file extension for compressed file extension
+        if (extension == ".gz") {
+            new_extension = true;
+            compression = "GZ";
+        } else if (extension == ".bz2") {
+            new_extension = true;
+            compression = "BZ2";
+        } else if (extension == ".xz") {
+            new_extension = true;
+            compression = "XZ";
+        }
+
+        if (new_extension) {
+            extension = "";
+            auto dot2 = path.substr(0, dot1).rfind('.');
+            if (dot2 != std::string::npos) {
+                extension = path.substr(0, dot1).substr(dot2);
+            }
+        }
+    }
+
+    if (extension.empty()) {
+        throw file_error(
+            "file at '{}' does not have an extension, provide a format name to read it",
+            path
+        );
+    }
+
+    auto registered_format = FormatFactory::get().by_extension(extension);
+    auto format = std::string(registered_format.metadata.name);
+
+    if (!compression.empty()) {
+        format += " / " + compression;
+    }
+
+    return format;
+}
+
 struct file_open_info {
-    static file_open_info parse(const std::string& path, const std::string& format);
+    static file_open_info parse(const std::string& path, std::string format);
     std::string format = "";
-    std::string extension = "";
     File::Compression compression = File::DEFAULT;
 };
 
-file_open_info file_open_info::parse(const std::string& path, const std::string& format) {
+file_open_info file_open_info::parse(const std::string& path, std::string format) {
     file_open_info info;
+
+    if (format.empty()) {
+        format = guess_format(path);
+    }
 
     auto slash = format.find('/');
     if (slash != std::string::npos) {
@@ -54,32 +105,6 @@ file_open_info file_open_info::parse(const std::string& path, const std::string&
 
     auto tmp = format.substr(0, slash);
     info.format = trim(tmp).to_string();
-
-    auto dot1 = path.rfind('.');
-    if (dot1 != std::string::npos) {
-        info.extension = path.substr(dot1);
-        if (info.compression == File::DEFAULT) {
-            bool new_extension = false;
-            // check file extension for compressed file extension
-            if (info.extension == ".gz") {
-                new_extension = true;
-                info.compression = File::GZIP;
-            } else if (info.extension == ".bz2") {
-                new_extension = true;
-                info.compression = File::BZIP2;
-            } else if (info.extension == ".xz") {
-                new_extension = true;
-                info.compression = File::LZMA;
-            }
-
-            if (new_extension) {
-                auto dot2 = path.substr(0, dot1).rfind('.');
-                if (dot2 != std::string::npos) {
-                    info.extension = path.substr(0, dot1).substr(dot2);
-                }
-            }
-        }
-    }
 
     return info;
 }
@@ -104,17 +129,7 @@ Trajectory::Trajectory(std::string path, char mode, const std::string& format)
     : path_(std::move(path)), mode_(mode), format_(nullptr) {
 
     auto info = file_open_info::parse(path_, format);
-    format_creator_t format_creator;
-    if (!info.format.empty()) {
-        format_creator = FormatFactory::get().by_name(info.format).creator;
-    } else if (!info.extension.empty()) {
-        format_creator = FormatFactory::get().by_extension(info.extension).creator;
-    } else {
-        throw file_error(
-            "file at '{}' does not have an extension, provide a format name to read it",
-            path_
-        );
-    }
+    auto format_creator = FormatFactory::get().by_name(info.format).creator;
 
     format_ = format_creator(path_, char_to_file_mode(mode), info.compression);
 
@@ -124,7 +139,6 @@ Trajectory::Trajectory(std::string path, char mode, const std::string& format)
 }
 
 Trajectory Trajectory::memory_reader(const char* data, size_t size, const std::string& format) {
-
     auto info = file_open_info::parse("", format);
 
     if (info.format == "") {

--- a/src/capi/misc.cpp
+++ b/src/capi/misc.cpp
@@ -15,6 +15,7 @@
 #include "chemfiles/capi/shared_allocator.hpp"
 
 #include "chemfiles/misc.hpp"
+#include "chemfiles/error_fmt.hpp"
 #include "chemfiles/external/optional.hpp"
 
 #include "chemfiles/FormatMetadata.hpp"
@@ -84,5 +85,23 @@ extern "C" chfl_status chfl_formats_list(chfl_format_metadata** metadata, uint64
             (*metadata)[i].bonds = meta.bonds;
             (*metadata)[i].residues = meta.residues;
         }
+    )
+}
+
+extern "C" chfl_status chfl_guess_format(const char* const path, char* const format, uint64_t buffsize) {
+    CHECK_POINTER(path);
+    CHECK_POINTER(format);
+    CHFL_ERROR_CATCH(
+        auto cpp_format = guess_format(path);
+
+        if (cpp_format.size() >= buffsize) {
+            throw memory_error(
+                "the format needs {} character, but the buffer only have room for {}",
+                cpp_format.size(), buffsize
+            );
+        }
+
+        strncpy(format, cpp_format.c_str(), checked_cast(buffsize) - 1);
+        format[buffsize - 1] = '\0';
     )
 }

--- a/tests/capi/misc.cpp
+++ b/tests/capi/misc.cpp
@@ -37,6 +37,23 @@ TEST_CASE("Version") {
     CHECK(chfl_version() == version);
 }
 
+TEST_CASE("Guess format") {
+    char format[256] = {0};
+    CHECK_STATUS(chfl_guess_format("filename.nc", format, sizeof(format)));
+    CHECK(format == std::string("Amber NetCDF"));
+
+    CHECK_STATUS(chfl_guess_format("filename.xyz.gz", format, sizeof(format)));
+    CHECK(format == std::string("XYZ / GZ"));
+
+    // buffer too small for the format
+    chfl_status status = chfl_guess_format("filename.nc", format, 8);
+    CHECK(status == CHFL_MEMORY_ERROR);
+
+    // no associated format
+    status = chfl_guess_format("filename.not-there", format, 8);
+    CHECK(status == CHFL_FORMAT_ERROR);
+}
+
 // Global variables for access from callback and main
 static char* buffer = nullptr;
 

--- a/tests/capi/utils.cpp
+++ b/tests/capi/utils.cpp
@@ -37,7 +37,6 @@ generate_function_status(MemoryError)
 generate_function_status(FileError)
 generate_function_status(FormatError)
 generate_function_status(SelectionError)
-generate_function_status(ConfigurationError)
 generate_function_status(OutOfBounds)
 generate_function_status(PropertyError)
 generate_function_status(Error)
@@ -65,7 +64,6 @@ generate_function_goto(MemoryError)
 generate_function_goto(FileError)
 generate_function_goto(FormatError)
 generate_function_goto(SelectionError)
-generate_function_goto(ConfigurationError)
 generate_function_goto(OutOfBounds)
 generate_function_goto(PropertyError)
 generate_function_goto(Error)
@@ -92,9 +90,6 @@ TEST_CASE("Error handling") {
 
         CHECK(throw_SelectionError() == CHFL_SELECTION_ERROR);
         CHECK(std::string(chfl_last_error()) == "SelectionError");
-
-        CHECK(throw_ConfigurationError() == CHFL_CONFIGURATION_ERROR);
-        CHECK(std::string(chfl_last_error()) == "ConfigurationError");
 
         CHECK(throw_OutOfBounds() == CHFL_OUT_OF_BOUNDS);
         CHECK(std::string(chfl_last_error()) == "OutOfBounds");
@@ -136,9 +131,6 @@ TEST_CASE("Error handling") {
 
         CHECK(goto_SelectionError() == 1);
         CHECK(std::string(chfl_last_error()) == "SelectionError");
-
-        CHECK(goto_ConfigurationError() == 1);
-        CHECK(std::string(chfl_last_error()) == "ConfigurationError");
 
         CHECK(goto_OutOfBounds() == 1);
         CHECK(std::string(chfl_last_error()) == "OutOfBounds");

--- a/tests/doc/capi/chfl_guess_format.c
+++ b/tests/doc/capi/chfl_guess_format.c
@@ -1,0 +1,18 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <chemfiles.h>
+#include <string.h>
+#include <assert.h>
+
+int main() {
+    // [example]
+    char format[256] = {0};
+    chfl_guess_format("filename.nc", format, sizeof(format));
+    assert(strcmp(format, "Amber NetCDF") == 0);
+
+    chfl_guess_format("filename.xyz.gz", format, sizeof(format));
+    assert(strcmp(format, "XYZ / GZ") == 0);
+    // [example]
+    return 0;
+}

--- a/tests/doc/guess_format.cpp
+++ b/tests/doc/guess_format.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <catch.hpp>
+#include <chemfiles.hpp>
+using namespace chemfiles;
+
+#undef assert
+#define assert CHECK
+
+TEST_CASE() {
+    // [example]
+    auto format = chemfiles::guess_format("filename.nc");
+    assert(format == "Amber NetCDF");
+
+    format = chemfiles::guess_format("filename.xyz.gz");
+    assert(format == "XYZ / GZ");
+    // [example]
+}

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -286,3 +286,17 @@ TEST_CASE("Check error throwing in formats") {
         );
     }
 }
+
+TEST_CASE("Guess format") {
+    auto format = chemfiles::guess_format("filename.nc");
+    CHECK(format == "Amber NetCDF");
+
+    format = chemfiles::guess_format("filename.xyz.gz");
+    CHECK(format == "XYZ / GZ");
+
+    // no associated format
+    CHECK_THROWS_WITH(
+        chemfiles::guess_format("filename.not-there"),
+        "can not find a format associated with the '.not-there' extension"
+    );
+}

--- a/tests/factory.cpp
+++ b/tests/factory.cpp
@@ -136,17 +136,17 @@ TEST_CASE("Geting registered format") {
     FormatFactory::get().add_format<DummyFormat>();
 
     DummyFormat dummy("", File::READ, File::DEFAULT);
-    auto format = FormatFactory::get().extension(".dummy")("", File::READ, File::DEFAULT);
+    auto format = FormatFactory::get().by_extension(".dummy").creator("", File::READ, File::DEFAULT);
     CHECK(typeid(dummy) == typeid(*format));
-    format = FormatFactory::get().name("Dummy")("", File::READ, File::DEFAULT);
+    format = FormatFactory::get().by_name("Dummy").creator("", File::READ, File::DEFAULT);
     CHECK(typeid(dummy) == typeid(*format));
 
     CHECK_THROWS_WITH(
-        FormatFactory::get().name("UNKOWN"),
+        FormatFactory::get().by_name("UNKOWN"),
         "can not find a format named 'UNKOWN'"
     );
     CHECK_THROWS_WITH(
-        FormatFactory::get().extension(".UNKOWN"),
+        FormatFactory::get().by_extension(".UNKOWN"),
         "can not find a format associated with the '.UNKOWN' extension"
     );
 }
@@ -164,14 +164,14 @@ TEST_CASE("Already registered format/extension") {
 
 TEST_CASE("Format names suggestions") {
     try {
-        FormatFactory::get().name("Dully");
+        FormatFactory::get().by_name("Dully");
         CHECK(false);
     } catch (const FormatError& e) {
         CHECK(std::string(e.what()) == "can not find a format named 'Dully', did you mean 'Dummy'?");
     }
 
     try {
-        FormatFactory::get().name("DUMMY");
+        FormatFactory::get().by_name("DUMMY");
         CHECK(false);
     } catch (const FormatError& e) {
         CHECK(std::string(e.what()) == "can not find a format named 'DUMMY', did you mean 'Dummy'?");
@@ -179,7 +179,7 @@ TEST_CASE("Format names suggestions") {
 
     FormatFactory::get().add_format<DunnyFormat>();
     try {
-        FormatFactory::get().name("Dully");
+        FormatFactory::get().by_name("Dully");
         CHECK(false);
     } catch (const FormatError& e) {
         CHECK(std::string(e.what()) == "can not find a format named 'Dully', did you mean 'Dummy' or 'Dunny'?");

--- a/tests/lints/check-capi-docs.py
+++ b/tests/lints/check-capi-docs.py
@@ -38,6 +38,7 @@ def functions_in_outline():
         "chfl_clear_errors",
         "chfl_version",
         "chfl_formats_list",
+        "chfl_guess_format",
     ]
     DOCS = os.path.join(ROOT, "doc", "src", "capi")
     functions = MISC_FUNCTIONS

--- a/tests/trajectory.cpp
+++ b/tests/trajectory.cpp
@@ -191,11 +191,25 @@ TEST_CASE("Specify a format parameter") {
     frame = Trajectory(tmpfile, 'r', "XYZ /GZ").read();
     CHECK(frame.size() == 1);
     CHECK(frame[0].name() == "Fe");
+}
 
-    // only the compression method, the format will be guessed from extension
-    frame = Trajectory(tmpfile, 'r', "/ GZ").read();
-    CHECK(frame.size() == 1);
-    CHECK(frame[0].name() == "Fe");
+TEST_CASE("Guessing format") {
+    CHECK(guess_format("not-a-file.xyz") == "XYZ");
+    CHECK(guess_format("not-a-file.pdb") == "PDB");
+    CHECK(guess_format("not-a-file.nc") == "Amber NetCDF");
+
+    CHECK(guess_format("not-a-file.xyz.gz") == "XYZ / GZ");
+    CHECK(guess_format("not-a-file.xyz.bz2") == "XYZ / BZ2");
+    CHECK(guess_format("not-a-file.xyz.xz") == "XYZ / XZ");
+
+    CHECK_THROWS_WITH(
+        guess_format("not-a-file.unknown"),
+        "can not find a format associated with the '.unknown' extension"
+    );
+    CHECK_THROWS_WITH(
+        guess_format("not-a-file"),
+        "file at 'not-a-file' does not have an extension, provide a format name to read it"
+    );
 }
 
 TEST_CASE("Errors") {


### PR DESCRIPTION
This will be used in the javascript bindings for 0.10 to decide when to use "native" in memory IO or write the file to a temporary in-memory filesystem and read/write from there.

@frodofine or @ezavod do you have some time to give this a look in the next week?