### PR TITLE
MMCIF reader optimization

### DIFF
--- a/include/chemfiles/formats/mmCIF.hpp
+++ b/include/chemfiles/formats/mmCIF.hpp
@@ -46,8 +46,10 @@ private:
     TextFile file_;
     /// Map of STAR records to their index
     std::map<std::string, size_t> atom_site_map_;
-    /// Map of residues, indexed by residue id and chainid.
-    std::map<std::pair<std::string, int64_t>, Residue> residues_;
+    /// Vector with all the residues.
+    std::vector<Residue> residues_;
+    /// Map of residue indexes, indexed by residue id and chainid. We use an indirection to keep the residue order (and don't sort them with the map id).
+    std::map<std::pair<std::string, int64_t>, size_t> map_residues_indexes;
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekpos` them instead of reading the whole step.
     std::vector<uint64_t> steps_positions_;


### PR DESCRIPTION
Hi,
I found that the same molecule may be way longer to open in mmcif than in mmtf format.
(1.5s for the mmtf, 33s for the mmcif. download link at end of post).

I discovered that in the mmcif reader, the residues were stored in a map before been added in the topology. But this intermediate structure change the order of the residues comparing to the order in the file (sort by chain ID).
And then, when we iterate over the residues to add the standard bonds, and because the residues don't have their initial sort, some bonds with atom of far IDs may be added early in the topology which will implies a lot of insertions. And because the bonds are stored in a "sorted_set", which in reality hide a vector, all these insertions may have a really big cost.

By adding an indirection, we can keep the residue order declared in the file and reduce drasticaly the number of insertions.

After this modification, the same molecule is opened at the same speed in mmtf or mmcif format.

Example file download links :
mmcif : https://www.rcsb.org/structure/7CGO
mmtf : https://mmtf.rcsb.org/v1.0/full/7cgo