### PR TITLE
CIF/mmCIF improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,7 +215,7 @@ jobs:
       - name: run tests
         run: |
           cd build
-          ctest --build-config ${{ matrix.build-type }} --parallel 2
+          ctest --output-on-failure --build-config ${{ matrix.build-type }} --parallel 2
       - name: check the list of exported symbols
         if: matrix.check-exported-symbols
         run: ./scripts/ci/check-exported-symbols.py build/libchemfiles.so

--- a/include/chemfiles/formats/mmCIF.hpp
+++ b/include/chemfiles/formats/mmCIF.hpp
@@ -48,9 +48,6 @@ private:
     std::map<std::string, size_t> atom_site_map_;
     /// Map of residues, indexed by residue id and chainid.
     std::map<std::pair<std::string, int64_t>, Residue> residues_;
-    /// Set to true if the file is based on fractional coordinates.
-    /// Set to false if the file is based on cartesian coordinates.
-    bool uses_fract_;
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekpos` them instead of reading the whole step.
     std::vector<uint64_t> steps_positions_;
@@ -62,6 +59,7 @@ private:
     size_t atoms_;
     /// Frame properties need to be stored
     std::string name_;
+    /// The PDB icode, if any
     std::string pdb_idcode_;
 };
 

--- a/include/chemfiles/misc.hpp
+++ b/include/chemfiles/misc.hpp
@@ -46,11 +46,12 @@ std::vector<std::reference_wrapper<const FormatMetadata>> CHFL_EXPORT formats_li
 /// optional.
 ///
 /// @param path path of the file we are trying to read
+/// @param mode the opening mode of the file, can be 'r', 'a' or 'w'
 /// @return guessed format of the file
 /// @throw FormatError if no format matching this filename is found.
 ///
 /// @example{guess_format.cpp}
-std::string CHFL_EXPORT guess_format(std::string path);
+std::string CHFL_EXPORT guess_format(std::string path, char mode = 'r');
 
 } // namespace chemfiles
 

--- a/src/Trajectory.cpp
+++ b/src/Trajectory.cpp
@@ -29,52 +29,6 @@ using namespace chemfiles;
 
 #define SENTINEL_VALUE (static_cast<size_t>(-1))
 
-std::string chemfiles::guess_format(std::string path) {
-    std::string extension;
-    std::string compression;
-
-    auto dot1 = path.rfind('.');
-    if (dot1 != std::string::npos) {
-        extension = path.substr(dot1);
-        bool new_extension = false;
-        // check file extension for compressed file extension
-        if (extension == ".gz") {
-            new_extension = true;
-            compression = "GZ";
-        } else if (extension == ".bz2") {
-            new_extension = true;
-            compression = "BZ2";
-        } else if (extension == ".xz") {
-            new_extension = true;
-            compression = "XZ";
-        }
-
-        if (new_extension) {
-            extension = "";
-            auto dot2 = path.substr(0, dot1).rfind('.');
-            if (dot2 != std::string::npos) {
-                extension = path.substr(0, dot1).substr(dot2);
-            }
-        }
-    }
-
-    if (extension.empty()) {
-        throw file_error(
-            "file at '{}' does not have an extension, provide a format name to read it",
-            path
-        );
-    }
-
-    auto registered_format = FormatFactory::get().by_extension(extension);
-    auto format = std::string(registered_format.metadata.name);
-
-    if (!compression.empty()) {
-        format += " / " + compression;
-    }
-
-    return format;
-}
-
 struct file_open_info {
     static file_open_info parse(const std::string& path, std::string format);
     std::string format = "";

--- a/src/formats/mmCIF.cpp
+++ b/src/formats/mmCIF.cpp
@@ -122,16 +122,15 @@ void mmCIFFormat::init_() {
                     trimmed.substr(1, trimmed.size() - 2).to_string() : "";
         }
 
-        if (in_loop && line_split[0].find("_atom_site") != std::string::npos) {
+        if (in_loop && line_split[0].find("_atom_site.") != std::string::npos) {
             auto atom_label = line_split[0].substr(11).to_string();
-            to_ascii_lowercase(atom_label);
             atom_site_map_[atom_label] = current_index++;
             break;
         }
     }
 
     if (current_index == 0) {
-        throw format_error("no atom sites found in mmCIF file");
+        throw format_error("could not find _atom_site loop in '{}'", file_.path());
     }
 
     cell_ = UnitCell(lengths, angles);
@@ -142,7 +141,6 @@ void mmCIFFormat::init_() {
     do {
         if (line.find("_atom_site") != std::string::npos) {
             auto atom_label = trim(line).substr(11).to_string();
-            to_ascii_lowercase(atom_label);
             atom_site_map_[atom_label] = current_index++;
 
             position = file_.tellpos();
@@ -159,22 +157,14 @@ void mmCIFFormat::init_() {
     steps_positions_.push_back(position);
 
     if (atom_site_map_.find("type_symbol") == atom_site_map_.end()) {
-        throw format_error("CIF files does not define type symbol");
+        throw format_error("could not find _atom_site.type_symbol in '{}'", file_.path());
     }
 
-    // Attempt to guess how coordinates are stored
-    auto cartn_x = atom_site_map_.find("cartn_x");
-    auto fract_x = atom_site_map_.find("fract_x");
-    if (cartn_x != atom_site_map_.end()) {
-        uses_fract_ = false;
-    } else if (fract_x != atom_site_map_.end()) {
-        uses_fract_ = true;
-    } else {
-        throw format_error("CIF file does not define coordinates");
+    if (atom_site_map_.find("Cartn_x") == atom_site_map_.end()) {
+        throw format_error("could not find _atom_site.Cartn_x in '{}'", file_.path());
     }
 
-
-    auto model_position = atom_site_map_.find("pdbx_pdb_model_num");
+    auto model_position = atom_site_map_.find("pdbx_PDB_model_num");
     // Do we have a special extension for multiple modes?
     if (model_position == atom_site_map_.end()) {
         // If not, we are done
@@ -232,7 +222,7 @@ void mmCIFFormat::read(Frame& frame) {
     // and stored with optional. I don't know which solution is better.
 
     // These are required for atoms
-    auto type_symbol = atom_site_map_.find("type_symbol");
+    auto type_symbol = atom_site_map_.at("type_symbol");
 
     // This has two names...
     auto label_atom_id = atom_site_map_.find("label_atom_id");
@@ -241,19 +231,14 @@ void mmCIFFormat::read(Frame& frame) {
     }
 
     // Other atom properties
-    auto group_pdb = atom_site_map_.find("group_pdb");
+    auto group_pdb = atom_site_map_.find("group_PDB");
     auto label_alt_id = atom_site_map_.find("label_alt_id");
     auto formal_charge = atom_site_map_.find("formal_charge");
 
     // Positions
-    auto cartn_x = atom_site_map_.find("cartn_x");
-    auto cartn_y = atom_site_map_.find("cartn_y");
-    auto cartn_z = atom_site_map_.find("cartn_z");
-
-    // Positions used by COD and CCSD
-    auto fract_x = atom_site_map_.find("fract_x");
-    auto fract_y = atom_site_map_.find("fract_y");
-    auto fract_z = atom_site_map_.find("fract_z");
+    auto cartn_x = atom_site_map_.at("Cartn_x");
+    auto cartn_y = atom_site_map_.at("Cartn_y");
+    auto cartn_z = atom_site_map_.at("Cartn_z");
 
     // Residue properties
     auto label_comp_id = atom_site_map_.find("label_comp_id");
@@ -262,7 +247,7 @@ void mmCIFFormat::read(Frame& frame) {
     auto label_seq_id = atom_site_map_.find("label_seq_id");
     auto label_entity_id = atom_site_map_.find("label_entity_id");
 
-    auto model_position = atom_site_map_.find("pdbx_pdb_model_num");
+    auto model_position = atom_site_map_.find("pdbx_PDB_model_num");
 
     auto position = file_.tellpos();
 
@@ -297,8 +282,10 @@ void mmCIFFormat::read(Frame& frame) {
             break;
         }
 
-        Atom atom(line_split[label_atom_id->second].to_string(),
-                  line_split[type_symbol->second].to_string());
+        Atom atom(
+            line_split[label_atom_id->second].to_string(),
+            line_split[type_symbol].to_string()
+        );
 
         if (label_alt_id != atom_site_map_.end() &&
             line_split[label_alt_id->second] != ".") {
@@ -309,20 +296,10 @@ void mmCIFFormat::read(Frame& frame) {
             atom.set_charge(cif_to_double(line_split[formal_charge->second].to_string()));
         }
 
-        if (!uses_fract_) {
-            auto x = cif_to_double(line_split[cartn_x->second].to_string());
-            auto y = cif_to_double(line_split[cartn_y->second].to_string());
-            auto z = cif_to_double(line_split[cartn_z->second].to_string());
-
-            frame.add_atom(std::move(atom), Vector3D(x, y, z));
-        } else {
-            auto u = cif_to_double(line_split[fract_x->second].to_string());
-            auto v = cif_to_double(line_split[fract_y->second].to_string());
-            auto w = cif_to_double(line_split[fract_z->second].to_string());
-
-            auto vector = cell_.matrix() * Vector3D(u, v, w);
-            frame.add_atom(std::move(atom), vector);
-        }
+        auto x = cif_to_double(line_split[cartn_x].to_string());
+        auto y = cif_to_double(line_split[cartn_y].to_string());
+        auto z = cif_to_double(line_split[cartn_z].to_string());
+        frame.add_atom(std::move(atom), Vector3D(x, y, z));
 
         position = file_.tellpos();
 

--- a/src/guess_format.cpp
+++ b/src/guess_format.cpp
@@ -1,0 +1,120 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <string>
+
+#include "chemfiles/FormatFactory.hpp"
+#include "chemfiles/FormatMetadata.hpp"
+#include "chemfiles/File.hpp"
+
+#include "chemfiles/misc.hpp"
+#include "chemfiles/utils.hpp"
+#include "chemfiles/error_fmt.hpp"
+#include "chemfiles/string_view.hpp"
+#include "chemfiles/external/optional.hpp"
+
+using namespace chemfiles;
+
+/// try to distinguish CIF and mmCIF files, since they share the same
+/// `.cif` extension
+static optional<std::string> distinguish_cif_variants(const std::string& path, const std::string& compression);
+
+static bool contains(string_view haystack, string_view needle) {
+    return haystack.find(needle) != haystack.npos;
+}
+
+std::string chemfiles::guess_format(std::string path, char mode) {
+    std::string extension;
+    std::string compression;
+
+    auto dot1 = path.rfind('.');
+    if (dot1 != std::string::npos) {
+        extension = path.substr(dot1);
+        bool new_extension = false;
+        // check file extension for compressed file extension
+        if (extension == ".gz") {
+            new_extension = true;
+            compression = "GZ";
+        } else if (extension == ".bz2") {
+            new_extension = true;
+            compression = "BZ2";
+        } else if (extension == ".xz") {
+            new_extension = true;
+            compression = "XZ";
+        }
+
+        if (new_extension) {
+            extension = "";
+            auto dot2 = path.substr(0, dot1).rfind('.');
+            if (dot2 != std::string::npos) {
+                extension = path.substr(0, dot1).substr(dot2);
+            }
+        }
+    }
+
+    if (extension.empty()) {
+        throw file_error(
+            "file at '{}' does not have an extension, provide a format name to read it",
+            path
+        );
+    }
+
+    if (extension == ".cif" && (mode == 'r' || mode == 'a')) {
+        extension = distinguish_cif_variants(path, compression).value_or(extension);
+    }
+
+    auto registered_format = FormatFactory::get().by_extension(extension);
+    auto format = std::string(registered_format.metadata.name);
+
+    if (!compression.empty()) {
+        format += " / " + compression;
+    }
+
+    return format;
+}
+
+
+static optional<std::string> distinguish_cif_variants(
+    const std::string& path,
+    const std::string& compression
+) {
+    auto c = File::DEFAULT;
+    if (compression == "GZ") {
+        c = File::GZIP;
+    } else if (compression == "BZ2") {
+        c = File::BZIP2;
+    } else if (compression == "XZ") {
+        c = File::LZMA;
+    }
+
+    try {
+        auto file = TextFile(path, File::READ, c);
+        while (!file.eof()) {
+            auto line = file.readline();
+            // check a few mmCIF/CIF specific tags that are more likely to be
+            // close to the top of the file
+            if (contains(line, "_audit_conform.dict_name")
+                || contains(line, "_cell.length_a")
+                || contains(line, "_atom_site.type_symbol")
+            ) {
+                return std::string(".mmcif");
+            }
+
+            if (contains(line, "_symmetry_equiv_pos_as_xyz")
+                || contains(line, "_cell_length_a")
+                || contains(line, "_atom_site_type_symbol")
+            ) {
+                return std::string(".cif");
+            }
+        }
+
+        // if we could not find any of the above strings in the file, it is very
+        // likely the file is invalid. As below, the user will get a proper
+        // error when trying to open the file
+        return nullopt;
+    } catch (const FileError&) {
+        // in case of error while reading, just use the file extension for now,
+        // the user will get a proper error when trying to open the file
+        return nullopt;
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "6fc982cdf888004671100d33d9f4fbe1ba670807")
+set(TESTS_DATA_GIT "b21d3e44dffe36b2b311976e7d6b13bb0a8a5326")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=04f1e562022cd603fa51f940800c0a33cfc0c7a6
+        EXPECTED_HASH SHA1=eafc5be961d096da29fa6f4f16f01a97f8244b27
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/cif.cpp
+++ b/tests/formats/cif.cpp
@@ -50,14 +50,14 @@ TEST_CASE("Read files in CIF format") {
         CHECK(frame[0].get("occupancy")->as_double() == 1.0);
         CHECK(frame[0].get("atomic_number")->as_double() == 6);
         CHECK(approx_eq(frame.positions()[0], Vector3D(0.124, 14.561, 4.200), 1e-3));
-        
+
         frame = file.read();
         CHECK(approx_eq(frame.cell().lengths(), {20.561233, 20.561233, 20.561233}, 1e-6));
         CHECK(frame[0].name() == "C1");
         CHECK(frame[0].get("occupancy")->as_double() == 1.0);
         CHECK(frame[0].get("atomic_number")->as_double() == 6);
         CHECK(approx_eq(frame.positions()[0], Vector3D(0.159, 4.170, 14.451), 1e-3));
-        
+
         frame = file.read();
         CHECK(approx_eq(frame.cell().lengths(), {20.415146, 20.415146, 20.415146}, 1e-6));
         CHECK(frame[0].name() == "C1");
@@ -77,7 +77,7 @@ TEST_CASE("Read files in CIF format") {
         CHECK(frame[0].get("occupancy")->as_double() == 1.0);
         CHECK(frame[0].get("atomic_number")->as_double() == 6);
         CHECK(approx_eq(frame.positions()[0], Vector3D(0.159, 4.170, 14.451), 1e-3));
-        
+
         frame = file.read_step(0);
         CHECK(approx_eq(frame.cell().lengths(), {20.721205, 20.721205, 20.721205}, 1e-6));
         CHECK(frame[0].name() == "C1");
@@ -85,7 +85,7 @@ TEST_CASE("Read files in CIF format") {
         CHECK(frame[0].get("occupancy")->as_double() == 1.0);
         CHECK(frame[0].get("atomic_number")->as_double() == 6);
         CHECK(approx_eq(frame.positions()[0], Vector3D(0.124, 14.561, 4.200), 1e-3));
-        
+
         frame = file.read_step(2);
         CHECK(approx_eq(frame.cell().lengths(), {20.415146, 20.415146, 20.415146}, 1e-6));
         CHECK(frame[0].name() == "C1");
@@ -93,6 +93,18 @@ TEST_CASE("Read files in CIF format") {
         CHECK(frame[0].get("occupancy")->as_double() == 1.0);
         CHECK(frame[0].get("atomic_number")->as_double() == 6);
         CHECK(approx_eq(frame.positions()[0], Vector3D(0.220, 4.142, 14.350), 1e-3));
+    }
+
+    SECTION("Read a COD file") {
+        auto file = Trajectory("data/cif/1544173.cif");
+        REQUIRE(file.nsteps() == 1);
+
+        auto frame = file.read();
+        CHECK(frame.size() == 100);
+
+        auto positions = frame.positions();
+        CHECK(approx_eq(positions[0], Vector3D(-0.428, 5.427, 11.536), 1e-3));
+        CHECK(approx_eq(positions[20],Vector3D(2.507, 4.442, 8.863), 1e-3));
     }
 }
 

--- a/tests/formats/mmcif.cpp
+++ b/tests/formats/mmcif.cpp
@@ -11,9 +11,7 @@ using namespace chemfiles;
 
 TEST_CASE("Read files in mmCIF format") {
     SECTION("Read single step") {
-        // This is how I imagine most people will resolve the conflict between
-        // CIF files and mmCIF files.
-        auto file = Trajectory("data/cif/4hhb.cif", 'r', "mmCIF");
+        auto file = Trajectory("data/cif/4hhb.cif");
         Frame frame = file.read();
 
         // If comparing to the RCSB-PDB file,
@@ -88,12 +86,12 @@ TEST_CASE("Read files in mmCIF format") {
     }
 
     SECTION("Check nsteps") {
-        auto file = Trajectory("data/cif/1j8k.cif", 'r', "mmCIF");
+        auto file = Trajectory("data/cif/1j8k.cif");
         CHECK(file.nsteps() == 20);
     }
 
     SECTION("Read next step") {
-        auto file = Trajectory("data/cif/1j8k.cif", 'r', "mmCIF");
+        auto file = Trajectory("data/cif/1j8k.cif");
         auto frame = file.read();
         CHECK(frame.size() == 1402);
 
@@ -105,7 +103,7 @@ TEST_CASE("Read files in mmCIF format") {
     }
 
     SECTION("Read a specific step") {
-        auto file = Trajectory("data/cif/1j8k.cif", 'r', "mmCIF");
+        auto file = Trajectory("data/cif/1j8k.cif");
 
         auto frame = file.read_step(13);
         CHECK(frame.size() == 1402);
@@ -123,7 +121,7 @@ TEST_CASE("Read files in mmCIF format") {
     }
 
     SECTION("Read the entire file") {
-        auto file = Trajectory("data/cif/1j8k.cif", 'r', "mmCIF");
+        auto file = Trajectory("data/cif/1j8k.cif");
         auto frame = file.read();
 
         CHECK(frame.get("name")->as_string() ==
@@ -141,7 +139,7 @@ TEST_CASE("Read files in mmCIF format") {
     }
 
     SECTION("1AKE") {
-        auto file = Trajectory("data/cif/1ake.cif.gz", 'r', "mmCIF / GZ");
+        auto file = Trajectory("data/cif/1ake.cif.gz");
         REQUIRE(file.nsteps() == 1);
 
         auto frame = file.read();

--- a/tests/formats/mmcif.cpp
+++ b/tests/formats/mmcif.cpp
@@ -140,17 +140,12 @@ TEST_CASE("Read files in mmCIF format") {
         CHECK(frame.size() == 1402);
     }
 
-    SECTION("Read a COD file") {
-        auto file = Trajectory("data/cif/1544173.cif", 'r', "mmCIF");
+    SECTION("1AKE") {
+        auto file = Trajectory("data/cif/1ake.cif.gz", 'r', "mmCIF / GZ");
         REQUIRE(file.nsteps() == 1);
 
         auto frame = file.read();
-        CHECK(frame.size() == 50);
-
-        auto positions = frame.positions();
-        CHECK(approx_eq(positions[0], Vector3D( -0.428, 5.427, 11.536), 1e-3));
-        CHECK(approx_eq(positions[1], Vector3D( -0.846, 4.873, 12.011), 1e-3));
-        CHECK(approx_eq(positions[10],Vector3D(  2.507, 4.442, 8.863), 1e-3));
+        CHECK(frame.size() == 3816);
     }
 }
 

--- a/tests/lints/check-error-messages.py
+++ b/tests/lints/check-error-messages.py
@@ -17,6 +17,8 @@ ERRORS = 0
 # are allowed
 ALLOWED = [
     "found deprecated configuration file at '{}', please rename it to .chemfiles.toml",
+    "could not find _atom_site.type_symbol in '{}'",
+    "could not find _atom_site.Cartn_x in '{}'",
 ]
 
 
@@ -73,7 +75,7 @@ def check_message(path, line, message):
 
 def check_file(path):
     with codecs.open(path, encoding="utf8") as fd:
-        lines = [l for l in fd]
+        lines = list(fd)
 
     for (i, line) in enumerate(lines):
         # ignore comments


### PR DESCRIPTION
This PR should fix all chemfiles' side issues reported in https://github.com/MDAnalysis/mdanalysis/issues/2367#issuecomment-876065924. I'll work on the MDAnalysis side for the remaining issues.

- make the mmCIF reader more strict, and move COD/CCSD files support to CIF reader
- make `guess_format` distinguish between CIF and mmCIF files if the extension is .cif


@frodofine since you wrote the mmCIF code, could you give this a look?