### PR TITLE
Fix writing of unit cells with negative values in extended XYZ

### DIFF
--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -247,7 +247,7 @@ std::string write_extended_comment_line(const Frame& frame, properties_list_t pr
         // set small elements to 0
         for (size_t i=0; i<3; i++) {
             for (size_t j=0; j<3; j++) {
-                if (matrix[i][j] < 1e-12) {
+                if (std::abs(matrix[i][j]) < 1e-12) {
                     matrix[i][j] = 0;
                 }
             }

--- a/tests/formats/xyz.cpp
+++ b/tests/formats/xyz.cpp
@@ -367,3 +367,25 @@ H 0.332 8.726 10.882
 
     CHECK(writer.memory_buffer().value() == EXPECTED);
 }
+
+
+TEST_CASE("Triclinic cell with negative values (issue 449)") {
+    auto matrix = Matrix3D(
+        6.92395,  -3.22455, 0.0000,
+        0.00000,   5.45355, 0.0000,
+        0.100667, -3.32057, 7.2836
+    );
+    auto frame = Frame(UnitCell(matrix));
+    frame.resize(1);
+
+    auto writer = Trajectory::memory_writer("XYZ");
+    writer.write(frame);
+
+    std::string EXPECTED =
+R"(1
+Properties=species:S:1:pos:R:3 Lattice="6.92395 0 0.100667 -3.22455 5.45355 -3.32057 0 0 7.2836"
+X 0 0 0
+)";
+
+    CHECK(writer.memory_buffer().value() == EXPECTED);
+}


### PR DESCRIPTION
Fix #449 

I failed to consider that the entries in unit cell matrix can be negative.