### PR TITLE
refactor(BinaryFile): swap and write binary data in buffered chunks

### DIFF
--- a/include/chemfiles/external/span.hpp
+++ b/include/chemfiles/external/span.hpp
@@ -64,7 +64,7 @@ public:
     }
 
     span(pointer data, size_type size): begin_(data), end_(data + size) {
-        assert(size == 0 ||(size > 0 && data != NULL));
+        assert(size == 0 ||(size > 0 && data != nullptr));
     }
 
     template< class U, size_t N >

--- a/include/chemfiles/files/BinaryFile.hpp
+++ b/include/chemfiles/files/BinaryFile.hpp
@@ -52,6 +52,12 @@ public:
     /// Seek to the specified `position` in the file
     void seek(uint64_t position);
 
+    /// Skip the next `count` Bytes in the file
+    void skip(uint64_t count);
+
+    /// Get the size of the file
+    uint64_t file_size();
+
     /// Read exactly `count` char, and store them in the `data` array
     void read_char(char* data, size_t count);
 

--- a/include/chemfiles/files/BinaryFile.hpp
+++ b/include/chemfiles/files/BinaryFile.hpp
@@ -265,6 +265,8 @@ public:
     void write_single_f64(double value) {
         this->write_f64(&value, 1);
     }
+protected:
+    std::vector<char> swap_buf_;
 
 private:
 #if CHEMFILES_BINARY_FILE_USE_MMAP
@@ -279,37 +281,6 @@ private:
 #else
     FILE* file_ = nullptr;
 #endif
-};
-
-class LittleEndianFile: public BinaryFile {
-public:
-    LittleEndianFile(std::string path, File::Mode mode): BinaryFile(std::move(path), mode) {}
-
-    virtual ~LittleEndianFile() override = default;
-
-    LittleEndianFile(const LittleEndianFile&) = delete;
-    LittleEndianFile& operator=(const LittleEndianFile&) = delete;
-
-    LittleEndianFile(LittleEndianFile&&) = default;
-    LittleEndianFile& operator=(LittleEndianFile&&) = default;
-
-    void read_i16(int16_t* data, size_t count) final override;
-    void read_u16(uint16_t* data, size_t count) final override;
-    void read_i32(int32_t* data, size_t count) final override;
-    void read_u32(uint32_t* data, size_t count) final override;
-    void read_i64(int64_t* data, size_t count) final override;
-    void read_u64(uint64_t* data, size_t count) final override;
-    void read_f32(float* data, size_t count) final override;
-    void read_f64(double* data, size_t count) final override;
-
-    void write_i16(const int16_t* data, size_t count) final override;
-    void write_u16(const uint16_t* data, size_t count) final override;
-    void write_i32(const int32_t* data, size_t count) final override;
-    void write_u32(const uint32_t* data, size_t count) final override;
-    void write_i64(const int64_t* data, size_t count) final override;
-    void write_u64(const uint64_t* data, size_t count) final override;
-    void write_f32(const float* data, size_t count) final override;
-    void write_f64(const double* data, size_t count) final override;
 };
 
 class BigEndianFile: public BinaryFile {
@@ -341,6 +312,43 @@ public:
     void write_u64(const uint64_t* data, size_t count) final override;
     void write_f32(const float* data, size_t count) final override;
     void write_f64(const double* data, size_t count) final override;
+private:
+    template<typename T> inline void read_as_big_endian(T* data, size_t count);
+    template<typename T> inline void write_as_big_endian(const T* data, size_t count);
+};
+
+class LittleEndianFile: public BinaryFile {
+public:
+    LittleEndianFile(std::string path, File::Mode mode): BinaryFile(std::move(path), mode) {}
+
+    virtual ~LittleEndianFile() override = default;
+
+    LittleEndianFile(const LittleEndianFile&) = delete;
+    LittleEndianFile& operator=(const LittleEndianFile&) = delete;
+
+    LittleEndianFile(LittleEndianFile&&) = default;
+    LittleEndianFile& operator=(LittleEndianFile&&) = default;
+
+    void read_i16(int16_t* data, size_t count) final override;
+    void read_u16(uint16_t* data, size_t count) final override;
+    void read_i32(int32_t* data, size_t count) final override;
+    void read_u32(uint32_t* data, size_t count) final override;
+    void read_i64(int64_t* data, size_t count) final override;
+    void read_u64(uint64_t* data, size_t count) final override;
+    void read_f32(float* data, size_t count) final override;
+    void read_f64(double* data, size_t count) final override;
+
+    void write_i16(const int16_t* data, size_t count) final override;
+    void write_u16(const uint16_t* data, size_t count) final override;
+    void write_i32(const int32_t* data, size_t count) final override;
+    void write_u32(const uint32_t* data, size_t count) final override;
+    void write_i64(const int64_t* data, size_t count) final override;
+    void write_u64(const uint64_t* data, size_t count) final override;
+    void write_f32(const float* data, size_t count) final override;
+    void write_f64(const double* data, size_t count) final override;
+private:
+    template<typename T> inline void read_as_little_endian(T* data, size_t count);
+    template<typename T> inline void write_as_little_endian(const T* data, size_t count);
 };
 
 }

