### PR TITLE
refactor(Atom): do not allocate map without atom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Added read support for PSF files using VMD molfile plugin.
 - Amber NetCDF files are now read/written with a custom netcdf parser (#443)
 
-### Changes to the C API
+### Changes to the C++ API
+- Per-atom properties are optional, i.e. `Atom::properties` returns an optional property map.
 
 ## 0.10.0 (14 Feb 2021)
 

--- a/include/chemfiles/Atom.hpp
+++ b/include/chemfiles/Atom.hpp
@@ -144,11 +144,12 @@ public:
     /// @example{atom/atomic_number.cpp}
     optional<uint64_t> atomic_number() const;
 
-    /// Get the map of properties associated with this atom. This map might be
-    /// iterated over to list the properties of the atom, or directly accessed.
+    /// Get the map of properties associated with this atom. If no properties
+    /// are set, this function returns `nullopt`. This map might be iterated
+    /// over to list the properties of the atom, or directly accessed.
     ///
     /// @example{atom/properties.cpp}
-    const property_map& properties() const {
+    const optional<property_map>& properties() const {
         return properties_;
     }
 
@@ -158,7 +159,10 @@ public:
     ///
     /// @example{atom/property.cpp}
     void set(std::string name, Property value) {
-        properties_.set(std::move(name), std::move(value));
+        if (!properties_) {
+            properties_ = property_map();
+        }
+        (*properties_).set(std::move(name), std::move(value));
     }
 
     /// Get the `Property` with the given `name` for this atom if it exists.
@@ -168,7 +172,10 @@ public:
     ///
     /// @example{atom/property.cpp}
     optional<const Property&> get(const std::string& name) const {
-        return properties_.get(name);
+        if (properties_) {
+            return (*properties_).get(name);
+        }
+        return nullopt;
     }
 
     /// Get the `Property` with the given `name` for this atom if it exists,
@@ -183,7 +190,10 @@ public:
     /// @example{atom/property.cpp}
     template<Property::Kind kind>
     optional<typename property_metadata<kind>::type> get(const std::string& name) const {
-        return properties_.get<kind>(name);
+        if (properties_) {
+            return (*properties_).get<kind>(name);
+        }
+        return nullopt;
     }
 
 private:
@@ -196,7 +206,7 @@ private:
     /// the atom charge
     double charge_ = 0;
     /// Additional properties of this atom
-    property_map properties_;
+    optional<property_map> properties_ = nullopt;
 
     friend bool operator==(const Atom& lhs, const Atom& rhs);
 };

--- a/src/capi/atom.cpp
+++ b/src/capi/atom.cpp
@@ -188,7 +188,12 @@ extern "C" chfl_status chfl_atom_properties_count(const CHFL_ATOM* const atom, u
     CHECK_POINTER(atom);
     CHECK_POINTER(count);
     CHFL_ERROR_CATCH(
-        *count = static_cast<uint64_t>(atom->properties().size());
+        if (atom->properties()) {
+            *count = static_cast<uint64_t>(atom->properties().value().size());
+        }
+        else {
+            *count = 0;
+        }
     )
 }
 
@@ -197,15 +202,21 @@ extern "C" chfl_status chfl_atom_list_properties(const CHFL_ATOM* const atom, co
     CHECK_POINTER(names);
     CHFL_ERROR_CATCH(
         auto& properties = atom->properties();
-        if (checked_cast(count) != properties.size()) {
+        size_t property_size = 0;
+        if (properties) {
+            property_size = (*properties).size();
+        }
+        if (checked_cast(count) != property_size) {
             set_last_error("wrong data size in function 'chfl_atom_list_properties'.");
             return CHFL_MEMORY_ERROR;
         }
 
-        size_t i = 0;
-        for (auto& it: properties) {
-            names[i] = it.first.c_str();
-            i++;
+        if (properties) {
+            size_t i = 0;
+            for (auto& it: *properties) {
+                names[i] = it.first.c_str();
+                i++;
+            }
         }
     )
 }

--- a/src/formats/CML.cpp
+++ b/src/formats/CML.cpp
@@ -596,10 +596,10 @@ void CMLFormat::write(const Frame& frame) {
         }
 
         auto& atom_properties = atom.properties();
-        if (!atom_properties.size()) {
+        if (!atom_properties) {
             continue;
         }
-        for (auto& prop : atom_properties) {
+        for (auto& prop : *atom_properties) {
             // special properties which are already written as attributes
             // charge and isotope are not stored as properties, so no need to check
             if (prop.first == "hydrogen_count" || prop.first == "title") {

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -331,29 +331,31 @@ properties_list_t get_atom_properties(const Frame& frame) {
     auto partially_defined_already_warned = std::set<std::string>();
 
     const auto& first_atom = frame[0];
-    for (const auto& property: first_atom.properties()) {
-        if (!is_valid_property_name(property.first)) {
-            warning(
-                "Extended XYZ", "'{}' is not a valid property name for extended "
-                "XYZ, is will not be saved",
-                property.first, 0
-            );
-            partially_defined_already_warned.insert(property.first);
-            continue;
-        }
-
-        if (property.second.kind() == Property::STRING) {
-            if (should_be_quoted(property.second.as_string())) {
+    if (first_atom.properties()) {
+        for (const auto& property: *first_atom.properties()) {
+            if (!is_valid_property_name(property.first)) {
                 warning(
-                    "Extended XYZ", "string value for property '{}' on atom {} "
-                    "can not be be saved as an atomic property",
+                    "Extended XYZ", "'{}' is not a valid property name for extended "
+                    "XYZ, is will not be saved",
                     property.first, 0
                 );
+                partially_defined_already_warned.insert(property.first);
                 continue;
             }
-        }
 
-        all_properties.emplace(property.first, property.second.kind());
+            if (property.second.kind() == Property::STRING) {
+                if (should_be_quoted(property.second.as_string())) {
+                    warning(
+                        "Extended XYZ", "string value for property '{}' on atom {} "
+                        "can not be be saved as an atomic property",
+                        property.first, 0
+                    );
+                    continue;
+                }
+            }
+
+            all_properties.emplace(property.first, property.second.kind());
+        }
     }
 
     for (size_t i=1; i<frame.size(); i++) {
@@ -387,9 +389,10 @@ properties_list_t get_atom_properties(const Frame& frame) {
             }
         }
 
-        if (atom.properties().size() > all_properties.size()) {
+        auto& atom_properties = atom.properties();
+        if (atom_properties && (*atom_properties).size() > all_properties.size()) {
             // warn for properties defined on this atom but not on others
-            for (const auto& property: atom.properties()) {
+            for (const auto& property: *atom.properties()) {
                 if (all_properties.count(property.first) == 0) {
                     if (partially_defined_already_warned.count(property.first) == 0) {
                         warning(

--- a/tests/atoms.cpp
+++ b/tests/atoms.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Use the Atom type") {
             std::tuple<std::string, Property>{"foo", "test"},
         };
         size_t i = 0;
-        for(auto it: atom.properties()) {
+        for(auto it: *atom.properties()) {
             CHECK(it.first == std::get<0>(expected[i]));
             CHECK(it.second == std::get<1>(expected[i]));
             i += 1;

--- a/tests/doc/atom/properties.cpp
+++ b/tests/doc/atom/properties.cpp
@@ -15,7 +15,7 @@ TEST_CASE() {
     atom.set("a number", 42.5);
 
     // Iterator over properties in the atom
-    for (auto it: atom.properties()) {
+    for (auto it: *atom.properties()) {
         if (it.first == "a string") {
             assert(it.second.as_string() == "this is a carbon");
         } else if (it.first == "a number") {


### PR DESCRIPTION
This makes the per-atom property map an optional field. Some (most?) formats don't make use of per-atom properties. Allocating the map for every atom nonetheless comes with quite some overhead. This is noticeable for frames with many atoms especially.

When reading 'ubiquitin.xtc' a ~11% speedup is observable (cf. [comparison to other implementations](https://github.com/chemfiles/benchmarks)).
For a `.nc` file with 50k atoms the speedup is ~19% for reading and ~7% for writing.

Ideally, this can be superseded by a more data-oriented approach as in #288.

This changes the user-facing API.


<details>
<summary>Benchmarking</summary>
R/W 1k steps with 50k atoms as `.nc` from C++ in a `tmpfs` ramdisk.

# master
```
Benchmark 1: ./bench_write
  Time (mean ± σ):     11.704 s ±  0.325 s    [User: 8.692 s, System: 3.004 s]
  Range (min … max):   10.672 s … 12.207 s    25 runs
 
Benchmark 1: ./bench_read
  Time (mean ± σ):      1.725 s ±  0.015 s    [User: 1.674 s, System: 0.050 s]
  Range (min … max):    1.697 s …  1.759 s    25 runs
```
# PR
```
Benchmark 1: ./bench_write
  Time (mean ± σ):     10.854 s ±  0.369 s    [User: 7.638 s, System: 3.209 s]
  Range (min … max):   10.102 s … 11.920 s    25 runs
 
Benchmark 1: ./bench_read
  Time (mean ± σ):      1.390 s ±  0.014 s    [User: 1.335 s, System: 0.054 s]
  Range (min … max):    1.370 s …  1.428 s    25 runs
```
</details>
