### PR TITLE
Update Molfile.cpp

### DIFF
--- a/src/formats/Molfile.cpp
+++ b/src/formats/Molfile.cpp
@@ -339,7 +339,7 @@ template<> const FormatMetadata& chemfiles::format_metadata<Molfile<DCD>>() {
 
     metadata.positions = true;
     metadata.velocities = false;
-    metadata.unit_cell = false;
+    metadata.unit_cell = true;
     metadata.atoms = false;
     metadata.bonds = false;
     metadata.residues = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "2db410d1f7651776e142676d26ec0d2cccd7b3cd")
+set(TESTS_DATA_GIT "235991a21b35bfd156d35a7084c75ddf0a637869")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=e3931a973886e8bd37a1db2835a963db2ff50d57
+        EXPECTED_HASH SHA1=d91217e19726b8de3eb0cef5f937e2f69b22f404
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/dcd-molfile.cpp
+++ b/tests/formats/dcd-molfile.cpp
@@ -28,3 +28,22 @@ TEST_CASE("Read files in DCD format using Molfile") {
     CHECK(approx_eq(positions[0], Vector3D(0.2990952, 8.31003, 11.72146), eps));
     CHECK(approx_eq(positions[296], Vector3D(6.797599, 11.50882, 12.70423), eps));
 }
+
+
+TEST_CASE("Read unit cell in DCD files") {
+    auto file = Trajectory("data/dcd/nopbc.dcd");
+    auto frame = file.read();
+
+    auto cell = frame.cell();
+    // FIXME: this should be UnitCell::INFINITE, cf https://github.com/chemfiles/chemfiles/issues/419
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(cell.lengths() == Vector3D(1.0, 1.0, 1.0));
+
+
+    file = Trajectory("data/dcd/withpbc.dcd");
+    frame = file.read();
+
+    cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(cell.lengths() == Vector3D(100.0, 100.0, 100.0));
+}


### PR DESCRIPTION
The unit cell is correctly read from DCD file, so the information in supported formats page needs to be changed.

Tested with two different DCD files generated by NAMD 2.14 (attached). Chemfiles correctly reads the unit cell parameters, which can be accessed from `frame.cell().lengths()` and `frame.cell().angles()`.

[dcd_pbc_test.zip](https://github.com/chemfiles/chemfiles/files/7070129/dcd_pbc_test.zip)