--- a/src/files/BinaryFile.cpp
+++ b/src/files/BinaryFile.cpp
@@ -416,25 +416,22 @@ inline uint64_t u64_from_big_endian(char buffer[8]) {
     return value;
 }
 
-inline void u16_to_big_endian(uint16_t value, char buffer[2]) {
+inline void u16_to_big_endian(uint16_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_LITTLE_ENDIAN
     value = swap_u16(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint16_t));
 }
 
-inline void u32_to_big_endian(uint32_t value, char buffer[4]) {
+inline void u32_to_big_endian(uint32_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_LITTLE_ENDIAN
     value = swap_u32(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint32_t));
 }
 
-inline void u64_to_big_endian(uint64_t value, char buffer[8]) {
+inline void u64_to_big_endian(uint64_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_LITTLE_ENDIAN
     value = swap_u64(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint64_t));
 }
 
 void BigEndianFile::read_i16(int16_t* data, size_t count) {
@@ -514,76 +511,82 @@ void BigEndianFile::read_f64(double* data, size_t count) {
 }
 
 void BigEndianFile::write_i16(const int16_t* data, size_t count) {
-    char buffer[sizeof(int16_t)];
     uint16_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int16_t));
-        u16_to_big_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int16_t));
+        u16_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int16_t));
     }
 }
 
 void BigEndianFile::write_u16(const uint16_t* data, size_t count) {
-    char buffer[sizeof(uint16_t)];
+    uint16_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u16_to_big_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint16_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint16_t));
+        u16_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint16_t));
     }
 }
 
 void BigEndianFile::write_i32(const int32_t* data, size_t count) {
-    char buffer[sizeof(int32_t)];
     uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int32_t));
-        u32_to_big_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int32_t));
+        u32_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int32_t));
     }
 }
 
 void BigEndianFile::write_u32(const uint32_t* data, size_t count) {
-    char buffer[sizeof(uint32_t)];
+    uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u32_to_big_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint32_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint32_t));
+        u32_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint32_t));
     }
 }
 
 void BigEndianFile::write_i64(const int64_t* data, size_t count) {
-    char buffer[sizeof(int64_t)];
     uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int64_t));
-        u64_to_big_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int64_t));
+        u64_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int64_t));
     }
 }
 
 void BigEndianFile::write_u64(const uint64_t* data, size_t count) {
-    char buffer[sizeof(uint64_t)];
+    uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u64_to_big_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint64_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint64_t));
+        u64_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint64_t));
     }
 }
 
 void BigEndianFile::write_f32(const float* data, size_t count) {
-    char buffer[sizeof(float)];
     uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(float));
-        u32_to_big_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(float));
+        u32_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(float));
     }
 }
 
 void BigEndianFile::write_f64(const double* data, size_t count) {
-    char buffer[sizeof(double)];
     uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(double));
-        u64_to_big_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(double));
+        u64_to_big_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(double));
     }
 }
 
@@ -617,25 +620,22 @@ inline uint64_t u64_from_little_endian(char buffer[8]) {
     return value;
 }
 
