### PR TITLE
Fix cursor position in text files and add unwrapped property to LAMMPS

### DIFF
--- a/doc/ext/chfl_selection.py
+++ b/doc/ext/chfl_selection.py
@@ -11,7 +11,7 @@ class ChemfilesSelection(Directive):
         self.assert_has_content()
 
         node = nodes.admonition('\n'.join(self.content))
-        node.set_class("chemfiles-selection")
+        node['classes'].append('chemfiles-selection')
 
         title_text = self.arguments[0]
         textnodes, _ = self.state.inline_text(title_text, self.lineno)

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -54,7 +54,7 @@ LAMMPS = "Style of units used by LAMMPS for a simulation."
 [xtc_precision]
 type = "number"
 
-XTC = """The precision used to compress the coordinates. Only used for ten or more atoms. Default is 1000."""
+XTC = "The precision used to compress the coordinates. Only used for ten or more atoms. Default is 1000."
 
 [has_positions]
 type = "bool"
@@ -65,3 +65,8 @@ TRR = "Set to ``true`` if the frame contains positions. All positions are zero i
 type = "number"
 
 TRR = "This is usually the free energy coupling parameter."
+
+[is_unwrapped]
+type = "bool"
+
+LAMMPS = "Indicates whether the frame contains unwrapped positions. Only set when reading a file."

--- a/examples/c/indexes.c
+++ b/examples/c/indexes.c
@@ -26,7 +26,7 @@ int main(void) {
 
     printf("Atoms with x < 5:\n");
     for (size_t i=0; i<matched; i++) {
-        printf("  - %lu", less_than_five[i]);
+        printf("  - %zu", less_than_five[i]);
     }
 
     free(less_than_five);

--- a/include/chemfiles/Format.hpp
+++ b/include/chemfiles/Format.hpp
@@ -129,6 +129,9 @@ private:
     /// Scan the whole file to get all the steps positions
     void scan_all();
 
+    /// The next step to read
+    size_t step_ = 0;
+
     /// Storing the positions of all the steps in the file, so that we can
     /// just `seekpos` them instead of reading the whole step.
     std::vector<uint64_t> steps_positions_;

--- a/include/chemfiles/external/string_view.hpp
+++ b/include/chemfiles/external/string_view.hpp
@@ -39,7 +39,7 @@
 #endif
 
 #ifndef  nssv_CONFIG_USR_SV_OPERATOR
-# define nssv_CONFIG_USR_SV_OPERATOR  1
+# define nssv_CONFIG_USR_SV_OPERATOR  0
 #endif
 
 #ifdef   nssv_CONFIG_CONVERSION_STD_STRING

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -130,17 +130,21 @@ void TextFormat::read_step(size_t step, Frame& frame) {
         }
     }
 
