### PR TITLE
Read Arbitrary Per-Atom Properties in LAMMPS Atoms Format

### DIFF
--- a/src/formats/LAMMPSTrajectory.cpp
+++ b/src/formats/LAMMPSTrajectory.cpp
@@ -517,7 +517,7 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
                 try {
                     // LAMMPS should always write double values
                     atom.set(fields[j].name, parse<double>(splitted[j]));
-                } catch (const Error& e) {
+                } catch (const Error&) {
                     // use the string value as fallback
                     atom.set(fields[j].name, splitted[j].to_string());
                 }

--- a/src/formats/LAMMPSTrajectory.cpp
+++ b/src/formats/LAMMPSTrajectory.cpp
@@ -137,7 +137,7 @@ std::array<double, 3> LAMMPSTrajectoryFormat::read_cell(Frame& frame) {
 /// variables
 enum lammps_atom_attr_t {
     // other possible attributes that are not important for chemfiles
-    UNKNOWN,
+    CUSTOM,
     // atom ID
     ATOMID,
     // atom type
@@ -238,18 +238,23 @@ static lammps_atom_attr_t attribute_from_str(string_view attr_str) {
     } else if (attr_str == "q") {
         return CHARGE;
     } else {
-        return UNKNOWN;
+        return CUSTOM;
     }
 }
 
+struct AtomField {
+    std::string name;
+    lammps_atom_attr_t kind;
+};
+
 static lammps_position_representation_t
-detect_best_pos_representation(const std::vector<lammps_atom_attr_t>& fields) {
+detect_best_pos_representation(const std::vector<AtomField>& fields) {
     int wrapped_count = 0;
     int scaled_count = 0;
     int unwrapped_count = 0;
     int scaled_unwrapped_count = 0;
-    for (const auto& attr : fields) {
-        switch (attr) {
+    for (const auto& atom_field : fields) {
+        switch (atom_field.kind) {
         case POSX:
         case POSY:
         case POSZ:
@@ -352,7 +357,7 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
         throw format_error("can not read next step as LAMMPS format: expected 'ATOMS' got '{}'",
                            *item);
     }
-    std::vector<lammps_atom_attr_t> fields;
+    std::vector<AtomField> fields;
     fields.reserve(atoms_item.size() - 1);
     optional<size_t> atomid_column = nullopt;
     std::vector<bool> duplicate_check;
@@ -369,7 +374,7 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
         if (attr == IMGX || attr == IMGY || attr == IMGZ) {
             images = std::vector<std::array<int, 3>>(natoms, {0, 0, 0});
         }
-        fields.push_back(attr);
+        fields.push_back({atoms_item[i].to_string(), attr});
     }
     lammps_position_representation_t use_pos_repr = detect_best_pos_representation(fields);
 
@@ -404,7 +409,7 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
 
         auto& atom = frame[atomid];
         for (size_t j = 0; j < fields.size(); ++j) {
-            switch (fields[j]) {
+            switch (fields[j].kind) {
             case TYPE:
                 atom.set_type(splitted[j].to_string());
                 break;
@@ -507,7 +512,15 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
                 atom.set_charge(charge);
             } break;
             case ATOMID:
-            case UNKNOWN:
+                break;
+            case CUSTOM:
+                try {
+                    // LAMMPS should always write double values
+                    atom.set(fields[j].name, parse<double>(splitted[j]));
+                } catch (const Error& e) {
+                    // use the string value as fallback
+                    atom.set(fields[j].name, splitted[j].to_string());
+                }
                 break;
             }
         }

--- a/tests/formats/lammps-trajectory.cpp
+++ b/tests/formats/lammps-trajectory.cpp
@@ -162,6 +162,44 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK_THROWS_AS(file.read(), FileError);
     }
 
+    SECTION("Atom Properties") {
+        auto file = Trajectory("data/lammps/properties.lammpstrj");
+        CHECK(file.nsteps() == 4);
+
+        Frame frame = file.read();
+        CHECK(frame.size() == 4000);
+        CHECK(frame.step() == 0);
+        CHECK(!frame.velocities());
+        auto positions = frame.positions();
+
+        CHECK(approx_eq(positions[390], Vector3D(10.4004,12.4805, 0.693361), 1e-3));
+        CHECK(approx_eq(positions[789], Vector3D(10.4004,13.1739, 1.38672), 1e-3));
+
+        CHECK(approx_eq(frame[390].get("c_stress[6]")->as_double(), -1.38816, 1e-3));
+        CHECK(approx_eq(frame[390].get("v_sq_pos")->as_double(), 264.412, 1e-3));
+        CHECK(approx_eq(frame[390].get("i_flag")->as_double(), 1.0, 1e-12));
+        CHECK(approx_eq(frame[789].get("c_stress[1]")->as_double(), -59.7086, 1e-3));
+        CHECK(approx_eq(frame[789].get("v_sq_pos")->as_double(), 283.642, 1e-3));
+        CHECK(approx_eq(frame[789].get("i_flag")->as_double(), 0.0, 1e-12));
+
+        frame = file.read_step(3);
+        CHECK(frame.size() == 4000);
+        CHECK(frame.step() == 300);
+        CHECK(!frame.velocities());
+        positions = frame.positions();
+
+        CHECK(approx_eq(positions[2988], Vector3D(9.71147, 5.5884, 9.71147), 1e-3));
+        CHECK(approx_eq(positions[3905], Vector3D(9.01993, 10.4242, 12.4797), 1e-3));
+
+        CHECK(approx_eq(frame[2988].get("c_stress[5]")->as_double(), 12.9949, 1e-3));
+        CHECK(approx_eq(frame[2988].get("v_sq_pos")->as_double(), 219.855, 1e-3));
+        CHECK(approx_eq(frame[2988].get("i_flag")->as_double(), 1.0, 1e-12));
+        CHECK(approx_eq(frame[3905].get("c_stress[2]")->as_double(), -67.6015, 1e-3));
+        CHECK(approx_eq(frame[3905].get("v_sq_pos")->as_double(), 345.766, 1e-3));
+        CHECK(approx_eq(frame[3905].get("i_flag")->as_double(), 0.0, 1e-12));
+
+    }
+
     SECTION("Errors") {
         // ITEM: TIMESTEP issues
         auto file = Trajectory("data/lammps/bad/timestep-no-item.lammpstrj");


### PR DESCRIPTION
Read per-atom properties (see discussion in #409). LAMMPS cannot store any frame properties, so nothing to do here. Also, all LAMMPS fixes, computes, or variables are either integer or double. Reading string properties is only a fallback if something went wrong, e.g. when dealing with incorrect user-generated data or upstream changes in LAMMPS.
Array data is written element-wise which means that a 3D property results in 3 scalar properties `myProp[I]` where `I = 1, 2, 3`.

Edit: Tests failing due to changes in #412. Waiting for these changes to be merged and then run tests again.
<details>
<summary>How to generate test input</summary>

```
variable x index 1
variable y index 1
variable z index 1
variable   t index 300

variable xx equal 10*$x
variable yy equal 10*$y
variable zz equal 10*$z

units         lj
atom_style    atomic

lattice       fcc 1.5
region        box block 0 ${xx} 0 ${yy} 0 ${zz}
create_box    1 box
create_atoms  1 box
mass     1 1.0

velocity all create 1.44 87287 loop geom

pair_style    lj/cut 2.5
pair_coeff    1 1 1.0 1.0 2.5

neighbor 0.3 bin
neigh_modify  delay 0 every 20 check no

fix      1 all nve

compute stress all stress/atom NULL
variable sq_pos atom "x^2+y^2+z^2"
fix 2 all property/atom i_flag

variable cluster atom (id%2)
set atom * i_flag v_cluster

dump 3 all custom 100 lj_dump.lammpstrj id type x y z c_stress[*] v_sq_pos i_flag
#dump 4 all netcdf 100 lj_dump.nc x y z c_stress[*]

#compute 6 all property/local ntype1 ntype2
#dump 5 all local 100 local.txt index c_6[1]

run      $t
```
</details>