-inline void u16_to_little_endian(uint16_t value, char buffer[2]) {
+inline void u16_to_little_endian(uint16_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_BIG_ENDIAN
     value = swap_u16(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint16_t));
 }
 
-inline void u32_to_little_endian(uint32_t value, char buffer[4]) {
+inline void u32_to_little_endian(uint32_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_BIG_ENDIAN
     value = swap_u32(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint32_t));
 }
 
-inline void u64_to_little_endian(uint64_t value, char buffer[8]) {
+inline void u64_to_little_endian(uint64_t& value) {
 #if CHEMFILES_BYTE_ORDER == CHEMFILES_BIG_ENDIAN
     value = swap_u64(value);
 #endif
-    std::memcpy(buffer, &value, sizeof(uint64_t));
 }
 
 
@@ -716,75 +716,81 @@ void LittleEndianFile::read_f64(double* data, size_t count) {
 }
 
 void LittleEndianFile::write_i16(const int16_t* data, size_t count) {
-    char buffer[sizeof(int16_t)];
     uint16_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int16_t));
-        u16_to_little_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int16_t));
+        u16_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int16_t));
     }
 }
 
 void LittleEndianFile::write_u16(const uint16_t* data, size_t count) {
-    char buffer[sizeof(uint16_t)];
+    uint16_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u16_to_little_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint16_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint16_t));
+        u16_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint16_t));
     }
 }
 
 void LittleEndianFile::write_i32(const int32_t* data, size_t count) {
-    char buffer[sizeof(int32_t)];
     uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int32_t));
-        u32_to_little_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int32_t));
+        u32_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int32_t));
     }
 }
 
 void LittleEndianFile::write_u32(const uint32_t* data, size_t count) {
-    char buffer[sizeof(uint32_t)];
+    uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u32_to_little_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint32_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint32_t));
+        u32_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint32_t));
     }
 }
 
 void LittleEndianFile::write_i64(const int64_t* data, size_t count) {
-    char buffer[sizeof(int64_t)];
     uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(int64_t));
-        u64_to_little_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(int64_t));
+        u64_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(int64_t));
     }
 }
 
 void LittleEndianFile::write_u64(const uint64_t* data, size_t count) {
-    char buffer[sizeof(uint64_t)];
+    uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
-        u64_to_little_endian(data[i], buffer);
-        this->write_char(buffer, sizeof(uint64_t));
+        std::memcpy(&unsigned_value, data + i, sizeof(uint64_t));
+        u64_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(uint64_t));
     }
 }
 
 void LittleEndianFile::write_f32(const float* data, size_t count) {
-    char buffer[sizeof(float)];
     uint32_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(float));
-        u32_to_little_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(float));
+        u32_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(float));
     }
 }
 
 void LittleEndianFile::write_f64(const double* data, size_t count) {
-    char buffer[sizeof(double)];
     uint64_t unsigned_value;
+    auto value_ptr = reinterpret_cast<char*>(&unsigned_value);
     for (size_t i=0; i<count; i++) {
         std::memcpy(&unsigned_value, data + i, sizeof(double));
-        u64_to_little_endian(unsigned_value, buffer);
-        this->write_char(buffer, sizeof(double));
+        u64_to_little_endian(unsigned_value);
+        this->write_char(value_ptr, sizeof(double));
     }
 }