+    step_ = step;
     file_.seekpos(steps_positions_[step]);
     read_next(frame);
 }
 
 void TextFormat::read(Frame& frame) {
+    file_.seekpos(steps_positions_[step_]);
+    ++step_;
     read_next(frame);
 }
 
 void TextFormat::write(const Frame& frame) {
     write_next(frame);
     steps_positions_.push_back(file_.tellpos());
+    ++step_;
 }
 
 size_t TextFormat::nsteps() {

--- a/src/formats/DCD.cpp
+++ b/src/formats/DCD.cpp
@@ -162,8 +162,8 @@ void DCDFormat::read_step(size_t step, Frame& frame) {
 
     // set frame properties
     if (timesteps_.dt != 0.0 && timesteps_.step != 0) {
-        auto step = static_cast<double>(timesteps_.step * step_ + timesteps_.start);
-        frame.set("time", timesteps_.dt * step);
+        auto simulation_step = static_cast<double>(timesteps_.step * step_ + timesteps_.start);
+        frame.set("time", timesteps_.dt * simulation_step);
     }
 
     if (!title_.empty()) {

--- a/src/formats/LAMMPSTrajectory.cpp
+++ b/src/formats/LAMMPSTrajectory.cpp
@@ -551,6 +551,13 @@ void LAMMPSTrajectoryFormat::read_next(Frame& frame) {
             unwrap(positions[i], (*images)[i], matrix);
         }
     }
+
+    if (use_pos_repr == UNWRAPPED || use_pos_repr == SCALED_UNWRAPPED || images) {
+        frame.set("is_unwrapped", true);
+    }
+    else {
+        frame.set("is_unwrapped", false);
+    }
 }
 
 static optional<size_t> parse_lammps_type(const std::string& type_str) {

--- a/tests/formats/lammps-trajectory.cpp
+++ b/tests/formats/lammps-trajectory.cpp
@@ -30,6 +30,8 @@ static void check_pos_representation(Trajectory& file) {
     CHECK(frame[5000].type() == "2");
     CHECK(frame[5000].name() == "C");
 
+    CHECK(frame.get("is_unwrapped").value().as_bool());
+
     frame = file.read_step(5);
     CHECK(frame.size() == 7751);
 
@@ -40,6 +42,8 @@ static void check_pos_representation(Trajectory& file) {
     velocities = *frame.velocities();
     CHECK(approx_eq(velocities[5000], Vector3D(-0.00404259, -0.000939097, 0.0152453), 1e-7));
     CHECK(approx_eq(velocities[7000], Vector3D(0.00122365, 0.0100476, -0.0167459), 1e-7));
+
+    CHECK(frame.get("is_unwrapped").value().as_bool());
 
     CHECK_THROWS_AS(file.read_step(11), FileError);
 }
@@ -57,6 +61,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(positions[1189], Vector3D(116.829, 91.2404, 79.8858), eps));
         // this one has a non zero image index (2 1 -3)
         CHECK(approx_eq(positions[1327], Vector3D(173.311, 87.853, 109.417), eps));
+
+        CHECK(frame.get("is_unwrapped").value().as_bool());
     }
 
     SECTION("NaCl") {
@@ -71,6 +77,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         auto velocities = *frame.velocities();
         CHECK(approx_eq(velocities[0], Vector3D(-0.00258494, 0.00270859, -0.00314039), 1e-7));
         CHECK(approx_eq(velocities[222], Vector3D(-0.00466812, -0.00196397, -0.000147051), 1e-7));
+
+        CHECK(!frame.get("is_unwrapped").value().as_bool());
 
         frame = file.read_step(5);
         CHECK(frame.size() == 512);
@@ -121,6 +129,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(positions[679], Vector3D(1.47679, -25.2886, 2.38234), 1e-3));
         CHECK(approx_eq(positions[764], Vector3D(-256.58, 117.368, 1.9654), 1e-3));
 
+        CHECK(frame.get("is_unwrapped").value().as_bool());
+
         frame = file.read();
         CHECK(frame.size() == 854);
         CHECK(frame.step() == 101000);
@@ -134,6 +144,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(positions[683], Vector3D(-43.3683, 322.948, 208.063), 1e-3));
         CHECK(approx_eq(positions[828], Vector3D(150.083, -135.113, 189.641), 1e-3));
 
+        CHECK(frame.get("is_unwrapped").value().as_bool());
+
         frame = file.read();
         CHECK(frame.size() == 856);
         CHECK(frame.step() == 102000);
@@ -141,6 +153,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         positions = frame.positions();
         CHECK(approx_eq(positions[747], Vector3D(-158.317, 142.593, 2.11392), 1e-3));
         CHECK(approx_eq(positions[799], Vector3D(224.784, -167.878, 39.3765), 1e-3));
+
+        CHECK(frame.get("is_unwrapped").value().as_bool());
 
         frame = file.read();
         CHECK(frame.size() == 856);
@@ -150,6 +164,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(positions[735], Vector3D(67.2657, 30.0627, 2.1141), 1e-3));
         CHECK(approx_eq(positions[775], Vector3D(125.347, -82.3507, 46.611), 1e-3));
 
+        CHECK(frame.get("is_unwrapped").value().as_bool());
+
         frame = file.read();
         CHECK(frame.size() == 856);
         CHECK(frame.step() == 104000);
@@ -157,6 +173,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         positions = frame.positions();
         CHECK(approx_eq(positions[652], Vector3D(-188.131, 96.0777, 196.23), 1e-3));
         CHECK(approx_eq(positions[838], Vector3D(-33.6068, -50.5113, 209.306), 1e-3));
+
+        CHECK(frame.get("is_unwrapped").value().as_bool());
 
         CHECK_THROWS_AS(file.read(), FileError);
     }