--- a/src/files/BinaryFile.cpp
+++ b/src/files/BinaryFile.cpp
@@ -218,10 +218,17 @@ void BinaryFile::read_char(char* data, size_t count) {
     offset_ += count;
 #else
     auto read = std::fread(data, 1, count, file_);
+    const char* error_info = "unknown cause";
     if (read != count) {
+        if (feof(file_)) {
+            error_info = "reached end of file";
+        }
+        else if (ferror(file_)) {
+            error_info = std::strerror(errno);
+        }
         throw file_error(
             "failed to read {} bytes from the file at '{}': {}",
-            count, this->path(), std::strerror(errno)
+            count, this->path(), error_info
         );
     }
 #endif

--- a/src/files/Netcdf3File.cpp
+++ b/src/files/Netcdf3File.cpp
@@ -477,9 +477,8 @@ Netcdf3File::~Netcdf3File() {
 }
 
 void Netcdf3File::skip_padding(int64_t size) {
-    for (int64_t i=0; i<padding(size); i++){
-        this->read_single_char();
-    }
+    const auto count = static_cast<uint64_t>(padding(size));
+    this->skip(count);
 }
 
 void Netcdf3File::add_padding(int64_t size) {

--- a/src/formats/CML.cpp
+++ b/src/formats/CML.cpp
@@ -86,11 +86,7 @@ void CMLFormat::init_() {
         return;
     }
 
-    std::string content;
-    while (!file_.eof()) {
-        auto line = file_.readline();
-        content.append(line.data(), line.size());
-    }
+    auto content = file_.readall();
 
     auto result = document_.load_string(content.c_str());
     if (!result) {

--- a/tests/files/binary-files.cpp
+++ b/tests/files/binary-files.cpp
@@ -76,15 +76,29 @@ static void check_read_binary_file(BinaryFile& file) {
     CHECK_BINARY_ARRAY(f64);
 }
 
+static void check_read_skip_binary_file(BinaryFile& file) {
+    file.seek(0L);
+    file.skip(7L);
+    CHECK(file.read_single_u16() == 42);
+    file.skip(8L);
+    CHECK(file.read_single_i64() == -123456);
+    file.skip(341L); // -88B (10*f64 + 2*f32) from end
+    CHECK(file.read_single_f32() == 8.0f);
+}
+
 TEST_CASE("Read binary files") {
     SECTION("big endian") {
         auto file = BigEndianFile("data/misc/big-endian.dat", File::Mode::READ);
+        CHECK(file.file_size() == 454);
         check_read_binary_file(file);
+        check_read_skip_binary_file(file);
     }
 
     SECTION("little endian") {
         auto file = LittleEndianFile("data/misc/little-endian.dat", File::Mode::READ);
+        CHECK(file.file_size() == 454);
         check_read_binary_file(file);
+        check_read_skip_binary_file(file);
     }
 }
 
@@ -116,12 +130,15 @@ TEST_CASE("Write binary files") {
             0x42, 0x5, 0x33, 0x33,
             0xc0, 0x4b, 0xe6, 0x66, 0x66, 0x66, 0x66, 0x66
         };
+        auto expected_2 = expected;
+        expected_2.insert(expected_2.end(), expected.begin(), expected.end());
 
         SECTION("write to file") {
             auto filename = NamedTempPath(".data");
             {
                 auto file = BigEndianFile(filename, File::Mode::WRITE);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);
@@ -133,6 +150,7 @@ TEST_CASE("Write binary files") {
             {
                 auto file = BigEndianFile(filename, File::Mode::WRITE);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);
@@ -141,11 +159,10 @@ TEST_CASE("Write binary files") {
             {
                 auto file = BigEndianFile(filename, File::Mode::APPEND);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected_2.size());
             }
 
             content = read_binary_file(filename);
-            auto expected_2 = expected;
-            expected_2.insert(expected_2.end(), expected.begin(), expected.end());
             CHECK(content == expected_2);
         }
 
@@ -154,6 +171,7 @@ TEST_CASE("Write binary files") {
             {
                 auto file = BigEndianFile(filename, File::Mode::APPEND);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);
@@ -173,12 +191,15 @@ TEST_CASE("Write binary files") {
             0x33, 0x33, 0x5,  0x42,
             0x66, 0x66, 0x66, 0x66, 0x66, 0xe6, 0x4b, 0xc0,
         };
+        auto expected_2 = expected;
+        expected_2.insert(expected_2.end(), expected.begin(), expected.end());
 
         SECTION("write to file") {
             auto filename = NamedTempPath(".data");
             {
                 auto file = LittleEndianFile(filename, File::Mode::WRITE);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);
@@ -190,6 +211,7 @@ TEST_CASE("Write binary files") {
             {
                 auto file = LittleEndianFile(filename, File::Mode::WRITE);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);
@@ -198,11 +220,10 @@ TEST_CASE("Write binary files") {
             {
                 auto file = LittleEndianFile(filename, File::Mode::APPEND);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected_2.size());
             }
 
             content = read_binary_file(filename);
-            auto expected_2 = expected;
-            expected_2.insert(expected_2.end(), expected.begin(), expected.end());
             CHECK(content == expected_2);
         }
 
@@ -211,6 +232,7 @@ TEST_CASE("Write binary files") {
             {
                 auto file = LittleEndianFile(filename, File::Mode::APPEND);
                 write_binary_file(file);
+                CHECK(file.file_size() == expected.size());
             }
 
             auto content = read_binary_file(filename);

--- a/tests/files/binary-files.cpp
+++ b/tests/files/binary-files.cpp
@@ -74,6 +74,8 @@ static void check_read_binary_file(BinaryFile& file) {
     double f64[10];
     file.read_f64(f64, 10);
     CHECK_BINARY_ARRAY(f64);
+
+    CHECK_THROWS_AS(file.read_single_char(), FileError);
 }
 
 static void check_read_skip_binary_file(BinaryFile& file) {


### PR DESCRIPTION
I'm currently in the process of rewriting the XTC and TRR parser based on the new `BinaryFile`.
While doing so, I couldn't reach the _writing_ speed obtained with `xdrfile`.
These formats frequently write large chunks of data (e.g. the position array) at once.
Before this PR, this involved a lot of overhead for swapping and writing individual values.
By using a buffer for swapping and writing, these chunks can be written at once without that much overhead.

For XTC/TRR it's also helpful to skip larger chunks of data without parsing it and to get the file size.
This PR introduces two functions for that in `BinaryFile`.

Besides this, there are also some misc changes:

 - Some minor adaptations in the CML parser and `span`.
 - Use the new skip function to skip the padding in NetCDF files.
 - Fix the exception strings for reading a `BinaryFile`.
 It seems that `fread` does not make use of `errno` (at least on my Linux machine) when reading beyond EOF.
 This results in error messages ending in 'Success' which in a bit confusing.

Some preliminary benchmarks show that the NetCDF R/W performance does not deteriorate.
Unfortunately, the NetCDF parser based on `mmap` does not really benefit from this PR because mostly single values are written. (Might be interesting to see if an buffered file stream would be beneficial.)
Interestingly, the `cstdio` version closes the gap to the `mmap` version.

<details>
<summary>Benchmarking</summary>
R/W 1k steps with 50k atoms as `.nc` from C++ in a `tmpfs` ramdisk.

# mmap
## write
### master
```
  Time (mean ± σ):     11.590 s ±  0.414 s    [User: 8.584 s, System: 2.999 s]
  Range (min … max):   10.661 s … 12.093 s    25 runs
```
### PR
```
  Time (mean ± σ):     11.033 s ±  0.374 s    [User: 8.182 s, System: 2.844 s]
  Range (min … max):   10.223 s … 11.580 s    25 runs
```
## read
### master
```
  Time (mean ± σ):      1.750 s ±  0.030 s    [User: 1.703 s, System: 0.046 s]
  Range (min … max):    1.702 s …  1.806 s    25 runs
```
### PR
```
  Time (mean ± σ):      1.749 s ±  0.032 s    [User: 1.701 s, System: 0.048 s]
  Range (min … max):    1.705 s …  1.808 s    25 runs
```
# cstdio
## write
### master
```
  Time (mean ± σ):     12.803 s ±  0.321 s    [User: 9.673 s, System: 3.121 s]
  Range (min … max):   11.911 s … 13.302 s    25 runs
```
### PR
```
  Time (mean ± σ):     11.140 s ±  0.325 s    [User: 8.102 s, System: 3.032 s]
  Range (min … max):   10.083 s … 11.614 s    25 runs
```
## read
### master
```
  Time (mean ± σ):      1.745 s ±  0.025 s    [User: 1.625 s, System: 0.119 s]
  Range (min … max):    1.690 s …  1.829 s    25 runs
```
### PR
```
  Time (mean ± σ):      1.731 s ±  0.026 s    [User: 1.608 s, System: 0.122 s]
  Range (min … max):    1.698 s …  1.810 s    25 runs
```
</details>