@@ -181,6 +199,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(frame[789].get("v_sq_pos")->as_double(), 283.642, 1e-3));
         CHECK(approx_eq(frame[789].get("i_flag")->as_double(), 0.0, 1e-12));
 
+        CHECK(!frame.get("is_unwrapped").value().as_bool());
+
         frame = file.read_step(3);
         CHECK(frame.size() == 4000);
         CHECK(frame.step() == 300);
@@ -196,6 +216,8 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         CHECK(approx_eq(frame[3905].get("c_stress[2]")->as_double(), -67.6015, 1e-3));
         CHECK(approx_eq(frame[3905].get("v_sq_pos")->as_double(), 345.766, 1e-3));
         CHECK(approx_eq(frame[3905].get("i_flag")->as_double(), 0.0, 1e-12));
+
+        CHECK(!frame.get("is_unwrapped").value().as_bool());
 
     }
 

--- a/tests/formats/lammps-trajectory.cpp
+++ b/tests/formats/lammps-trajectory.cpp
@@ -218,30 +218,34 @@ TEST_CASE("Read files in LAMMPS Atom format") {
         );
 
         file = Trajectory("data/lammps/bad/box-not-numbers.lammpstrj");
+        CHECK(file.nsteps() == 3);
         CHECK_THROWS_WITH(
-            file.read_step(0),
+            file.read(),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 2 but got 1"
         );
         CHECK_THROWS_WITH(
             file.read_step(1),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 2 but got 1"
         );
+        // read a step after an exception was thrown
         CHECK_THROWS_WITH(
-            file.read_step(2),
+            file.read(),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 2 but got 1"
         );
 
         file = Trajectory("data/lammps/bad/box-wrong-size.lammpstrj");
+        CHECK(file.nsteps() == 3);
         CHECK_THROWS_WITH(
-            file.read_step(0),
+            file.read(),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 3 but got 2"
         );
         CHECK_THROWS_WITH(
             file.read_step(1),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 3 but got 2"
         );
+        // read a step after an exception was thrown
         CHECK_THROWS_WITH(
-            file.read_step(2),
+            file.read(),
             "can not read box header in LAMMPS format: incomplete box dimensions in LAMMPS format, expected 3 but got 2"
         );
 

--- a/tests/parse.cpp
+++ b/tests/parse.cpp
@@ -206,7 +206,7 @@ TEST_CASE("scan") {
     );
 }
 
-static void recycle(uint64_t width, int64_t value, const std::string& hybrid) {
+static void recycle(size_t width, int64_t value, const std::string& hybrid) {
     CHECK(chemfiles::encode_hybrid36(width, value) == hybrid);
     CHECK(chemfiles::decode_hybrid36(width, hybrid) == value);
 }

--- a/tests/selection.cpp
+++ b/tests/selection.cpp
@@ -1,6 +1,7 @@
 // Chemfiles, a modern library for chemistry file reading and writing
 // Copyright (C) Guillaume Fraux and contributors -- BSD license
-#include <catch.hpp>
+#include "catch.hpp"
+#include "helpers.hpp"
 #include "chemfiles.hpp"
 using namespace chemfiles;
 
@@ -293,7 +294,7 @@ TEST_CASE("Atoms selections") {
         frame.add_atom(Atom("Cl"), {0, 0, 0});
         frame.add_atom(Atom("F"), {2, -2, 2});
 
-        Trajectory("tmp.pdb", 'w').write(frame);
+        Trajectory(NamedTempPath(".pdb"), 'w').write(frame);
 
         selection = Selection("four: dihedral(#1, #2, #3, #4) > deg2rad(120) and name(#1) H1 and name(#2) Cl");
         expected = std::vector<Match>{


### PR DESCRIPTION
This fixes #442 by adding the frame property `is_unwrapped` to the LAMMPS trajectory reader. This boolean property is always set when reading.
Also, this fixes #398 (at least for text files) by advancing the cursor before reading (and parsing) of a frame. It's possible to read the next frame after an (parsing) exception, as long as the initial scanning of frame offsets works without an error.
As stated in the issue, I think this is most important for text files because they can be easily edited by hand which may introduce inconsistencies.

Additionally, there are some minor changes to suppress compiler warnings. Notably, Clang doesn't like the string literal `_sv`, so this option is disabled in the cmake config.