### PR TITLE
feat: TPR reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   them sorted by the associated key.
 - added `chemfiles::guess_format` and `chfl_guess_format` to get the format
   chemfiles would use for a given file based on its filename
+- Added read support for GROMACS TPR format.
 
 ### Changes in supported formats
 

--- a/doc/src/properties/atom.toml
+++ b/doc/src/properties/atom.toml
@@ -70,3 +70,10 @@ SMI = "Sets if the atom was defined as a wildcard card atom."
 type = "number"
 
 Tinker = "The Tinker atom type."
+
+[ff_type]
+type = "string"
+
+TPR = """Describes the atom type specified in the ``[atoms]`` section of the
+topology. The type can be used to reference a specific set of force field
+parameters for a given atom."""

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -11,6 +11,7 @@ MOL2 = "The first line after ``@<TRIPOS>MOLECULE`` is used as the frame **name**
 MMTF = "The text in the ``title`` field is used as the frame **name** when reading."
 mmCIF = "The text in the ``_struct.title`` field is used as the frame **name** when reading."
 SMI = "Any string after a terminating (blank) character in a SMILES string."
+TPR = "Name of the system as declared in the ``[system]`` section of the TOP file."
 
 [classification]
 type = "string"

--- a/include/chemfiles/files/BinaryFile.hpp
+++ b/include/chemfiles/files/BinaryFile.hpp
@@ -1,10 +1,11 @@
 #ifndef CHEMFILES_BINARY_FILE
 #define CHEMFILES_BINARY_FILE
 
-#include <vector>
-#include <string>
 #include <cstdint>
-#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include "chemfiles/config.h"
 #include "chemfiles/File.hpp"

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "chemfiles/UnitCell.hpp"
+
 #include "chemfiles/files/BinaryFile.hpp"
 
 namespace chemfiles {
@@ -37,6 +39,9 @@ class XDRFile final : public BigEndianFile {
     float read_gmx_compressed_floats(std::vector<float>& data);
     /// Write compressed GROMACS floats with a given precision
     void write_gmx_compressed_floats(const std::vector<float>& data, float precision);
+
+    /// Read the GROMACS simulation box in nano meters
+    UnitCell read_gmx_box(bool use_double = false);
 
   private:
     /// Read XDR variable-length opaque data

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -27,6 +27,7 @@ class XDRFile final : public BigEndianFile {
 
     using BinaryFile::read_f32;
     using BinaryFile::read_f64;
+    using BinaryFile::read_i32;
     using BinaryFile::write_f32;
 
     /// Read a non-compliant GROMACS string

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -4,9 +4,11 @@
 #ifndef CHEMFILES_XDR_FILE_HPP
 #define CHEMFILES_XDR_FILE_HPP
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
+#include "chemfiles/File.hpp"
 #include "chemfiles/UnitCell.hpp"
 
 #include "chemfiles/files/BinaryFile.hpp"

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -43,6 +43,9 @@ class XDRFile final : public BigEndianFile {
     /// Read the GROMACS simulation box in nano meters
     UnitCell read_gmx_box(bool use_double = false);
 
+    /// Read an unsigned size value as i32 by performing a checked conversion
+    size_t read_single_size_as_i32();
+
   private:
     /// Read XDR variable-length opaque data
     void read_opaque(std::vector<char>& data);

--- a/include/chemfiles/formats/TPR.hpp
+++ b/include/chemfiles/formats/TPR.hpp
@@ -1,0 +1,109 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#ifndef CHEMFILES_TPR_FORMAT_HPP
+#define CHEMFILES_TPR_FORMAT_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "chemfiles/File.hpp"
+#include "chemfiles/Format.hpp"
+
+#include "chemfiles/files/XDRFile.hpp"
+
+namespace chemfiles {
+class Frame;
+class FormatMetadata;
+
+/// GROMACS TPR file format reader.
+/// The reader closely follows the original GROMACS implementation
+/// and often refers to specific files in the GROMACS repository.
+/// In the following, the repository path is abbreviated as
+/// <GMX> := https://gitlab.com/gromacs/gromacs/-/tree/v2022.2
+class TPRFormat final : public Format {
+  public:
+    TPRFormat(std::string path, File::Mode mode, File::Compression compression);
+
+    void read_step(size_t step, Frame& frame) override;
+    void read(Frame& frame) override;
+    size_t nsteps() override;
+
+  private:
+    // Since GROMACS 2020 (TPR version 119) the way the body is deserialized changes.
+    // For `FileIOXdr` see <GMX>/src/gromacs/fileio/gmxfio_xdr.cpp
+    // and <GMX>/src/gromacs/fileio/gmx_internal_xdr.cpp
+    // Deviations from the XDR specification:
+    //  - uses `read_gmx_string()` from XDRFile
+    //  - stores unsigned char as u32
+    //  - stores unsigned short as u32
+    //  - stores bool as i32
+    // For `InMemory` see <GMX>/src/gromacs/utility/inmemoryserializer.cpp
+    // Deviations from the XDR specification:
+    //  - uses a different string serializer
+    //  - stores bool as u8
+    enum TprBodyConvention {
+        FileIOXdr,
+        InMemory,
+    };
+
+    /// The header contains information about the general aspect of the system.
+    /// see `TpxFileHeader` in <GMX>/api/legacy/include/gromacs/fileio/tpxio.h
+    struct TprHeader {
+        /// Indicates if input record is present
+        bool has_input_record = false;
+        /// Indicates if a box is present
+        bool has_box = false;
+        /// Indicates if a topology is present
+        bool has_topology = false;
+        /// Indicates if coordinates are present
+        bool has_positions = false;
+        /// Indicates if velocities are present
+        bool has_velocities = false;
+        /// Indicates if forces are present
+        /// No longer supported, but retained so old TPR can be read
+        bool has_forces = false;
+        /// The total number of atoms
+        size_t natoms = 0;
+        /// The number of temperature coupling groups
+        size_t ngroups_temperature_coupling = 0;
+        /// Current value of lambda
+        double lambda = 0;
+        /// File version
+        int file_version = 0;
+        /// File generation
+        int file_generation = 0;
+        /// If the TPR file was written in double precision
+        bool use_double = false;
+        /// Size of real values in bytes, depends on `use_double`
+        size_t sizeof_real;
+        /// Version-dependent serializer used for the body
+        TprBodyConvention body_convention = FileIOXdr;
+    };
+
+    /// Read the file header
+    /// see `do_tpxheader()` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    TprHeader read_header();
+
+    /// Read box and skip temperature coupling groups
+    /// see `do_tpx_state_first()` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    void read_box(Frame& frame, const TprHeader& header);
+
+    /// Read a GROMACS string dependending on the body convention
+    std::string read_gmx_string(TprBodyConvention body_convention);
+
+    /// Read a GROMACS bool dependending on the body convention
+    bool read_gmx_bool(TprBodyConvention body_convention = FileIOXdr);
+
+    /// Associated XDR file
+    XDRFile file_;
+    /// The next step to read
+    size_t step_ = 0;
+};
+
+template <> const FormatMetadata& format_metadata<TPRFormat>();
+
+} // namespace chemfiles
+
+#endif

--- a/include/chemfiles/formats/TPR.hpp
+++ b/include/chemfiles/formats/TPR.hpp
@@ -95,6 +95,10 @@ class TPRFormat final : public Format {
     /// see `do_tpx_mtop()` and `do_mtop` in <GMX>/src/gromacs/fileio/tpxio.cpp
     void read_topology(Frame& frame, const TprHeader& header);
 
+    // Read positions, velocities, and skip forces
+    // see `do_tpx_state_second` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    void read_coordinates(Frame& frame, const TprHeader& header);
+
     // Read all symbol strings which can be referenced by index.
     // see `do_symtab` in <GMX>/src/gromacs/fileio/tpxio.cpp
     std::vector<std::string> read_symbol_table(const TprHeader& header);

--- a/include/chemfiles/formats/TPR.hpp
+++ b/include/chemfiles/formats/TPR.hpp
@@ -76,10 +76,13 @@ class TPRFormat final : public Format {
         int file_generation = 0;
         /// If the TPR file was written in double precision
         bool use_double = false;
-        /// Size of real values in bytes, depends on `use_double`
-        size_t sizeof_real;
         /// Version-dependent serializer used for the body
         TprBodyConvention body_convention = FileIOXdr;
+
+        /// Size of real values in bytes
+        inline constexpr size_t sizeof_real() {
+            return this->use_double ? sizeof(double) : sizeof(float);
+        }
     };
 
     /// Read the file header

--- a/include/chemfiles/formats/TPR.hpp
+++ b/include/chemfiles/formats/TPR.hpp
@@ -90,8 +90,25 @@ class TPRFormat final : public Format {
     /// see `do_tpx_state_first()` in <GMX>/src/gromacs/fileio/tpxio.cpp
     void read_box(Frame& frame, const TprHeader& header);
 
+    /// Read the topology which contains atoms, residues, and bonds.
+    /// Angles, Dihedrals, and Impropers are not added to the frame.
+    /// see `do_tpx_mtop()` and `do_mtop` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    void read_topology(Frame& frame, const TprHeader& header);
+
+    // Read all symbol strings which can be referenced by index.
+    // see `do_symtab` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    std::vector<std::string> read_symbol_table(const TprHeader& header);
+
+    /// Read an index to an entry from the symbol table
+    /// Return a reference to the entry in the table
+    /// see `do_symstr()` in <GMX>/src/gromacs/fileio/tpxio.cpp
+    const std::string& read_symbol_table_entry(const std::vector<std::string>& table);
+
     /// Read a GROMACS string dependending on the body convention
     std::string read_gmx_string(TprBodyConvention body_convention);
+
+    /// Read a GROMACS unsigned char dependending on the body convention
+    uint8_t read_gmx_uchar(TprBodyConvention body_convention);
 
     /// Read a GROMACS bool dependending on the body convention
     bool read_gmx_bool(TprBodyConvention body_convention = FileIOXdr);

--- a/include/chemfiles/formats/TPR.hpp
+++ b/include/chemfiles/formats/TPR.hpp
@@ -84,24 +84,24 @@ class TPRFormat final : public Format {
 
     /// Read the file header
     /// see `do_tpxheader()` in <GMX>/src/gromacs/fileio/tpxio.cpp
-    TprHeader read_header();
+    void read_header();
 
     /// Read box and skip temperature coupling groups
     /// see `do_tpx_state_first()` in <GMX>/src/gromacs/fileio/tpxio.cpp
-    void read_box(Frame& frame, const TprHeader& header);
+    void read_box(Frame& frame);
 
     /// Read the topology which contains atoms, residues, and bonds.
     /// Angles, Dihedrals, and Impropers are not added to the frame.
     /// see `do_tpx_mtop()` and `do_mtop` in <GMX>/src/gromacs/fileio/tpxio.cpp
-    void read_topology(Frame& frame, const TprHeader& header);
+    void read_topology(Frame& frame);
 
     // Read positions, velocities, and skip forces
     // see `do_tpx_state_second` in <GMX>/src/gromacs/fileio/tpxio.cpp
-    void read_coordinates(Frame& frame, const TprHeader& header);
+    void read_coordinates(Frame& frame);
 
     // Read all symbol strings which can be referenced by index.
     // see `do_symtab` in <GMX>/src/gromacs/fileio/tpxio.cpp
-    std::vector<std::string> read_symbol_table(const TprHeader& header);
+    std::vector<std::string> read_symbol_table();
 
     /// Read an index to an entry from the symbol table
     /// Return a reference to the entry in the table
@@ -109,16 +109,18 @@ class TPRFormat final : public Format {
     const std::string& read_symbol_table_entry(const std::vector<std::string>& table);
 
     /// Read a GROMACS string dependending on the body convention
-    std::string read_gmx_string(TprBodyConvention body_convention);
+    std::string read_gmx_string();
 
     /// Read a GROMACS unsigned char dependending on the body convention
-    uint8_t read_gmx_uchar(TprBodyConvention body_convention);
+    uint8_t read_gmx_uchar();
 
     /// Read a GROMACS bool dependending on the body convention
-    bool read_gmx_bool(TprBodyConvention body_convention = FileIOXdr);
+    bool read_gmx_bool();
 
     /// Associated XDR file
     XDRFile file_;
+    /// TPR header of the file
+    TprHeader header_;
     /// The next step to read
     size_t step_ = 0;
 };

--- a/include/chemfiles/formats/TRR.hpp
+++ b/include/chemfiles/formats/TRR.hpp
@@ -4,7 +4,9 @@
 #ifndef CHEMFILES_TRR_FORMAT_HPP
 #define CHEMFILES_TRR_FORMAT_HPP
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "chemfiles/File.hpp"
 #include "chemfiles/Format.hpp"

--- a/include/chemfiles/formats/TRR.hpp
+++ b/include/chemfiles/formats/TRR.hpp
@@ -27,23 +27,23 @@ class TRRFormat final : public Format {
 
   private:
     struct FrameHeader {
-        bool use_double; /* Double precision?                                       */
-        int32_t ir_size;     /* Backward compatibility                              */
-        int32_t e_size;      /* Backward compatibility                              */
-        int32_t box_size;    /* Size in Bytes, non zero if a box is present         */
-        int32_t vir_size;    /* Backward compatibility                              */
-        int32_t pres_size;   /* Backward compatibility                              */
-        int32_t top_size;    /* Backward compatibility                              */
-        int32_t sym_size;    /* Backward compatibility                              */
-        int32_t x_size;      /* Size in Bytes, non zero if coordinates are present  */
-        int32_t v_size;      /* Size in Bytes, non zero if velocities are present   */
-        int32_t f_size;      /* Size in Bytes, non zero if forces are present       */
+        bool use_double;  /* Double precision?                                  */
+        size_t ir_size;   /* Backward compatibility                             */
+        size_t e_size;    /* Backward compatibility                             */
+        size_t box_size;  /* Size in Bytes, non zero if a box is present        */
+        size_t vir_size;  /* Backward compatibility                             */
+        size_t pres_size; /* Backward compatibility                             */
+        size_t top_size;  /* Backward compatibility                             */
+        size_t sym_size;  /* Backward compatibility                             */
+        size_t x_size;    /* Size in Bytes, non zero if coordinates are present */
+        size_t v_size;    /* Size in Bytes, non zero if velocities are present  */
+        size_t f_size;    /* Size in Bytes, non zero if forces are present      */
 
-        int32_t natoms;    /* The total number of atoms                           */
-        int32_t step;      /* Current step number                                 */
-        int32_t nre;       /* Backward compatibility                              */
-        double time;   /* Current time (float or double)                          */
-        double lambda; /* Current value of lambda (float or double)               */
+        size_t natoms; /* The total number of atoms                 */
+        size_t step;   /* Current step number                       */
+        size_t nre;    /* Backward compatibility                    */
+        double time;   /* Current time (float or double)            */
+        double lambda; /* Current value of lambda (float or double) */
     };
 
     /// Read header of the Frame at the current position

--- a/include/chemfiles/formats/XTC.hpp
+++ b/include/chemfiles/formats/XTC.hpp
@@ -27,9 +27,9 @@ class XTCFormat final : public Format {
 
   private:
     struct FrameHeader {
-        int32_t natoms; /* The total number of atoms */
-        int32_t step;   /* Current step number       */
-        float time;     /* Current time              */
+        size_t natoms; /* The total number of atoms */
+        size_t step;   /* Current step number       */
+        float time;    /* Current time              */
     };
 
     /// Read header of the Frame at the current position

--- a/include/chemfiles/formats/XTC.hpp
+++ b/include/chemfiles/formats/XTC.hpp
@@ -4,7 +4,9 @@
 #ifndef CHEMFILES_XTC_FORMAT_HPP
 #define CHEMFILES_XTC_FORMAT_HPP
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "chemfiles/File.hpp"
 #include "chemfiles/Format.hpp"

--- a/src/FormatFactory.cpp
+++ b/src/FormatFactory.cpp
@@ -38,6 +38,7 @@
 #include "chemfiles/formats/mmCIF.hpp"
 #include "chemfiles/formats/CML.hpp"
 #include "chemfiles/formats/SMI.hpp"
+#include "chemfiles/formats/TPR.hpp"
 #include "chemfiles/formats/TRR.hpp"
 #include "chemfiles/formats/XTC.hpp"
 #include "chemfiles/formats/CIF.hpp"
@@ -84,6 +85,7 @@ FormatFactory::FormatFactory() {
     this->add_format<TinkerFormat>();
     this->add_format<TNGFormat>();
     this->add_format<Molfile<TRJ>>();
+    this->add_format<TPRFormat>();
     this->add_format<TRRFormat>();
     this->add_format<XTCFormat>();
     this->add_format<XYZFormat>();

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -3,13 +3,22 @@
 
 #include <cassert>
 #include <climits>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "chemfiles/files/BinaryFile.hpp"
 #include "chemfiles/files/XDRFile.hpp"
 
+#include "chemfiles/File.hpp"
+#include "chemfiles/UnitCell.hpp"
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/external/span.hpp"
+#include "chemfiles/types.hpp"
 #include "chemfiles/warnings.hpp"
 
 using namespace chemfiles;
@@ -654,7 +663,8 @@ void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float 
             uint32_t num = static_cast<uint32_t>(run + is_smaller + 1);
             encodebits(compressed_data_, state, 5, num);
         } else {
-            encodebits(compressed_data_, state, 1, 0); // flag the fact that runlength did not change
+            // flag the fact that runlength did not change
+            encodebits(compressed_data_, state, 1, 0);
         }
         for (int k = 0; k < run; k += 3) {
             encodeints(compressed_data_, state, 3, smallidx, sizesmall, &tmpcoord[k]);
@@ -675,6 +685,7 @@ void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float 
     if (state.lastbits != 0) {
         ++state.count;
     }
-    assert(state.count < compressed_data_.size() && "internal Error: overflow during decompression");
+    assert(state.count < compressed_data_.size() &&
+           "internal Error: overflow during decompression");
     write_opaque(compressed_data_.data(), static_cast<uint32_t>(state.count));
 }

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -72,6 +72,14 @@ UnitCell XDRFile::read_gmx_box(bool use_double) {
     }
 }
 
+size_t XDRFile::read_single_size_as_i32() {
+    int32_t value = read_single_i32();
+    if (value < 0) {
+        throw file_error("invalid value in XDR file: expected a positive integer, got {}", value);
+    }
+    return static_cast<size_t>(value);
+}
+
 /***** from xdrfile *****/
 
 /* Internal support routines for reading/writing compressed coordinates

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -50,6 +50,28 @@ void XDRFile::write_gmx_string(const std::string& value) {
     write_opaque(value.c_str(), len - 1);
 }
 
+UnitCell XDRFile::read_gmx_box(bool use_double) {
+    if (use_double) {
+        // Double
+        std::vector<double> box(3 * 3);
+        read_f64(box);
+        auto matrix =
+            Matrix3D(box[0], box[3], box[6], box[1], box[4], box[7], box[2], box[5], box[8]);
+        // Factor 10 because the lengths are in nm in the TPR/TRR/XTC format
+        return UnitCell(10.0 * matrix);
+    } else {
+        // Float
+        std::vector<float> box(3 * 3);
+        read_f32(box);
+        auto matrix = Matrix3D(
+            static_cast<double>(box[0]), static_cast<double>(box[3]), static_cast<double>(box[6]),
+            static_cast<double>(box[1]), static_cast<double>(box[4]), static_cast<double>(box[7]),
+            static_cast<double>(box[2]), static_cast<double>(box[5]), static_cast<double>(box[8]));
+        // Factor 10 because the lengths are in nm in the TPR/TRR/XTC format
+        return UnitCell(10.0 * matrix);
+    }
+}
+
 /***** from xdrfile *****/
 
 /* Internal support routines for reading/writing compressed coordinates

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -774,7 +774,7 @@ void TPRFormat::read(Frame& frame) {
     }
 
     if (header_.ngroups_temperature_coupling > 0) {
-        const size_t ngtc_size = header_.ngroups_temperature_coupling * header_.sizeof_real;
+        const size_t ngtc_size = header_.ngroups_temperature_coupling * header_.sizeof_real();
         if (header_.file_version < 69) {
             // Skip some legacy entries
             file_.skip(ngtc_size);
@@ -808,8 +808,6 @@ void TPRFormat::read_header() {
         throw format_error("invalid precision {}, expected {} or {}", precision, sizeof(float),
                            sizeof(double));
     }
-
-    header_.sizeof_real = header_.use_double ? sizeof(double) : sizeof(float);
 
     header_.file_version = file_.read_single_i32();
 
@@ -864,7 +862,7 @@ void TPRFormat::read_header() {
 
     if (header_.file_version < 62) {
         // Skip some legacy entries
-        file_.skip(sizeof(int) + header_.sizeof_real);
+        file_.skip(sizeof(int) + header_.sizeof_real());
     }
     if (header_.file_version >= 79) {
         // Skip current value of the alchemical state
@@ -907,16 +905,16 @@ void TPRFormat::read_box(Frame& frame) {
     if (header_.file_version >= 51) {
         // Relative box vectors characteristic of the box shape
         // Skip unused 3*3 real matrix
-        file_.skip(header_.sizeof_real * 9);
+        file_.skip(header_.sizeof_real() * 9);
     }
 
     // Box velocities for Parrinello-Rahman barostat
     // Skip unused 3*3 real matrix
-    file_.skip(header_.sizeof_real * 9);
+    file_.skip(header_.sizeof_real() * 9);
 
     if (header_.file_version < 56) {
         // Skip some legacy entries
-        file_.skip(header_.sizeof_real * 9);
+        file_.skip(header_.sizeof_real() * 9);
     }
 }
 
@@ -929,7 +927,7 @@ void TPRFormat::read_topology(Frame& frame) {
     frame.set("name", read_symbol_table_entry(symbol_table));
 
     const FFParams ffparams =
-        read_force_field_parameters(file_, header_.sizeof_real, header_.file_version);
+        read_force_field_parameters(file_, header_.sizeof_real(), header_.file_version);
 
     // Read the definitions of the different molecule types and
     // their atoms and residues.
@@ -953,7 +951,7 @@ void TPRFormat::read_topology(Frame& frame) {
                 atom_prop.charge = file_.read_single_f64();
             }
             // Skip mass and charge for Free Energy calculations
-            file_.skip(2 * header_.sizeof_real);
+            file_.skip(2 * header_.sizeof_real());
             // Skip internal atom type
             if (header_.body_convention == FileIOXdr) {
                 file_.skip(2 * sizeof(uint32_t));
@@ -1096,7 +1094,7 @@ void TPRFormat::read_topology(Frame& frame) {
         file_.skip(sizeof(int32_t));
         for (size_t j = 0; j < 2; ++j) {
             size_t nposition_restraints = file_.read_single_size_as_i32();
-            file_.skip(nposition_restraints * 3 * header_.sizeof_real);
+            file_.skip(nposition_restraints * 3 * header_.sizeof_real());
         }
     }
 
@@ -1117,12 +1115,12 @@ void TPRFormat::read_topology(Frame& frame) {
     if (header_.file_version < TPRVersion::RemoveAtomtypes) {
         size_t ntypes = file_.read_single_size_as_i32();
         if (header_.file_version < TPRVersion::RemoveImplicitSolvation) {
-            file_.skip(3 * ntypes * header_.sizeof_real);
+            file_.skip(3 * ntypes * header_.sizeof_real());
         }
         file_.skip(ntypes * sizeof(int32_t));
         if (header_.file_version >= 60 &&
             header_.file_version < TPRVersion::RemoveImplicitSolvation) {
-            file_.skip(2 * ntypes * header_.sizeof_real);
+            file_.skip(2 * ntypes * header_.sizeof_real());
         }
     }
 
@@ -1131,7 +1129,7 @@ void TPRFormat::read_topology(Frame& frame) {
     if (header_.file_version >= 65) {
         size_t ngrids = file_.read_single_size_as_i32();
         size_t grid_spacing = file_.read_single_size_as_i32();
-        file_.skip(ngrids * grid_spacing * grid_spacing * 4 * header_.sizeof_real);
+        file_.skip(ngrids * grid_spacing * grid_spacing * 4 * header_.sizeof_real());
     }
 
     // Skip atom groups
@@ -1226,7 +1224,7 @@ void TPRFormat::read_coordinates(Frame& frame) {
         }
     }
     if (header_.has_forces) {
-        file_.skip(header_.natoms * 3 * header_.sizeof_real);
+        file_.skip(header_.natoms * 3 * header_.sizeof_real());
     }
 }
 

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -33,41 +33,44 @@
 // GROMACS explains: Enum of values that describe the contents of a TPR file
 // whose format matches a version number.
 // see `tpxv` in <GMX>/src/gromacs/fileio/tpxio.cpp
-enum TPRVersion {
-    tprv_ComputationalElectrophysiology = 96,
-    tprv_Use64BitRandomSeed,
-    tprv_RestrictedBendingAndCombinedAngleTorsionPotentials,
-    tprv_InteractiveMolecularDynamics,
-    tprv_RemoveObsoleteParameters1,
-    tprv_PullCoordTypeGeom,
-    tprv_PullGeomDirRel,
-    tprv_IntermolecularBondeds,
-    tprv_CompElWithSwapLayerOffset,
-    tprv_CompElPolyatomicIonsAndMultipleIonTypes,
-    tprv_RemoveAdress,
-    tprv_PullCoordNGroup,
-    tprv_RemoveTwinRange,
-    tprv_ReplacePullPrintCOM12,
-    tprv_PullExternalPotential,
-    tprv_GenericParamsForElectricField,
-    tprv_AcceleratedWeightHistogram,
-    tprv_RemoveImplicitSolvation,
-    tprv_PullPrevStepCOMAsReference,
-    tprv_MimicQMMM,
-    tprv_PullAverage,
-    tprv_GenericInternalParameters,
-    tprv_VSite2FD,
-    tprv_AddSizeField,
-    tprv_StoreNonBondedInteractionExclusionGroup,
-    tprv_VSite1,
-    tprv_MTS,
-    tprv_RemovedConstantAcceleration,
-    tprv_TransformationPullCoord,
-    tprv_SoftcoreGapsys,
-    tprv_ReaddedConstantAcceleration,
-    tprv_RemoveTholeRfac,
-    tprv_RemoveAtomtypes,
-    tprv_Count // This number is for the total number of versions
+class TPRVersion {
+  public:
+    enum TV : int {
+        ComputationalElectrophysiology = 96,
+        Use64BitRandomSeed,
+        RestrictedBendingAndCombinedAngleTorsionPotentials,
+        InteractiveMolecularDynamics,
+        RemoveObsoleteParameters1,
+        PullCoordTypeGeom,
+        PullGeomDirRel,
+        IntermolecularBondeds,
+        CompElWithSwapLayerOffset,
+        CompElPolyatomicIonsAndMultipleIonTypes,
+        RemoveAdress,
+        PullCoordNGroup,
+        RemoveTwinRange,
+        ReplacePullPrintCOM12,
+        PullExternalPotential,
+        GenericParamsForElectricField,
+        AcceleratedWeightHistogram,
+        RemoveImplicitSolvation,
+        PullPrevStepCOMAsReference,
+        MimicQMMM,
+        PullAverage,
+        GenericInternalParameters,
+        VSite2FD,
+        AddSizeField,
+        StoreNonBondedInteractionExclusionGroup,
+        VSite1,
+        MTS,
+        RemovedConstantAcceleration,
+        TransformationPullCoord,
+        SoftcoreGapsys,
+        ReaddedConstantAcceleration,
+        RemoveTholeRfac,
+        RemoveAtomtypes,
+        Count // This number is for the total number of versions
+    };
 };
 
 // GROMACS explains:
@@ -79,7 +82,7 @@ enum TPRVersion {
 // Backward compatibility for reading old run input files is maintained
 // by checking this version number against that of the file and then using
 // the correct code path.
-static const int TPR_VERSION = tprv_Count - 1;
+static const int TPR_VERSION = TPRVersion::Count - 1;
 
 // GROMACS explains:
 // Value of current TPR generation to keep track of incompatible changes for older TPR versions.
@@ -233,10 +236,10 @@ struct FunctionTypeUpdate {
 // see `ftupd` in <GMX>/src/gromacs/fileio/tpxio.cpp
 static const FunctionTypeUpdate FUNCTION_TYPE_UPDATES[24]{
     {70, F_RESTRBONDS},
-    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRANGLES},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRANGLES},
     {76, F_LINEAR_ANGLES},
-    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRDIHS},
-    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_CBTDIHS},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRDIHS},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_CBTDIHS},
     {65, F_CMAP},
     {60, F_GB12_NOLONGERUSED},
     {61, F_GB13_NOLONGERUSED},
@@ -246,9 +249,9 @@ static const FunctionTypeUpdate FUNCTION_TYPE_UPDATES[24]{
     {93, F_LJ_RECIP},
     {76, F_ANHARM_POL},
     {90, F_FBPOSRES},
-    {tprv_VSite1, F_VSITE1},
-    {tprv_VSite2FD, F_VSITE2FD},
-    {tprv_GenericInternalParameters, F_DENSITYFITTING},
+    {TPRVersion::VSite1, F_VSITE1},
+    {TPRVersion::VSite2FD, F_VSITE2FD},
+    {TPRVersion::GenericInternalParameters, F_DENSITYFITTING},
     {69, F_VTEMP_NOLONGERUSED},
     {66, F_PDISPCORR},
     {79, F_DVDL_COUL},
@@ -557,7 +560,7 @@ static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, in
         return 6 * sizeof_real;
     case F_THOLE_POL: {
         size_t size = 3 * sizeof_real;
-        if (file_version < tprv_RemoveTholeRfac) {
+        if (file_version < TPRVersion::RemoveTholeRfac) {
             size += sizeof_real;
         }
         return size;
@@ -627,7 +630,7 @@ static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, in
         if (file_version < 68) {
             size += 4 * sizeof_real;
         }
-        if (file_version < tprv_RemoveImplicitSolvation) {
+        if (file_version < TPRVersion::RemoveImplicitSolvation) {
             size += 5 * sizeof_real;
         }
         return size;
@@ -862,7 +865,7 @@ void TPRFormat::read_header() {
     header_.has_forces = read_gmx_bool();
     header_.has_box = read_gmx_bool();
 
-    if (header_.file_version >= tprv_AddSizeField && header_.file_generation >= 27) {
+    if (header_.file_version >= TPRVersion::AddSizeField && header_.file_generation >= 27) {
         // Skip size of the TPR body in bytes
         file_.read_single_i64();
     }
@@ -873,7 +876,7 @@ void TPRFormat::read_header() {
         header_.has_input_record = false;
     }
 
-    if (header_.file_version >= tprv_AddSizeField && header_.file_generation >= 27) {
+    if (header_.file_version >= TPRVersion::AddSizeField && header_.file_generation >= 27) {
         header_.body_convention = InMemory;
     } else {
         header_.body_convention = FileIOXdr;
@@ -1083,7 +1086,7 @@ void TPRFormat::read_topology(Frame& frame) {
     const size_t natoms = file_.read_single_size_as_i32();
     assert(natoms == header_.natoms);
 
-    if (header_.file_version >= tprv_IntermolecularBondeds) {
+    if (header_.file_version >= TPRVersion::IntermolecularBondeds) {
         bool has_intermolecular_bonds = read_gmx_bool();
         if (has_intermolecular_bonds) {
             InteractionLists interaction_lists =
@@ -1094,13 +1097,14 @@ void TPRFormat::read_topology(Frame& frame) {
 
     // Skip atom types for old formats
     // see `do_atomtypes`
-    if (header_.file_version < tprv_RemoveAtomtypes) {
+    if (header_.file_version < TPRVersion::RemoveAtomtypes) {
         size_t ntypes = file_.read_single_size_as_i32();
-        if (header_.file_version < tprv_RemoveImplicitSolvation) {
+        if (header_.file_version < TPRVersion::RemoveImplicitSolvation) {
             file_.skip(3 * ntypes * header_.sizeof_real);
         }
         file_.skip(ntypes * sizeof(int32_t));
-        if (header_.file_version >= 60 && header_.file_version < tprv_RemoveImplicitSolvation) {
+        if (header_.file_version >= 60 &&
+            header_.file_version < TPRVersion::RemoveImplicitSolvation) {
             file_.skip(2 * ntypes * header_.sizeof_real);
         }
     }
@@ -1137,7 +1141,7 @@ void TPRFormat::read_topology(Frame& frame) {
         }
     }
 
-    if (header_.file_version >= tprv_StoreNonBondedInteractionExclusionGroup) {
+    if (header_.file_version >= TPRVersion::StoreNonBondedInteractionExclusionGroup) {
         int64_t intermolecularExclusionGroupSize = file_.read_single_i64();
         if (intermolecularExclusionGroupSize < 0) {
             throw format_error("invalid intermolecular exclusion group size in TPR file: expected "

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -105,109 +105,125 @@ static const int TPR_GENERATION = 28;
 static const int TPR_INCOMPATIBLE_VERSION = 57; // GMX4.0 has version 58
 
 // see <GMX>/api/legacy/include/gromacs/topology/ifunc.h
-enum FunctionType {
-    F_BONDS,
-    F_G96BONDS,
-    F_MORSE,
-    F_CUBICBONDS,
-    F_CONNBONDS,
-    F_HARMONIC,
-    F_FENEBONDS,
-    F_TABBONDS,
-    F_TABBONDSNC,
-    F_RESTRBONDS,
-    F_ANGLES,
-    F_G96ANGLES,
-    F_RESTRANGLES,
-    F_LINEAR_ANGLES,
-    F_CROSS_BOND_BONDS,
-    F_CROSS_BOND_ANGLES,
-    F_UREY_BRADLEY,
-    F_QUARTIC_ANGLES,
-    F_TABANGLES,
-    F_PDIHS,
-    F_RBDIHS,
-    F_RESTRDIHS,
-    F_CBTDIHS,
-    F_FOURDIHS,
-    F_IDIHS,
-    F_PIDIHS,
-    F_TABDIHS,
-    F_CMAP,
-    F_GB12_NOLONGERUSED,
-    F_GB13_NOLONGERUSED,
-    F_GB14_NOLONGERUSED,
-    F_GBPOL_NOLONGERUSED,
-    F_NPSOLVATION_NOLONGERUSED,
-    F_LJ14,
-    F_COUL14,
-    F_LJC14_Q,
-    F_LJC_PAIRS_NB,
-    F_LJ,
-    F_BHAM,
-    F_LJ_LR_NOLONGERUSED,
-    F_BHAM_LR_NOLONGERUSED,
-    F_DISPCORR,
-    F_COUL_SR,
-    F_COUL_LR_NOLONGERUSED,
-    F_RF_EXCL,
-    F_COUL_RECIP,
-    F_LJ_RECIP,
-    F_DPD,
-    F_POLARIZATION,
-    F_WATER_POL,
-    F_THOLE_POL,
-    F_ANHARM_POL,
-    F_POSRES,
-    F_FBPOSRES,
-    F_DISRES,
-    F_DISRESVIOL,
-    F_ORIRES,
-    F_ORIRESDEV,
-    F_ANGRES,
-    F_ANGRESZ,
-    F_DIHRES,
-    F_DIHRESVIOL,
-    F_CONSTR,
-    F_CONSTRNC,
-    F_SETTLE,
-    F_VSITE1,
-    F_VSITE2,
-    F_VSITE2FD,
-    F_VSITE3,
-    F_VSITE3FD,
-    F_VSITE3FAD,
-    F_VSITE3OUT,
-    F_VSITE4FD,
-    F_VSITE4FDN,
-    F_VSITEN,
-    F_COM_PULL,
-    F_DENSITYFITTING,
-    F_EQM,
-    F_EPOT,
-    F_EKIN,
-    F_ETOT,
-    F_ECONSERVED,
-    F_TEMP,
-    F_VTEMP_NOLONGERUSED,
-    F_PDISPCORR,
-    F_PRES,
-    F_DVDL_CONSTR,
-    F_DVDL,
-    F_DKDL,
-    F_DVDL_COUL,
-    F_DVDL_VDW,
-    F_DVDL_BONDED,
-    F_DVDL_RESTRAINT,
-    F_DVDL_TEMPERATURE,
-    F_NRE // This number is for the total number of energies
+class FunctionType {
+  public:
+    enum FT : size_t {
+        BONDS,
+        G96BONDS,
+        MORSE,
+        CUBICBONDS,
+        CONNBONDS,
+        HARMONIC,
+        FENEBONDS,
+        TABBONDS,
+        TABBONDSNC,
+        RESTRBONDS,
+        ANGLES,
+        G96ANGLES,
+        RESTRANGLES,
+        LINEAR_ANGLES,
+        CROSS_BOND_BONDS,
+        CROSS_BOND_ANGLES,
+        UREY_BRADLEY,
+        QUARTIC_ANGLES,
+        TABANGLES,
+        PDIHS,
+        RBDIHS,
+        RESTRDIHS,
+        CBTDIHS,
+        FOURDIHS,
+        IDIHS,
+        PIDIHS,
+        TABDIHS,
+        CMAP,
+        GB12_NOLONGERUSED,
+        GB13_NOLONGERUSED,
+        GB14_NOLONGERUSED,
+        GBPOL_NOLONGERUSED,
+        NPSOLVATION_NOLONGERUSED,
+        LJ14,
+        COUL14,
+        LJC14_Q,
+        LJC_PAIRS_NB,
+        LJ,
+        BHAM,
+        LJ_LR_NOLONGERUSED,
+        BHAM_LR_NOLONGERUSED,
+        DISPCORR,
+        COUL_SR,
+        COUL_LR_NOLONGERUSED,
+        RF_EXCL,
+        COUL_RECIP,
+        LJ_RECIP,
+        DPD,
+        POLARIZATION,
+        WATER_POL,
+        THOLE_POL,
+        ANHARM_POL,
+        POSRES,
+        FBPOSRES,
+        DISRES,
+        DISRESVIOL,
+        ORIRES,
+        ORIRESDEV,
+        ANGRES,
+        ANGRESZ,
+        DIHRES,
+        DIHRESVIOL,
+        CONSTR,
+        CONSTRNC,
+        SETTLE,
+        VSITE1,
+        VSITE2,
+        VSITE2FD,
+        VSITE3,
+        VSITE3FD,
+        VSITE3FAD,
+        VSITE3OUT,
+        VSITE4FD,
+        VSITE4FDN,
+        VSITEN,
+        COM_PULL,
+        DENSITYFITTING,
+        EQM,
+        EPOT,
+        EKIN,
+        ETOT,
+        ECONSERVED,
+        TEMP,
+        VTEMP_NOLONGERUSED,
+        PDISPCORR,
+        PRES,
+        DVDL_CONSTR,
+        DVDL,
+        DKDL,
+        DVDL_COUL,
+        DVDL_VDW,
+        DVDL_BONDED,
+        DVDL_RESTRAINT,
+        DVDL_TEMPERATURE,
+        Count
+    };
+    FunctionType() = default;
+    constexpr FunctionType(FT v) : value(v) {}
+    constexpr FunctionType(size_t v) : value(static_cast<FT>(v)) {}
+    FunctionType(int v) : value(static_cast<FT>(v)) { assert(v >= 0); }
+    operator int() const { return static_cast<int>(value); }
+
+  private:
+    FT value;
 };
+
+// This number is for the total number of energies / interaction function types
+static const int NRE = FunctionType::Count;
 
 // Set of function types which are considered as bonds.
 // Update when new function types are introduced.
 const std::vector<FunctionType> BOND_TYPES = {
-    F_BONDS,     F_G96BONDS,   F_MORSE,  F_CUBICBONDS, F_CONNBONDS, F_HARMONIC,
-    F_FENEBONDS, F_RESTRBONDS, F_CONSTR, F_CONSTRNC,   F_TABBONDS,  F_TABBONDSNC,
+    FunctionType::BONDS,      FunctionType::G96BONDS,   FunctionType::MORSE,
+    FunctionType::CUBICBONDS, FunctionType::CONNBONDS,  FunctionType::HARMONIC,
+    FunctionType::FENEBONDS,  FunctionType::RESTRBONDS, FunctionType::CONSTR,
+    FunctionType::CONSTRNC,   FunctionType::TABBONDS,   FunctionType::TABBONDSNC,
 };
 
 // All force filed parameters of the system.
@@ -235,30 +251,30 @@ struct FunctionTypeUpdate {
 // are added. Necessary to support reading of old TPR file versions.
 // see `ftupd` in <GMX>/src/gromacs/fileio/tpxio.cpp
 static const FunctionTypeUpdate FUNCTION_TYPE_UPDATES[24]{
-    {70, F_RESTRBONDS},
-    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRANGLES},
-    {76, F_LINEAR_ANGLES},
-    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRDIHS},
-    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, F_CBTDIHS},
-    {65, F_CMAP},
-    {60, F_GB12_NOLONGERUSED},
-    {61, F_GB13_NOLONGERUSED},
-    {61, F_GB14_NOLONGERUSED},
-    {72, F_GBPOL_NOLONGERUSED},
-    {72, F_NPSOLVATION_NOLONGERUSED},
-    {93, F_LJ_RECIP},
-    {76, F_ANHARM_POL},
-    {90, F_FBPOSRES},
-    {TPRVersion::VSite1, F_VSITE1},
-    {TPRVersion::VSite2FD, F_VSITE2FD},
-    {TPRVersion::GenericInternalParameters, F_DENSITYFITTING},
-    {69, F_VTEMP_NOLONGERUSED},
-    {66, F_PDISPCORR},
-    {79, F_DVDL_COUL},
-    {79, F_DVDL_VDW},
-    {79, F_DVDL_BONDED},
-    {79, F_DVDL_RESTRAINT},
-    {79, F_DVDL_TEMPERATURE},
+    {70, FunctionType::RESTRBONDS},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, FunctionType::RESTRANGLES},
+    {76, FunctionType::LINEAR_ANGLES},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, FunctionType::RESTRDIHS},
+    {TPRVersion::RestrictedBendingAndCombinedAngleTorsionPotentials, FunctionType::CBTDIHS},
+    {65, FunctionType::CMAP},
+    {60, FunctionType::GB12_NOLONGERUSED},
+    {61, FunctionType::GB13_NOLONGERUSED},
+    {61, FunctionType::GB14_NOLONGERUSED},
+    {72, FunctionType::GBPOL_NOLONGERUSED},
+    {72, FunctionType::NPSOLVATION_NOLONGERUSED},
+    {93, FunctionType::LJ_RECIP},
+    {76, FunctionType::ANHARM_POL},
+    {90, FunctionType::FBPOSRES},
+    {TPRVersion::VSite1, FunctionType::VSITE1},
+    {TPRVersion::VSite2FD, FunctionType::VSITE2FD},
+    {TPRVersion::GenericInternalParameters, FunctionType::DENSITYFITTING},
+    {69, FunctionType::VTEMP_NOLONGERUSED},
+    {66, FunctionType::PDISPCORR},
+    {79, FunctionType::DVDL_COUL},
+    {79, FunctionType::DVDL_VDW},
+    {79, FunctionType::DVDL_BONDED},
+    {79, FunctionType::DVDL_RESTRAINT},
+    {79, FunctionType::DVDL_TEMPERATURE},
 };
 
 // see `t_interaction_function` in <GMX>/api/legacy/include/gromacs/topology/ifunc.h
@@ -270,7 +286,7 @@ struct FunctionTypeInfo {
 // This table contains a human-readable name for a function type
 // and the number of atoms needed per function.
 // see `interaction_function` in <GMX>/src/gromacs/topology/ifunc.cpp
-const FunctionTypeInfo FUNCTION_TYPE_INFOS[F_NRE]{
+const FunctionTypeInfo FUNCTION_TYPE_INFOS[NRE]{
     {"Bond", 2},
     {"G96Bond", 2},
     {"Morse", 2},
@@ -430,7 +446,7 @@ struct InteractionList {
     }
 
     void add_settle_atoms() {
-        assert(function_type == F_SETTLE);
+        assert(function_type == FunctionType::SETTLE);
         assert(!settle_done); // This can be called only once
         settle_done = true;
         // GROMACS: Settle used to only store the first atom: add the other two
@@ -449,7 +465,7 @@ struct InteractionList {
 
 // GROMACS: List of interaction lists, one list for each interaction type.
 // see <GMX>/api/legacy/include/gromacs/topology/idef.h
-typedef std::array<chemfiles::optional<InteractionList>, F_NRE> InteractionLists;
+typedef std::array<chemfiles::optional<InteractionList>, NRE> InteractionLists;
 
 // see `gmx_moltype_t` in <GMX>/api/legacy/include/gromacs/topology/topology.h
 struct MoleculeType {
@@ -506,85 +522,85 @@ void TPRFormat::read_step(size_t step, Frame& frame) {
 // see `do_iparams` <GMX>/src/gromacs/fileio/tpxio.cpp
 static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, int file_version) {
     switch (ftype) {
-    case F_ANGLES:
-    case F_G96ANGLES:
-    case F_BONDS:
-    case F_G96BONDS:
-    case F_HARMONIC:
-    case F_IDIHS:
+    case FunctionType::ANGLES:
+    case FunctionType::G96ANGLES:
+    case FunctionType::BONDS:
+    case FunctionType::G96BONDS:
+    case FunctionType::HARMONIC:
+    case FunctionType::IDIHS:
         return 4 * sizeof_real;
-    case F_RESTRANGLES:
+    case FunctionType::RESTRANGLES:
         return 2 * sizeof_real;
-    case F_LINEAR_ANGLES:
+    case FunctionType::LINEAR_ANGLES:
         return 4 * sizeof_real;
-    case F_FENEBONDS:
+    case FunctionType::FENEBONDS:
         return 2 * sizeof_real;
-    case F_RESTRBONDS:
+    case FunctionType::RESTRBONDS:
         return 8 * sizeof_real;
-    case F_TABBONDS:
-    case F_TABBONDSNC:
-    case F_TABANGLES:
-    case F_TABDIHS:
+    case FunctionType::TABBONDS:
+    case FunctionType::TABBONDSNC:
+    case FunctionType::TABANGLES:
+    case FunctionType::TABDIHS:
         return 2 * sizeof_real + sizeof(int32_t);
-    case F_CROSS_BOND_BONDS:
+    case FunctionType::CROSS_BOND_BONDS:
         return 3 * sizeof_real;
-    case F_CROSS_BOND_ANGLES:
+    case FunctionType::CROSS_BOND_ANGLES:
         return 4 * sizeof_real;
-    case F_UREY_BRADLEY: {
+    case FunctionType::UREY_BRADLEY: {
         size_t size = 4 * sizeof_real;
         if (file_version >= 79) {
             size += 4 * sizeof_real;
         }
         return size;
     }
-    case F_QUARTIC_ANGLES:
+    case FunctionType::QUARTIC_ANGLES:
         return 6 * sizeof_real;
-    case F_BHAM:
+    case FunctionType::BHAM:
         return 3 * sizeof_real;
-    case F_MORSE: {
+    case FunctionType::MORSE: {
         size_t size = 3 * sizeof_real;
         if (file_version >= 79) {
             size += 3 * sizeof_real;
         }
         return size;
     }
-    case F_CUBICBONDS:
+    case FunctionType::CUBICBONDS:
         return 3 * sizeof_real;
-    case F_CONNBONDS:
+    case FunctionType::CONNBONDS:
         return 0;
-    case F_POLARIZATION:
+    case FunctionType::POLARIZATION:
         return sizeof_real;
-    case F_ANHARM_POL:
+    case FunctionType::ANHARM_POL:
         return 3 * sizeof_real;
-    case F_WATER_POL:
+    case FunctionType::WATER_POL:
         return 6 * sizeof_real;
-    case F_THOLE_POL: {
+    case FunctionType::THOLE_POL: {
         size_t size = 3 * sizeof_real;
         if (file_version < TPRVersion::RemoveTholeRfac) {
             size += sizeof_real;
         }
         return size;
     }
-    case F_LJ:
+    case FunctionType::LJ:
         return 2 * sizeof_real;
-    case F_LJ14:
+    case FunctionType::LJ14:
         return 4 * sizeof_real;
-    case F_LJC14_Q:
+    case FunctionType::LJC14_Q:
         return 5 * sizeof_real;
-    case F_LJC_PAIRS_NB:
+    case FunctionType::LJC_PAIRS_NB:
         return 4 * sizeof_real;
-    case F_PDIHS:
-    case F_PIDIHS:
-    case F_ANGRES:
-    case F_ANGRESZ:
+    case FunctionType::PDIHS:
+    case FunctionType::PIDIHS:
+    case FunctionType::ANGRES:
+    case FunctionType::ANGRESZ:
         return 4 * sizeof_real + sizeof(int32_t);
-    case F_RESTRDIHS:
+    case FunctionType::RESTRDIHS:
         return 2 * sizeof_real;
-    case F_DISRES:
+    case FunctionType::DISRES:
         return 2 * sizeof(int32_t) + 4 * sizeof_real;
-    case F_ORIRES:
+    case FunctionType::ORIRES:
         return 3 * sizeof(int32_t) + 3 * sizeof_real;
-    case F_DIHRES: {
+    case FunctionType::DIHRES: {
         size_t size = 3 * sizeof_real;
         if (file_version < 82) {
             size += 2 * sizeof(int32_t);
@@ -594,38 +610,38 @@ static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, in
         }
         return size;
     }
-    case F_POSRES:
+    case FunctionType::POSRES:
         return 4 * 3 * sizeof_real;
-    case F_FBPOSRES:
+    case FunctionType::FBPOSRES:
         return sizeof(int32_t) + 5 * sizeof_real;
-    case F_CBTDIHS:
+    case FunctionType::CBTDIHS:
         return NR_CBTDIHS * sizeof_real;
-    case F_RBDIHS:
-    case F_FOURDIHS:
+    case FunctionType::RBDIHS:
+    case FunctionType::FOURDIHS:
         return 2 * NR_RBDIHS * sizeof_real;
-    case F_CONSTR:
-    case F_CONSTRNC:
+    case FunctionType::CONSTR:
+    case FunctionType::CONSTRNC:
         return 2 * sizeof_real;
-    case F_SETTLE:
+    case FunctionType::SETTLE:
         return 2 * sizeof_real;
-    case F_VSITE1:
+    case FunctionType::VSITE1:
         return 0;
-    case F_VSITE2:
-    case F_VSITE2FD:
+    case FunctionType::VSITE2:
+    case FunctionType::VSITE2FD:
         return 1 * sizeof_real;
-    case F_VSITE3:
-    case F_VSITE3FD:
-    case F_VSITE3FAD:
+    case FunctionType::VSITE3:
+    case FunctionType::VSITE3FD:
+    case FunctionType::VSITE3FAD:
         return 2 * sizeof_real;
-    case F_VSITE3OUT:
-    case F_VSITE4FD:
-    case F_VSITE4FDN:
+    case FunctionType::VSITE3OUT:
+    case FunctionType::VSITE4FD:
+    case FunctionType::VSITE4FDN:
         return 3 * sizeof_real;
-    case F_VSITEN:
+    case FunctionType::VSITEN:
         return sizeof(int32_t) + sizeof_real;
-    case F_GB12_NOLONGERUSED:
-    case F_GB13_NOLONGERUSED:
-    case F_GB14_NOLONGERUSED: {
+    case FunctionType::GB12_NOLONGERUSED:
+    case FunctionType::GB13_NOLONGERUSED:
+    case FunctionType::GB14_NOLONGERUSED: {
         size_t size = 0;
         if (file_version < 68) {
             size += 4 * sizeof_real;
@@ -635,7 +651,7 @@ static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, in
         }
         return size;
     }
-    case F_CMAP:
+    case FunctionType::CMAP:
         return 2 * sizeof(int32_t);
     default:
         throw format_error("unknown function type {} ({})", ftype, FUNCTION_TYPE_INFOS[ftype].name);
@@ -645,7 +661,7 @@ static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, in
 // see `do_ilists` in <GMX>/src/gromacs/fileio/tpxio.cpp
 static InteractionLists read_interaction_lists(XDRFile& file, int file_version) {
     InteractionLists interaction_lists;
-    for (size_t i = 0; i < F_NRE; ++i) {
+    for (size_t i = 0; i < NRE; ++i) {
         const FunctionType function_type = static_cast<FunctionType>(i);
         bool is_old_interaction = false;
         for (const auto function_type_update : FUNCTION_TYPE_UPDATES) {
@@ -667,7 +683,8 @@ static InteractionLists read_interaction_lists(XDRFile& file, int file_version) 
                 ilist.interaction_tuples.emplace_back(idx);
             }
 
-            if (file_version < 78 && ilist.function_type == F_SETTLE && !ilist.empty()) {
+            if (file_version < 78 && ilist.function_type == FunctionType::SETTLE &&
+                !ilist.empty()) {
                 ilist.add_settle_atoms();
             }
 
@@ -695,7 +712,7 @@ static void add_conectivity(Frame& frame, const InteractionLists& interaction_li
                 assert(iatoms.size() == 2);
                 frame.add_bond(atom_idx_offset + iatoms[0], atom_idx_offset + iatoms[1]);
             }
-        } else if (ilist.value().function_type == F_SETTLE) {
+        } else if (ilist.value().function_type == FunctionType::SETTLE) {
             for (size_t i = 0; i < ilist.value().size(); ++i) {
                 auto iatoms = ilist.value()[i];
                 assert(iatoms.size() == 3);

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -1,0 +1,322 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include <cassert>
+#include <cstdint>
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "chemfiles/error_fmt.hpp"
+#include "chemfiles/external/optional.hpp"
+#include "chemfiles/external/span.hpp"
+#include "chemfiles/periodic_table.hpp"
+#include "chemfiles/types.hpp"
+#include "chemfiles/warnings.hpp"
+
+#include "chemfiles/Atom.hpp"
+#include "chemfiles/File.hpp"
+#include "chemfiles/FormatMetadata.hpp"
+#include "chemfiles/Frame.hpp"
+#include "chemfiles/Residue.hpp"
+
+#include "chemfiles/files/XDRFile.hpp"
+#include "chemfiles/formats/TPR.hpp"
+
+// see <GMX>/src/gromacs/fileio/tpxio.cpp
+#define TPR_TAG_RELEASE "release"
+
+// GROMACS explains: Enum of values that describe the contents of a TPR file
+// whose format matches a version number.
+// see `tpxv` in <GMX>/src/gromacs/fileio/tpxio.cpp
+enum TPRVersion {
+    tprv_ComputationalElectrophysiology = 96,
+    tprv_Use64BitRandomSeed,
+    tprv_RestrictedBendingAndCombinedAngleTorsionPotentials,
+    tprv_InteractiveMolecularDynamics,
+    tprv_RemoveObsoleteParameters1,
+    tprv_PullCoordTypeGeom,
+    tprv_PullGeomDirRel,
+    tprv_IntermolecularBondeds,
+    tprv_CompElWithSwapLayerOffset,
+    tprv_CompElPolyatomicIonsAndMultipleIonTypes,
+    tprv_RemoveAdress,
+    tprv_PullCoordNGroup,
+    tprv_RemoveTwinRange,
+    tprv_ReplacePullPrintCOM12,
+    tprv_PullExternalPotential,
+    tprv_GenericParamsForElectricField,
+    tprv_AcceleratedWeightHistogram,
+    tprv_RemoveImplicitSolvation,
+    tprv_PullPrevStepCOMAsReference,
+    tprv_MimicQMMM,
+    tprv_PullAverage,
+    tprv_GenericInternalParameters,
+    tprv_VSite2FD,
+    tprv_AddSizeField,
+    tprv_StoreNonBondedInteractionExclusionGroup,
+    tprv_VSite1,
+    tprv_MTS,
+    tprv_RemovedConstantAcceleration,
+    tprv_TransformationPullCoord,
+    tprv_SoftcoreGapsys,
+    tprv_ReaddedConstantAcceleration,
+    tprv_RemoveTholeRfac,
+    tprv_RemoveAtomtypes,
+    tprv_Count // This number is for the total number of versions
+};
+
+// GROMACS explains:
+// Version number of the file format written to run input
+// files by this version of the code.
+//
+// The TPR version increases whenever the file format in the main
+// development branch changes, due to an extension of the `TPRVersion` enum above.
+// Backward compatibility for reading old run input files is maintained
+// by checking this version number against that of the file and then using
+// the correct code path.
+static const int TPR_VERSION = tprv_Count - 1;
+
+// GROMACS explains:
+// Value of current TPR generation to keep track of incompatible changes for older TPR versions.
+//
+// The generation should be incremented when editing the TOPOLOGY or HEADER of the TPR format.
+// In particular, updating `FUNCTION_TYPE_UPDATES` or changing the fields of the TPR header
+// often triggers such needs.
+//
+// This way GROMACS can maintain forward compatibility for all analysis tools and/or external
+// programs that only need to know the atom/residue names, charges, and bond connectivity.
+//
+// For chemfiles, this means it is possible to read TPR files from future versions as long as they
+// are the same generation as specified here.
+// The generation is tracked by GROMACS with an enum.
+// see `TpxGeneration` in in <GMX>/src/gromacs/fileio/tpxio.cpp
+static const int TPR_GENERATION = 28;
+
+// This number should be the most recent backwards incompatible version.
+// I.e., if this number is 9, we cannot read TPR version 9 with this code.
+static const int TPR_INCOMPATIBLE_VERSION = 57; // GMX4.0 has version 58
+
+using namespace chemfiles;
+
+template <> const FormatMetadata& chemfiles::format_metadata<TPRFormat>() {
+    static FormatMetadata metadata;
+    metadata.name = "TPR";
+    metadata.extension = ".tpr";
+    metadata.description = "GROMACS TPR binary format";
+    metadata.reference = "http://manual.gromacs.org/current/reference-manual/file-formats.html#tpr";
+
+    metadata.read = true;
+    metadata.write = false;
+    metadata.memory = false;
+
+    metadata.positions = false;
+    metadata.velocities = false;
+    metadata.unit_cell = true;
+    metadata.atoms = false;
+    metadata.bonds = false;
+    metadata.residues = false;
+    return metadata;
+}
+
+TPRFormat::TPRFormat(std::string path, File::Mode mode, File::Compression compression)
+    : file_(std::move(path), mode) {
+    if (compression != File::DEFAULT) {
+        throw format_error("TPR format does not support compression");
+    }
+    if (mode != File::READ) {
+        throw format_error("TPR format does not support write & append");
+    }
+}
+
+size_t TPRFormat::nsteps() { return 1; }
+
+void TPRFormat::read_step(size_t step, Frame& frame) {
+    step_ = step;
+    this->read(frame);
+}
+
+void TPRFormat::read(Frame& frame) {
+    const TprHeader header = read_header();
+    frame.resize(header.natoms);
+
+    // Now read the body of the TPR file
+    // see `do_tpx_body` in <GMX>/src/gromacs/fileio/tpxio.cpp
+
+    if (header.has_box) {
+        read_box(frame, header);
+    }
+
+    if (header.ngroups_temperature_coupling > 0) {
+        const size_t ngtc_size = header.ngroups_temperature_coupling * header.sizeof_real;
+        if (header.file_version < 69) {
+            // Skip some legacy entries
+            file_.skip(ngtc_size);
+        }
+        // GROMACS: These used to be the Berendsen tcoupl_lambda's
+        file_.skip(ngtc_size);
+    }
+
+    step_++;
+}
+
+TPRFormat::TprHeader TPRFormat::read_header() {
+    TprHeader header;
+
+    const std::string version = file_.read_gmx_string();
+    if (version.compare(0, 7, "VERSION") != 0) {
+        throw format_error("unsupported file from a GROMACS version which is older than 2.0");
+    }
+
+    size_t precision = file_.read_single_size_as_i32();
+    header.use_double = (precision == sizeof(double));
+    if (precision != sizeof(float) && precision != sizeof(double)) {
+        throw format_error("invalid precision {}, expected {} or {}", precision, sizeof(float),
+                           sizeof(double));
+    }
+
+    header.sizeof_real = header.use_double ? sizeof(double) : sizeof(float);
+
+    header.file_version = file_.read_single_i32();
+
+    // GROMACS explains:
+    // This is for backward compatibility with development versions 77-79
+    // where the tag was, mistakenly, placed before the generation,
+    // which would cause a segv instead of a proper error message
+    // when reading the topology only from tpx with <77 code.
+    std::string fileTag;
+    if (header.file_version >= 77 && header.file_version <= 79) {
+        fileTag = file_.read_gmx_string();
+    }
+
+    header.file_generation = file_.read_single_i32();
+
+    if (header.file_version >= 81) {
+        fileTag = file_.read_gmx_string();
+    }
+    if (header.file_version < 77 || header.file_version == 80) {
+        // GROMACS: Versions before 77 don't have the tag, set it to release.
+        // Version 80 is not handled by the current GROMACS implementation
+        // but MDAnalysis sets the tag to release as well for version 80.
+        // Version 80 was used by both 5.0-dev and 4.6-dev.
+        fileTag = TPR_TAG_RELEASE;
+    }
+
+    // GROMACS explains:
+    // We only support reading tpx files with the same tag as the code
+    // or tpx files with the release tag and with lower version number.
+    if (fileTag != TPR_TAG_RELEASE && header.file_version < TPR_VERSION) {
+        throw format_error("TPR tag/version mismatch: reading file with version {}, tag '{}' with "
+                           "program for version {}, tag '{}'",
+                           header.file_version, fileTag, TPR_VERSION, TPR_TAG_RELEASE);
+    }
+
+    if (header.file_version > TPR_VERSION) {
+        warning("TPR",
+                "file version is from the future: implementation uses version {}, but got {}",
+                TPR_VERSION, header.file_version);
+    }
+
+    // Assume `TopOnlyOK` is true, i.e. we need only the topology and not the input record.
+    // This allows reading of future versions of the same generation.
+    if ((header.file_version <= TPR_INCOMPATIBLE_VERSION) ||
+        (header.file_generation > TPR_GENERATION)) {
+        throw format_error("unable to read version {} with version {} program", header.file_version,
+                           TPR_VERSION);
+    }
+
+    header.natoms = file_.read_single_size_as_i32();
+    header.ngroups_temperature_coupling = file_.read_single_size_as_i32();
+
+    if (header.file_version < 62) {
+        // Skip some legacy entries
+        file_.skip(sizeof(int) + header.sizeof_real);
+    }
+    if (header.file_version >= 79) {
+        // Skip current value of the alchemical state
+        file_.read_single_i32();
+    }
+    if (!header.use_double) {
+        header.lambda = static_cast<double>(file_.read_single_f32());
+    } else {
+        header.lambda = file_.read_single_f64();
+    }
+    header.has_input_record = read_gmx_bool();
+    header.has_topology = read_gmx_bool();
+    header.has_positions = read_gmx_bool();
+    header.has_velocities = read_gmx_bool();
+    header.has_forces = read_gmx_bool();
+    header.has_box = read_gmx_bool();
+
+    if (header.file_version >= tprv_AddSizeField && header.file_generation >= 27) {
+        // Skip size of the TPR body in bytes
+        file_.read_single_i64();
+    }
+
+    if (header.file_generation > TPR_GENERATION && header.has_input_record) {
+        // Trying to read a file from the future with an input record.
+        // At this point in time, it's unknown what will be in the record.
+        header.has_input_record = false;
+    }
+
+    if (header.file_version >= tprv_AddSizeField && header.file_generation >= 27) {
+        header.body_convention = InMemory;
+    } else {
+        header.body_convention = FileIOXdr;
+    }
+
+    return header;
+}
+
+void TPRFormat::read_box(Frame& frame, const TprHeader& header) {
+    const auto box = file_.read_gmx_box(header.use_double);
+    frame.set_cell(box);
+
+    if (header.file_version >= 51) {
+        // Relative box vectors characteristic of the box shape
+        // Skip unused 3*3 real matrix
+        file_.skip(header.sizeof_real * 9);
+    }
+
+    // Box velocities for Parrinello-Rahman barostat
+    // Skip unused 3*3 real matrix
+    file_.skip(header.sizeof_real * 9);
+
+    if (header.file_version < 56) {
+        // Skip some legacy entries
+        file_.skip(header.sizeof_real * 9);
+    }
+}
+
+std::string TPRFormat::read_gmx_string(TprBodyConvention body_convention) {
+    if (body_convention == FileIOXdr) {
+        return file_.read_gmx_string();
+    } else {
+        assert(body_convention == InMemory);
+        // Read a non-XDR-compliant *long* GROMACS string
+        // A long GROMACS string stores the length of the string as uint64 before
+        // the string contents. The contents are *not* padded to make the size a
+        // multiple of four bytes.
+
+        // lenght without null terminator
+        const uint64_t len = file_.read_single_u64();
+        // next comes the contents of the string without padding
+        std::vector<char> buf;
+        buf.resize(static_cast<size_t>(len));
+        file_.read_char(buf);
+        return std::string(buf.begin(), buf.end());
+    }
+}
+
+bool TPRFormat::read_gmx_bool(TprBodyConvention body_convention) {
+    if (body_convention == FileIOXdr) {
+        return file_.read_single_i32() != 0;
+    } else {
+        assert(body_convention == InMemory);
+        return file_.read_single_u8() != 0;
+    }
+}

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -101,6 +101,357 @@ static const int TPR_GENERATION = 28;
 // I.e., if this number is 9, we cannot read TPR version 9 with this code.
 static const int TPR_INCOMPATIBLE_VERSION = 57; // GMX4.0 has version 58
 
+// see <GMX>/api/legacy/include/gromacs/topology/ifunc.h
+enum FunctionType {
+    F_BONDS,
+    F_G96BONDS,
+    F_MORSE,
+    F_CUBICBONDS,
+    F_CONNBONDS,
+    F_HARMONIC,
+    F_FENEBONDS,
+    F_TABBONDS,
+    F_TABBONDSNC,
+    F_RESTRBONDS,
+    F_ANGLES,
+    F_G96ANGLES,
+    F_RESTRANGLES,
+    F_LINEAR_ANGLES,
+    F_CROSS_BOND_BONDS,
+    F_CROSS_BOND_ANGLES,
+    F_UREY_BRADLEY,
+    F_QUARTIC_ANGLES,
+    F_TABANGLES,
+    F_PDIHS,
+    F_RBDIHS,
+    F_RESTRDIHS,
+    F_CBTDIHS,
+    F_FOURDIHS,
+    F_IDIHS,
+    F_PIDIHS,
+    F_TABDIHS,
+    F_CMAP,
+    F_GB12_NOLONGERUSED,
+    F_GB13_NOLONGERUSED,
+    F_GB14_NOLONGERUSED,
+    F_GBPOL_NOLONGERUSED,
+    F_NPSOLVATION_NOLONGERUSED,
+    F_LJ14,
+    F_COUL14,
+    F_LJC14_Q,
+    F_LJC_PAIRS_NB,
+    F_LJ,
+    F_BHAM,
+    F_LJ_LR_NOLONGERUSED,
+    F_BHAM_LR_NOLONGERUSED,
+    F_DISPCORR,
+    F_COUL_SR,
+    F_COUL_LR_NOLONGERUSED,
+    F_RF_EXCL,
+    F_COUL_RECIP,
+    F_LJ_RECIP,
+    F_DPD,
+    F_POLARIZATION,
+    F_WATER_POL,
+    F_THOLE_POL,
+    F_ANHARM_POL,
+    F_POSRES,
+    F_FBPOSRES,
+    F_DISRES,
+    F_DISRESVIOL,
+    F_ORIRES,
+    F_ORIRESDEV,
+    F_ANGRES,
+    F_ANGRESZ,
+    F_DIHRES,
+    F_DIHRESVIOL,
+    F_CONSTR,
+    F_CONSTRNC,
+    F_SETTLE,
+    F_VSITE1,
+    F_VSITE2,
+    F_VSITE2FD,
+    F_VSITE3,
+    F_VSITE3FD,
+    F_VSITE3FAD,
+    F_VSITE3OUT,
+    F_VSITE4FD,
+    F_VSITE4FDN,
+    F_VSITEN,
+    F_COM_PULL,
+    F_DENSITYFITTING,
+    F_EQM,
+    F_EPOT,
+    F_EKIN,
+    F_ETOT,
+    F_ECONSERVED,
+    F_TEMP,
+    F_VTEMP_NOLONGERUSED,
+    F_PDISPCORR,
+    F_PRES,
+    F_DVDL_CONSTR,
+    F_DVDL,
+    F_DKDL,
+    F_DVDL_COUL,
+    F_DVDL_VDW,
+    F_DVDL_BONDED,
+    F_DVDL_RESTRAINT,
+    F_DVDL_TEMPERATURE,
+    F_NRE // This number is for the total number of energies
+};
+
+// All force filed parameters of the system.
+// see `gmx_ffparams_t` in <GMX>/api/legacy/include/gromacs/topology/forcefieldparameters.h
+struct FFParams {
+    // Number of non-bonded atom types
+    int natom_types;
+    // Function type of an interaction
+    std::vector<int32_t> function_types;
+};
+
+// Maximum allowed number of parameters.
+// see <GMX>/api/legacy/include/gromacs/topology/ifunc.h
+const int NR_RBDIHS = 6;
+const int NR_CBTDIHS = 6;
+
+// see `t_ftupd` in <GMX>/src/gromacs/fileio/tpxio.cpp
+struct FunctionTypeUpdate {
+    // File version number in which the function type first appeared
+    int file_version;
+    FunctionType function_type;
+};
+
+// The following Table is used maintain TRR compatibility  when function types
+// are added. Necessary to support reading of old TPR file versions.
+// see `ftupd` in <GMX>/src/gromacs/fileio/tpxio.cpp
+static const FunctionTypeUpdate FUNCTION_TYPE_UPDATES[24]{
+    {70, F_RESTRBONDS},
+    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRANGLES},
+    {76, F_LINEAR_ANGLES},
+    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_RESTRDIHS},
+    {tprv_RestrictedBendingAndCombinedAngleTorsionPotentials, F_CBTDIHS},
+    {65, F_CMAP},
+    {60, F_GB12_NOLONGERUSED},
+    {61, F_GB13_NOLONGERUSED},
+    {61, F_GB14_NOLONGERUSED},
+    {72, F_GBPOL_NOLONGERUSED},
+    {72, F_NPSOLVATION_NOLONGERUSED},
+    {93, F_LJ_RECIP},
+    {76, F_ANHARM_POL},
+    {90, F_FBPOSRES},
+    {tprv_VSite1, F_VSITE1},
+    {tprv_VSite2FD, F_VSITE2FD},
+    {tprv_GenericInternalParameters, F_DENSITYFITTING},
+    {69, F_VTEMP_NOLONGERUSED},
+    {66, F_PDISPCORR},
+    {79, F_DVDL_COUL},
+    {79, F_DVDL_VDW},
+    {79, F_DVDL_BONDED},
+    {79, F_DVDL_RESTRAINT},
+    {79, F_DVDL_TEMPERATURE},
+};
+
+// see `t_interaction_function` in <GMX>/api/legacy/include/gromacs/topology/ifunc.h
+struct FunctionTypeInfo {
+    std::string name;
+    size_t natoms;
+};
+
+// This table contains a human-readable name for a function type
+// and the number of atoms needed per function.
+// see `interaction_function` in <GMX>/src/gromacs/topology/ifunc.cpp
+const FunctionTypeInfo FUNCTION_TYPE_INFOS[F_NRE]{
+    {"Bond", 2},
+    {"G96Bond", 2},
+    {"Morse", 2},
+    {"Cubic Bonds", 2},
+    {"Connect Bonds", 2},
+    {"Harmonic Pot.", 2},
+    {"FENE Bonds", 2},
+    {"Tab. Bonds", 2},
+    {"Tab. Bonds NC", 2},
+    {"Restraint Pot.", 2},
+    {"Angle", 3},
+    {"G96Angle", 3},
+    {"Restricted Angles", 3},
+    {"Lin. Angle", 3},
+    {"Bond-Cross", 3},
+    {"BA-Cross", 3},
+    {"U-B", 3},
+    {"Quartic Angles", 3},
+    {"Tab. Angles", 3},
+    {"Proper Dih.", 4},
+    {"Ryckaert-Bell.", 4},
+    {"Restricted Dih.", 4},
+    {"CBT Dih.", 4},
+    {"Fourier Dih.", 4},
+    {"Improper Dih.", 4},
+    {"Periodic Improper Dih.", 4},
+    {"Tab. Dih.", 4},
+    {"CMAP Dih.", 5},
+    {"GB 1-2 Pol. ", 0},
+    {"GB 1-3 Pol. ", 0},
+    {"GB 1-4 Pol. ", 0},
+    {"GB Polarization ", 0},
+    {"Nonpolar Sol. ", 0},
+    {"LJ-14", 2},
+    {"Coulomb-14", 0},
+    {"LJC-14 q", 2},
+    {"LJC Pairs NB", 2},
+    {"LJ (SR)", 2},
+    {"Buck.ham (SR)", 2},
+    {"LJ ", 0},
+    {"B.ham ", 0},
+    {"Disper. corr.", 0},
+    {"Coulomb (SR)", 0},
+    {"Coul ", 0},
+    {"RF excl.", 0},
+    {"Coul. recip.", 0},
+    {"LJ recip.", 0},
+    {"DPD", 0},
+    {"Polarization", 2},
+    {"Water Pol.", 5},
+    {"Thole Pol.", 4},
+    {"Anharm. Pol.", 2},
+    {"Position Rest.", 1},
+    {"Flat-bottom posres", 1},
+    {"Dis. Rest.", 2},
+    {"D.R.Viol. (nm)", 0},
+    {"Orient. Rest.", 2},
+    {"Ori. R. RMSD", 0},
+    {"Angle Rest.", 4},
+    {"Angle Rest. Z", 2},
+    {"Dih. Rest.", 4},
+    {"Dih. Rest. Viol.", 0},
+    {"Constraint", 2},
+    {"Constr. No Conn.", 2},
+    {"Settle", 3},
+    {"Virtual site 1", 2},
+    {"Virtual site 2", 3},
+    {"Virtual site 2fd", 3},
+    {"Virtual site 3", 4},
+    {"Virtual site 3fd", 4},
+    {"Virtual site 3fad", 4},
+    {"Virtual site 3out", 4},
+    {"Virtual site 4fd", 5},
+    {"Virtual site 4fdn", 5},
+    {"Virtual site N", 2},
+    {"COM Pull En.", 0},
+    {"Density fitting", 0},
+    {"Quantum En.", 0},
+    {"Potential", 0},
+    {"Kinetic En.", 0},
+    {"Total Energy", 0},
+    {"Conserved En.", 0},
+    {"Temperature", 0},
+    {"Vir. Temp. ", 0},
+    {"Pres. DC", 0},
+    {"Pressure", 0},
+    {"dH/dl constr.", 0},
+    {"dVremain/dl", 0},
+    {"dEkin/dl", 0},
+    {"dVcoul/dl", 0},
+    {"dVvdw/dl", 0},
+    {"dVbonded/dl", 0},
+    {"dVrestraint/dl", 0},
+    {"dVtemperature/dl", 0},
+};
+
+// see `t_resinfo` in <GMX>/api/legacy/include/gromacs/topology/atoms.h
+struct ResidueInfo {
+    std::string name;
+    int64_t residue_number;
+    uint8_t insertion_code;
+};
+
+// see `t_atom` in <GMX>/api/legacy/include/gromacs/topology/atoms.h
+struct AtomProperties {
+    double mass;
+    double charge;
+    // Index into `residue_infos` in `Atoms`
+    size_t residue_idx;
+    chemfiles::optional<std::string> element_name = chemfiles::nullopt;
+};
+
+// see `t_atoms` in <GMX>/api/legacy/include/gromacs/topology/atoms.h
+struct Atoms {
+    std::vector<AtomProperties> atom_properties;
+    std::vector<std::string> atom_names;
+    std::vector<std::string> atom_types;
+    std::vector<ResidueInfo> residue_infos;
+
+    size_t size() const {
+        size_t natoms = atom_properties.size();
+        assert(natoms == atom_names.size());
+        assert(natoms == atom_types.size());
+        return natoms;
+    }
+};
+
+// All the interactions for a given function type. This is stored as multiple
+// interaction tuples which refer to a set of function parameters (skipped)
+// and the atom indices.
+// see <GMX>/api/legacy/include/gromacs/topology/idef.h
+struct InteractionList {
+    FunctionType function_type;
+    // An interaction tuple contains the type of the interaction
+    // (i.e. index to function parameters) first
+    // followed by the number of interacting atoms.
+    // This number depends on the function type (e.g. bond defines two atoms).
+    std::vector<size_t> interaction_tuples;
+    bool settle_done = false;
+
+    bool empty() const { return interaction_tuples.empty(); }
+
+    size_t size() const {
+        // Number of entries per interaction (type_index + N * atom_index)
+        size_t nentries = FUNCTION_TYPE_INFOS[function_type].natoms + 1;
+        size_t size = interaction_tuples.size() / nentries;
+        assert(size * nentries == interaction_tuples.size());
+        return size;
+    }
+
+    chemfiles::span<const size_t> operator[](size_t i) const {
+        size_t natoms = FUNCTION_TYPE_INFOS[function_type].natoms;
+        // Stored as (type, atom_1, atom_2, ..., atom_N)
+        // Skip first `i` tuples and the next type
+        size_t begin = (natoms + 1) * i + 1;
+        return chemfiles::span<const size_t>(interaction_tuples.data() + begin, natoms);
+    }
+
+    void add_settle_atoms() {
+        assert(function_type == F_SETTLE);
+        assert(!settle_done); // This can be called only once
+        settle_done = true;
+        // GROMACS: Settle used to only store the first atom: add the other two
+        size_t size = interaction_tuples.size();
+        interaction_tuples.resize(2 * size);
+        auto& iatoms = interaction_tuples;
+        for (int i = static_cast<int>(size) / 2 - 1; i >= 0; --i) {
+            size_t j = static_cast<size_t>(i);
+            iatoms[4 * j + 0] = iatoms[2 * j + 0];
+            iatoms[4 * j + 1] = iatoms[2 * j + 1];
+            iatoms[4 * j + 2] = iatoms[2 * j + 1] + 1;
+            iatoms[4 * j + 3] = iatoms[2 * j + 1] + 2;
+        }
+    }
+};
+
+// GROMACS: List of interaction lists, one list for each interaction type.
+// see <GMX>/api/legacy/include/gromacs/topology/idef.h
+typedef std::array<chemfiles::optional<InteractionList>, F_NRE> InteractionLists;
+
+// see `gmx_moltype_t` in <GMX>/api/legacy/include/gromacs/topology/topology.h
+struct MoleculeType {
+    std::string name;
+    Atoms atoms;
+    InteractionLists interaction_lists;
+};
+
+// `Count` in `SimulationAtomGroupType`
+// see <GMX>/api/legacy/include/gromacs/topology/topology_enums.h
+const size_t NR_GROUP_TYPES = 10;
+
 using namespace chemfiles;
 
 template <> const FormatMetadata& chemfiles::format_metadata<TPRFormat>() {
@@ -117,9 +468,9 @@ template <> const FormatMetadata& chemfiles::format_metadata<TPRFormat>() {
     metadata.positions = false;
     metadata.velocities = false;
     metadata.unit_cell = true;
-    metadata.atoms = false;
+    metadata.atoms = true;
     metadata.bonds = false;
-    metadata.residues = false;
+    metadata.residues = true;
     return metadata;
 }
 
@@ -138,6 +489,221 @@ size_t TPRFormat::nsteps() { return 1; }
 void TPRFormat::read_step(size_t step, Frame& frame) {
     step_ = step;
     this->read(frame);
+}
+
+// Determine the size of all the interaction parameters for a function type.
+// see `do_iparams` <GMX>/src/gromacs/fileio/tpxio.cpp
+static size_t interaction_params_size(FunctionType ftype, size_t sizeof_real, int file_version) {
+    switch (ftype) {
+    case F_ANGLES:
+    case F_G96ANGLES:
+    case F_BONDS:
+    case F_G96BONDS:
+    case F_HARMONIC:
+    case F_IDIHS:
+        return 4 * sizeof_real;
+    case F_RESTRANGLES:
+        return 2 * sizeof_real;
+    case F_LINEAR_ANGLES:
+        return 4 * sizeof_real;
+    case F_FENEBONDS:
+        return 2 * sizeof_real;
+    case F_RESTRBONDS:
+        return 8 * sizeof_real;
+    case F_TABBONDS:
+    case F_TABBONDSNC:
+    case F_TABANGLES:
+    case F_TABDIHS:
+        return 2 * sizeof_real + sizeof(int32_t);
+    case F_CROSS_BOND_BONDS:
+        return 3 * sizeof_real;
+    case F_CROSS_BOND_ANGLES:
+        return 4 * sizeof_real;
+    case F_UREY_BRADLEY: {
+        size_t size = 4 * sizeof_real;
+        if (file_version >= 79) {
+            size += 4 * sizeof_real;
+        }
+        return size;
+    }
+    case F_QUARTIC_ANGLES:
+        return 6 * sizeof_real;
+    case F_BHAM:
+        return 3 * sizeof_real;
+    case F_MORSE: {
+        size_t size = 3 * sizeof_real;
+        if (file_version >= 79) {
+            size += 3 * sizeof_real;
+        }
+        return size;
+    }
+    case F_CUBICBONDS:
+        return 3 * sizeof_real;
+    case F_CONNBONDS:
+        return 0;
+    case F_POLARIZATION:
+        return sizeof_real;
+    case F_ANHARM_POL:
+        return 3 * sizeof_real;
+    case F_WATER_POL:
+        return 6 * sizeof_real;
+    case F_THOLE_POL: {
+        size_t size = 3 * sizeof_real;
+        if (file_version < tprv_RemoveTholeRfac) {
+            size += sizeof_real;
+        }
+        return size;
+    }
+    case F_LJ:
+        return 2 * sizeof_real;
+    case F_LJ14:
+        return 4 * sizeof_real;
+    case F_LJC14_Q:
+        return 5 * sizeof_real;
+    case F_LJC_PAIRS_NB:
+        return 4 * sizeof_real;
+    case F_PDIHS:
+    case F_PIDIHS:
+    case F_ANGRES:
+    case F_ANGRESZ:
+        return 4 * sizeof_real + sizeof(int32_t);
+    case F_RESTRDIHS:
+        return 2 * sizeof_real;
+    case F_DISRES:
+        return 2 * sizeof(int32_t) + 4 * sizeof_real;
+    case F_ORIRES:
+        return 3 * sizeof(int32_t) + 3 * sizeof_real;
+    case F_DIHRES: {
+        size_t size = 3 * sizeof_real;
+        if (file_version < 82) {
+            size += 2 * sizeof(int32_t);
+        }
+        if (file_version >= 82) {
+            size += 3 * sizeof_real;
+        }
+        return size;
+    }
+    case F_POSRES:
+        return 4 * 3 * sizeof_real;
+    case F_FBPOSRES:
+        return sizeof(int32_t) + 5 * sizeof_real;
+    case F_CBTDIHS:
+        return NR_CBTDIHS * sizeof_real;
+    case F_RBDIHS:
+    case F_FOURDIHS:
+        return 2 * NR_RBDIHS * sizeof_real;
+    case F_CONSTR:
+    case F_CONSTRNC:
+        return 2 * sizeof_real;
+    case F_SETTLE:
+        return 2 * sizeof_real;
+    case F_VSITE1:
+        return 0;
+    case F_VSITE2:
+    case F_VSITE2FD:
+        return 1 * sizeof_real;
+    case F_VSITE3:
+    case F_VSITE3FD:
+    case F_VSITE3FAD:
+        return 2 * sizeof_real;
+    case F_VSITE3OUT:
+    case F_VSITE4FD:
+    case F_VSITE4FDN:
+        return 3 * sizeof_real;
+    case F_VSITEN:
+        return sizeof(int32_t) + sizeof_real;
+    case F_GB12_NOLONGERUSED:
+    case F_GB13_NOLONGERUSED:
+    case F_GB14_NOLONGERUSED: {
+        size_t size = 0;
+        if (file_version < 68) {
+            size += 4 * sizeof_real;
+        }
+        if (file_version < tprv_RemoveImplicitSolvation) {
+            size += 5 * sizeof_real;
+        }
+        return size;
+    }
+    case F_CMAP:
+        return 2 * sizeof(int32_t);
+    default:
+        throw format_error("unknown function type {} ({})", ftype, FUNCTION_TYPE_INFOS[ftype].name);
+    }
+}
+
+// see `do_ilists` in <GMX>/src/gromacs/fileio/tpxio.cpp
+static InteractionLists read_interaction_lists(XDRFile& file, int file_version) {
+    InteractionLists interaction_lists;
+    for (size_t i = 0; i < F_NRE; ++i) {
+        const FunctionType function_type = static_cast<FunctionType>(i);
+        bool is_old_interaction = false;
+        for (const auto function_type_update : FUNCTION_TYPE_UPDATES) {
+            // Compare the read file version to the update table
+            if ((file_version < function_type_update.file_version) &&
+                (function_type == function_type_update.function_type)) {
+                is_old_interaction = true;
+                break;
+            }
+        }
+        if (!is_old_interaction) {
+            InteractionList ilist;
+
+            ilist.function_type = function_type;
+            size_t ninteraction_data = file.read_single_size_as_i32();
+            ilist.interaction_tuples.reserve(ninteraction_data);
+            for (size_t j = 0; j < ninteraction_data; ++j) {
+                size_t idx = file.read_single_size_as_i32();
+                ilist.interaction_tuples.emplace_back(idx);
+            }
+
+            if (file_version < 78 && ilist.function_type == F_SETTLE && !ilist.empty()) {
+                ilist.add_settle_atoms();
+            }
+
+            interaction_lists[i] = ilist;
+        }
+    }
+    return interaction_lists;
+}
+
+// Read all the different interations in the system. As only the types of
+// interactions are used, the interaction parameters are skipped.
+// see `do_ffparams` in <GMX>/src/gromacs/fileio/tpxio.cpp
+static FFParams read_force_field_parameters(XDRFile& file, size_t sizeof_real, int file_version) {
+    FFParams ffparams;
+    ffparams.natom_types = file.read_single_i32();
+    const size_t num_function_types = file.read_single_size_as_i32();
+    ffparams.function_types.resize(num_function_types);
+
+    // Read all function types
+    file.read_i32(ffparams.function_types);
+
+    if (file_version >= 66) {
+        // Skip `reppow`: Repulsion power $p$ for VdW: $C12*r^-p$
+        file.skip(sizeof(double));
+    }
+
+    // Skip `fudgeQQ`: Scaling factor $f$ for Coulomb 1-4: $f*q1*q2$
+    file.skip(sizeof_real);
+
+    // GROMACS explains:
+    // Check whether all these function types are supported by the code.
+    // In practice the code is backwards compatible, which means that the
+    // numbering may have to be altered from old numbering to new numbering.
+    for (auto& function_type : ffparams.function_types) {
+        for (const auto& function_type_update : FUNCTION_TYPE_UPDATES) {
+            // Compare the read file version to the update table
+            if ((file_version < function_type_update.file_version) &&
+                (function_type >= function_type_update.function_type)) {
+                ++function_type;
+            }
+        }
+        // Skip the force field parameters of the function
+        size_t params_size = interaction_params_size(static_cast<FunctionType>(function_type),
+                                                     sizeof_real, file_version);
+        file.skip(params_size);
+    }
+    return ffparams;
 }
 
 void TPRFormat::read(Frame& frame) {
@@ -159,6 +725,10 @@ void TPRFormat::read(Frame& frame) {
         }
         // GROMACS: These used to be the Berendsen tcoupl_lambda's
         file_.skip(ngtc_size);
+    }
+
+    if (header.has_topology) {
+        read_topology(frame, header);
     }
 
     step_++;
@@ -292,6 +862,267 @@ void TPRFormat::read_box(Frame& frame, const TprHeader& header) {
     }
 }
 
+void TPRFormat::read_topology(Frame& frame, const TprHeader& header) {
+    // Most of the used functions are defined in <GMX>/src/gromacs/fileio/tpxio.cpp
+    // which is not repeated everytime in the following section.
+
+    const std::vector<std::string> symbol_table = read_symbol_table(header);
+
+    frame.set("name", read_symbol_table_entry(symbol_table));
+
+    const FFParams ffparams =
+        read_force_field_parameters(file_, header.sizeof_real, header.file_version);
+
+    // Read the definitions of the different molecule types and
+    // their atoms and residues.
+    // see `do_moltype`
+    auto read_molecule_types = [this, header, symbol_table]() -> std::vector<MoleculeType> {
+        const size_t nmoltypes = file_.read_single_size_as_i32();
+        std::vector<MoleculeType> molecule_types;
+        molecule_types.reserve(nmoltypes);
+
+        // Read the properties of single atom
+        // see `do_atom`
+        auto read_atom = [this, header]() -> AtomProperties {
+            AtomProperties atom_prop;
+            if (!header.use_double) {
+                // Float
+                atom_prop.mass = static_cast<double>(file_.read_single_f32());
+                atom_prop.charge = static_cast<double>(file_.read_single_f32());
+            } else {
+                // Double
+                atom_prop.mass = file_.read_single_f64();
+                atom_prop.charge = file_.read_single_f64();
+            }
+            // Skip mass and charge for Free Energy calculations
+            file_.skip(2 * header.sizeof_real);
+            // Skip internal atom type
+            if (header.body_convention == FileIOXdr) {
+                file_.skip(2 * sizeof(uint32_t));
+            } else {
+                assert(header.body_convention == InMemory);
+                file_.skip(2 * sizeof(uint16_t));
+            }
+            // Skip internal particle type
+            file_.skip(sizeof(int32_t));
+            atom_prop.residue_idx = file_.read_single_size_as_i32();
+            const uint64_t atomnumber = static_cast<uint64_t>(file_.read_single_i32());
+            for (const auto& kv : PERIODIC_TABLE) {
+                // Determine the shortened element name from the atomnumber
+                const auto& name = kv.first;
+                const auto& atomic_data = kv.second;
+                if (atomic_data.number && *atomic_data.number == atomnumber) {
+                    atom_prop.element_name = name;
+                }
+            }
+            return atom_prop;
+        };
+
+        // Read the definition of all the atoms in a molecule type
+        // -> do_atoms
+        auto read_atoms = [this, header, symbol_table, read_atom]() -> Atoms {
+            Atoms atoms;
+            const size_t natoms = file_.read_single_size_as_i32();
+            const size_t nresidue_info = file_.read_single_size_as_i32();
+            atoms.atom_properties.reserve(natoms);
+            atoms.atom_names.reserve(natoms);
+            atoms.atom_types.reserve(natoms);
+            atoms.residue_infos.reserve(nresidue_info);
+            for (size_t j = 0; j < natoms; ++j) {
+                AtomProperties atom_prop = read_atom();
+                atoms.atom_properties.emplace_back(atom_prop);
+            }
+            for (size_t j = 0; j < natoms; ++j) {
+                auto name = read_symbol_table_entry(symbol_table);
+                atoms.atom_names.emplace_back(name);
+            }
+            for (size_t j = 0; j < natoms; ++j) {
+                auto type = read_symbol_table_entry(symbol_table);
+                atoms.atom_types.emplace_back(type);
+            }
+            for (size_t j = 0; j < natoms; ++j) {
+                // Skip the types for Free Energy calculations
+                read_symbol_table_entry(symbol_table);
+            }
+
+            // Read the definition of residues
+            // see `do_resinfo`
+            for (size_t j = 0; j < nresidue_info; ++j) {
+                std::string name = read_symbol_table_entry(symbol_table);
+                uint8_t insertion_code = ' ';
+                int64_t residue_number = static_cast<int64_t>(j) + 1;
+                if (header.file_version >= 63) {
+                    residue_number = static_cast<int64_t>(file_.read_single_i32());
+                    insertion_code = read_gmx_uchar(header.body_convention);
+                }
+                ResidueInfo res_info = {name, residue_number, insertion_code};
+                atoms.residue_infos.emplace_back(res_info);
+            }
+
+            return atoms;
+        };
+
+        for (size_t i = 0; i < nmoltypes; ++i) {
+            MoleculeType moltype;
+            moltype.name = read_symbol_table_entry(symbol_table);
+            moltype.atoms = read_atoms();
+
+            // Read the interaction lists
+            moltype.interaction_lists = read_interaction_lists(file_, header.file_version);
+
+            molecule_types.emplace_back(moltype);
+
+            // GROMACS: Skip the obsolete charge group index
+            // see `do_block`
+            const size_t nblocks = file_.read_single_size_as_i32();
+            file_.skip((nblocks + 1) * sizeof(int32_t));
+
+            // Skip the exclusions
+            size_t nlists = file_.read_single_size_as_i32();
+            size_t nelements = file_.read_single_size_as_i32();
+            file_.skip((nlists + 1 + nelements) * sizeof(int32_t));
+        }
+        return molecule_types;
+    };
+    const std::vector<MoleculeType> molecule_types = read_molecule_types();
+
+    // Now create the actual topology of the system. The molecules are listed
+    // sequentially after each other. Multiple molecules of the same type in
+    // one row are aggregated in molecule blocks.
+    // see `do_molblock` but most of the code is chemfiles specific
+    size_t global_atom_idx = 0; // Number of atoms in the previous molecules
+    const size_t nmolblocks = file_.read_single_size_as_i32();
+    for (size_t i = 0; i < nmolblocks; ++i) {
+        // Index of the molecule type read previously
+        size_t moltype_idx = file_.read_single_size_as_i32();
+        auto& moltype = molecule_types.at(moltype_idx);
+        size_t nmolecules = file_.read_single_size_as_i32();
+        const auto& atoms = moltype.atoms;
+        for (size_t j = 0; j < nmolecules; ++j) {
+            std::vector<chemfiles::Residue> residues_of_mol;
+            residues_of_mol.reserve(atoms.residue_infos.size());
+            for (const auto& res_info : atoms.residue_infos) {
+                Residue residue = {res_info.name, res_info.residue_number};
+                residue.set("insertion_code",
+                            std::string(1, static_cast<char>(res_info.insertion_code)));
+                residues_of_mol.emplace_back(residue);
+            }
+            for (size_t atom_idx = 0; atom_idx < atoms.size(); ++atom_idx) {
+                auto& atom = frame[global_atom_idx + atom_idx];
+                atom.set_name(atoms.atom_names[atom_idx]);
+                atom.set("ff_type", atoms.atom_types[atom_idx]);
+                auto& props = atoms.atom_properties[atom_idx];
+                if (props.element_name) {
+                    atom.set_type(*props.element_name);
+                }
+                atom.set_mass(props.mass);
+                atom.set_charge(props.charge);
+
+                if (props.residue_idx < moltype.atoms.residue_infos.size()) {
+                    residues_of_mol[props.residue_idx].add_atom(global_atom_idx + atom_idx);
+                } else {
+                    throw format_error(
+                        "residue index out of bounds, there are {} residues, got index {}",
+                        moltype.atoms.residue_infos.size(), props.residue_idx);
+                }
+            }
+            global_atom_idx += atoms.size();
+            for (const auto& residue : residues_of_mol) {
+                frame.add_residue(residue);
+            }
+        }
+
+        // Skip number of atoms per molecule as this is already stored in the type
+        file_.skip(sizeof(int32_t));
+        for (size_t j = 0; j < 2; ++j) {
+            size_t nposition_restraints = file_.read_single_size_as_i32();
+            file_.skip(nposition_restraints * 3 * header.sizeof_real);
+        }
+    }
+
+    const size_t natoms = file_.read_single_size_as_i32();
+    assert(natoms == header.natoms);
+
+    if (header.file_version >= tprv_IntermolecularBondeds) {
+        bool has_intermolecular_bonds = read_gmx_bool(header.body_convention);
+        if (has_intermolecular_bonds) {
+            InteractionLists interaction_lists = read_interaction_lists(file_, header.file_version);
+        }
+    }
+
+    // Skip atom types for old formats
+    // see `do_atomtypes`
+    if (header.file_version < tprv_RemoveAtomtypes) {
+        size_t ntypes = file_.read_single_size_as_i32();
+        if (header.file_version < tprv_RemoveImplicitSolvation) {
+            file_.skip(3 * ntypes * header.sizeof_real);
+        }
+        file_.skip(ntypes * sizeof(int32_t));
+        if (header.file_version >= 60 && header.file_version < tprv_RemoveImplicitSolvation) {
+            file_.skip(2 * ntypes * header.sizeof_real);
+        }
+    }
+
+    // Skip dihedral correction maps (CMAP)
+    // see `do_cmap`
+    if (header.file_version >= 65) {
+        size_t ngrids = file_.read_single_size_as_i32();
+        size_t grid_spacing = file_.read_single_size_as_i32();
+        file_.skip(ngrids * grid_spacing * grid_spacing * 4 * header.sizeof_real);
+    }
+
+    // Skip atom groups
+    // see `do_groups`
+    {
+        // Skip sizes of groups
+        for (size_t i = 0; i < NR_GROUP_TYPES; ++i) {
+            // see `do_grps`
+            size_t group_size = file_.read_single_size_as_i32();
+            file_.skip(group_size * sizeof(int32_t));
+        }
+        size_t ngroup_names = file_.read_single_size_as_i32();
+        // Skip symbol table indices
+        file_.skip(ngroup_names * sizeof(int32_t));
+        // Skip group numbers
+        for (size_t i = 0; i < NR_GROUP_TYPES; ++i) {
+            size_t ngroup_numbers = file_.read_single_size_as_i32();
+            if (header.body_convention == FileIOXdr) {
+                file_.skip(ngroup_numbers * sizeof(uint32_t));
+            } else {
+                assert(header.body_convention == InMemory);
+                file_.skip(ngroup_numbers * sizeof(uint8_t));
+            }
+        }
+    }
+
+    if (header.file_version >= tprv_StoreNonBondedInteractionExclusionGroup) {
+        int64_t intermolecularExclusionGroupSize = file_.read_single_i64();
+        if (intermolecularExclusionGroupSize < 0) {
+            throw format_error("invalid intermolecular exclusion group size in TPR file: expected "
+                               "a positive value, got {}",
+                               intermolecularExclusionGroupSize);
+        }
+        uint64_t skip_size =
+            static_cast<uint64_t>(intermolecularExclusionGroupSize) * sizeof(int32_t);
+        file_.skip(skip_size);
+    }
+}
+
+std::vector<std::string> TPRFormat::read_symbol_table(const TprHeader& header) {
+    size_t nsymbols = file_.read_single_size_as_i32();
+    std::vector<std::string> symbol_table;
+    symbol_table.reserve(nsymbols);
+    for (size_t i = 0; i < nsymbols; ++i) {
+        symbol_table.emplace_back(read_gmx_string(header.body_convention));
+    }
+    return symbol_table;
+}
+
+const std::string& TPRFormat::read_symbol_table_entry(const std::vector<std::string>& table) {
+    size_t idx = file_.read_single_size_as_i32();
+    return table.at(idx);
+}
+
 std::string TPRFormat::read_gmx_string(TprBodyConvention body_convention) {
     if (body_convention == FileIOXdr) {
         return file_.read_gmx_string();
@@ -309,6 +1140,15 @@ std::string TPRFormat::read_gmx_string(TprBodyConvention body_convention) {
         buf.resize(static_cast<size_t>(len));
         file_.read_char(buf);
         return std::string(buf.begin(), buf.end());
+    }
+}
+
+uint8_t TPRFormat::read_gmx_uchar(TprBodyConvention body_convention) {
+    if (body_convention == FileIOXdr) {
+        return static_cast<uint8_t>(file_.read_single_u32());
+    } else {
+        assert(body_convention == InMemory);
+        return file_.read_single_u8();
     }
 }
 

--- a/src/formats/TRR.cpp
+++ b/src/formats/TRR.cpp
@@ -3,8 +3,8 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstdio>
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -16,6 +16,7 @@
 #include "chemfiles/File.hpp"
 #include "chemfiles/FormatMetadata.hpp"
 #include "chemfiles/Frame.hpp"
+#include "chemfiles/Property.hpp"
 #include "chemfiles/UnitCell.hpp"
 
 #include "chemfiles/files/XDRFile.hpp"

--- a/src/formats/XTC.cpp
+++ b/src/formats/XTC.cpp
@@ -109,14 +109,8 @@ void XTCFormat::read(Frame& frame) {
     frame.set("time", static_cast<double>(header.time)); // time in pico seconds
     frame.resize(natoms);
 
-    std::vector<float> box(3 * 3);
-    file_.read_f32(box);
-    auto matrix = Matrix3D(
-        static_cast<double>(box[0]), static_cast<double>(box[3]), static_cast<double>(box[6]),
-        static_cast<double>(box[1]), static_cast<double>(box[4]), static_cast<double>(box[7]),
-        static_cast<double>(box[2]), static_cast<double>(box[5]), static_cast<double>(box[8]));
-    // Factor 10 because the lengths are in nm in the XTC format
-    frame.set_cell(UnitCell(10.0 * matrix));
+    const auto box = file_.read_gmx_box();
+    frame.set_cell(box);
 
     size_t natoms_again = static_cast<size_t>(file_.read_single_i32());
     if (natoms_again != natoms) {

--- a/src/formats/XTC.cpp
+++ b/src/formats/XTC.cpp
@@ -3,8 +3,8 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstdio>
 
+#include <array>
 #include <string>
 #include <vector>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "66aba97578dc8f0b8e3fbfd005f9e07daa95476c")
+set(TESTS_DATA_GIT "a22233e95c69f9c13190c1feb901da4f519b76b9")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=ddc71439afd0c36d3c698e47c35861db6117976b
+        EXPECTED_HASH SHA1=70a9414c29d6a1e7f3f5896bc013de11f0d85a4e
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/files/xdr-file.cpp
+++ b/tests/files/xdr-file.cpp
@@ -44,6 +44,12 @@ TEST_CASE("XDR files") {
         for (size_t i = 0; i < 3; ++i) {
             CHECK(approx_eq(array[i], expected[i], 1e-4f));
         }
+
+        // Go back to the beginning to check reading of sizes as i32
+        file.seek(0);
+        CHECK_THROWS_WITH(file.read_single_size_as_i32(),
+                          "invalid value in XDR file: expected a positive integer, got -123");
+        CHECK(file.read_single_size_as_i32() == 123);
     }
 
     // clang-format off

--- a/tests/formats/tpr.cpp
+++ b/tests/formats/tpr.cpp
@@ -1,0 +1,219 @@
+// Chemfiles, a modern library for chemistry file reading and writing
+// Copyright (C) Guillaume Fraux and contributors -- BSD license
+
+#include "catch.hpp"
+#include "chemfiles.hpp"
+#include "helpers.hpp"
+
+#include <algorithm>
+
+using namespace chemfiles;
+
+static void check_traj(const char* path) {
+    auto file = Trajectory(path);
+    auto frame = file.read();
+
+    auto file_ref = Trajectory("data/tpr/reference.pdb");
+    auto frame_ref = file_ref.read();
+
+    CHECK(frame.size() == 293);
+    auto cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::TRICLINIC);
+    CHECK(approx_eq(cell.lengths(), {22.500, 33.549, 44.700}, 1e-3));
+    CHECK(approx_eq(cell.angles(), {96.66, 80.20, 109.45}, 1e-2));
+
+    auto positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(29.0200, 21.7100, 11.3700), 1e-4));
+    CHECK(approx_eq(positions[10], Vector3D(25.8400, 21.5300, 35.2600), 1e-4));
+    CHECK(approx_eq(positions[200], Vector3D(9.9500, -0.7900, 30.9400), 1e-4));
+    CHECK(approx_eq(positions[292], Vector3D(17.4500, -5.4200, 17.7700), 1e-4));
+
+    auto velocities = *frame.velocities();
+    CHECK(approx_eq(velocities[0], Vector3D(0.0, 0.0, 0.0), 1e-4));
+    CHECK(approx_eq(velocities[10], Vector3D(0.0, 0.0, 0.0), 1e-4));
+    CHECK(approx_eq(velocities[200], Vector3D(0.0, 0.0, 0.0), 1e-4));
+    CHECK(approx_eq(velocities[292], Vector3D(0.0, 0.0, 0.0), 1e-4));
+
+    CHECK(frame.get("name").value().as_string() == "MySystemName");
+
+    CHECK(frame.size() == frame_ref.size());
+    auto positions_ref = frame_ref.positions();
+    for (size_t i = 0; i < frame.size(); ++i) {
+        CHECK(approx_eq(positions[i], positions_ref[i], 1e-4));
+        auto& atom = frame[i];
+        auto& atom_ref = frame_ref[i];
+        CHECK(atom.name() == atom_ref.name());
+        CHECK(atom.type() == atom_ref.type());
+    }
+
+    const std::vector<Residue>& residues = frame.topology().residues();
+    const std::vector<Residue>& residues_ref = frame_ref.topology().residues();
+    CHECK(residues.size() == residues_ref.size());
+    for (size_t i = 0; i < residues.size(); ++i) {
+        auto& res = residues[i];
+        auto& res_ref = residues_ref[i];
+        CHECK(res.name() == res_ref.name());
+        // Do not compare residue ids because PDB is numbered sequentially
+        // and TPR uses internal numbering with possible duplicates.
+        // For this specific test file, the id is either `id == 1`
+        // for new versions or `1 >= id <= 4` for old versions.
+        CHECK((*res.id() >= 1 && *res.id() <= 4));
+        CHECK(res.size() == res_ref.size());
+        CHECK(std::equal(res.begin(), res.end(), res_ref.begin()));
+        CHECK(res.properties().size() == 1);
+        CHECK(*res.get("insertion_code") == " ");
+    }
+
+    // First Li
+    CHECK(frame[0].name() == "Li");
+    CHECK(frame[0].type() == "Li");
+    auto res = *frame.topology().residue_for_atom(0);
+    CHECK(res.name() == "LI");
+    CHECK(*res.id() == 1);
+    CHECK(approx_eq(frame[0].mass(), 6.9410, 1e-4));
+    CHECK(approx_eq(frame[0].charge(), 0.8000, 1e-4));
+    CHECK(*frame[0].get("ff_type") == "LI");
+
+    // First protein, first residue, first N
+    CHECK(frame[2].name() == "N");
+    CHECK(frame[2].type() == "N");
+    res = *frame.topology().residue_for_atom(2);
+    CHECK(res.name() == "RSK");
+    CHECK(*res.id() == 2); // from ITP, differs from PDB
+    CHECK(approx_eq(frame[2].mass(), 14.0027, 1e-4));
+    CHECK(approx_eq(frame[2].charge(), -0.3000, 1e-4));
+    CHECK(*frame[2].get("ff_type") == "opls_287");
+
+    // Third protein, last residue, first O
+    CHECK(frame[63].name() == "O1");
+    CHECK(frame[63].type() == "O");
+    res = *frame.topology().residue_for_atom(63);
+    CHECK(res.name() == "RSR");
+    CHECK(*res.id() == 4); // from ITP, differs from PDB
+    CHECK(approx_eq(frame[63].mass(), 15.9994, 1e-4));
+    CHECK(approx_eq(frame[63].charge(), -0.8000, 1e-4));
+    CHECK(*frame[63].get("ff_type") == "opls_272");
+
+    // Fourth Li
+    CHECK(frame[192].name() == "Li");
+    CHECK(frame[192].type() == "Li");
+    res = *frame.topology().residue_for_atom(192);
+    CHECK(res.name() == "LI");
+    CHECK(*res.id() == 1);
+    CHECK(approx_eq(frame[192].mass(), 6.9410, 1e-4));
+    CHECK(approx_eq(frame[192].charge(), 0.8000, 1e-4));
+    CHECK(*frame[192].get("ff_type") == "LI");
+
+    // First THF, second C
+    CHECK(frame[196].name() == "C");
+    CHECK(frame[196].type() == "C");
+    res = *frame.topology().residue_for_atom(196);
+    CHECK(res.name() == "THF");
+    CHECK(*res.id() == 1);
+    CHECK(approx_eq(frame[196].mass(), 12.0110, 1e-4));
+    CHECK(approx_eq(frame[196].charge(), -0.1200, 1e-4));
+    CHECK(*frame[196].get("ff_type") == "opls_136");
+
+    // First THF, O
+    CHECK(frame[205].name() == "O");
+    CHECK(frame[205].type() == "O");
+    res = *frame.topology().residue_for_atom(205);
+    CHECK(res.name() == "THF");
+    CHECK(*res.id() == 1);
+    CHECK(approx_eq(frame[205].mass(), 15.9994, 1e-4));
+    CHECK(approx_eq(frame[205].charge(), -0.4000, 1e-4));
+    CHECK(*frame[205].get("ff_type") == "opls_180");
+
+    const std::vector<Bond>& bonds = frame.topology().bonds();
+    const std::vector<Bond>& bonds_ref = frame_ref.topology().bonds();
+    if (bonds.size() > bonds_ref.size()) {
+        // new TPR format
+        // one intermolecular bond which is not dumped in the reference
+        CHECK(bonds.size() == bonds_ref.size() + 1);
+        Bond intermolecular_bond = {0, 99};
+        auto it = std::lower_bound(bonds.begin(), bonds.end(), intermolecular_bond);
+        CHECK(it != bonds.end());
+        CHECK(*it == intermolecular_bond);
+    } else {
+        // old TPR format
+        // no intermolecular bonds
+        CHECK(bonds.size() == bonds_ref.size());
+    }
+    for (const auto& bond : bonds_ref) {
+        auto it = std::lower_bound(bonds.begin(), bonds.end(), bond);
+        CHECK(it != bonds.end());
+        CHECK(*it == bond);
+    }
+}
+
+TEST_CASE("Read files in TPR format") {
+    SECTION("Read TPR Version 2022") {
+        check_traj("data/tpr/gmx_v2022_s.tpr");
+        check_traj("data/tpr/gmx_v2022_d.tpr");
+    }
+
+    SECTION("Read TPR Version 2021") {
+        check_traj("data/tpr/gmx_v2021_s.tpr");
+        check_traj("data/tpr/gmx_v2021_d.tpr");
+    }
+
+    SECTION("Read TPR Version 2020") {
+        check_traj("data/tpr/gmx_v2020_s.tpr");
+        check_traj("data/tpr/gmx_v2020_d.tpr");
+    }
+
+    SECTION("Read TPR Version 2019") {
+        check_traj("data/tpr/gmx_v2019_s.tpr");
+        check_traj("data/tpr/gmx_v2019_d.tpr");
+    }
+
+    SECTION("Read TPR Version 2018") {
+        check_traj("data/tpr/gmx_v2018_s.tpr");
+        check_traj("data/tpr/gmx_v2018_d.tpr");
+    }
+
+    SECTION("Read TPR Version 2016") {
+        check_traj("data/tpr/gmx_v2016_s.tpr");
+        check_traj("data/tpr/gmx_v2016_d.tpr");
+    }
+
+    SECTION("Read TPR Version v5.1") {
+        check_traj("data/tpr/gmx_v5.1_s.tpr");
+        check_traj("data/tpr/gmx_v5.1_d.tpr");
+    }
+
+    SECTION("Read TPR Version v5.0") {
+        check_traj("data/tpr/gmx_v5.0_s.tpr");
+        check_traj("data/tpr/gmx_v5.0_d.tpr");
+    }
+
+    SECTION("Read TPR Version v4.6") {
+        check_traj("data/tpr/gmx_v4.6_s.tpr");
+        check_traj("data/tpr/gmx_v4.6_d.tpr");
+    }
+
+    SECTION("Read TPR Version v4.5") {
+        check_traj("data/tpr/gmx_v4.5_s.tpr");
+        check_traj("data/tpr/gmx_v4.5_d.tpr");
+    }
+}
+
+TEST_CASE("Errors") {
+    SECTION("Read multiple frames") {
+        auto file = Trajectory("data/tpr/gmx_v2021_s.tpr");
+        file.read();
+        CHECK_THROWS_WITH(
+            file.read(),
+            "can not read file 'data/tpr/gmx_v2021_s.tpr' at step 1: maximal step is 0");
+    }
+
+    SECTION("Write error") {
+        auto tmpfile = NamedTempPath(".tpr");
+        CHECK_THROWS_WITH(Trajectory(tmpfile, 'w'), "TPR format does not support write & append");
+    }
+
+    SECTION("Append error") {
+        auto tmpfile = NamedTempPath(".tpr");
+        CHECK_THROWS_WITH(Trajectory(tmpfile, 'a'), "TPR format does not support write & append");
+    }
+}


### PR DESCRIPTION
This somewhat completes my journey through the GROMACS binary formats and is the last format needed to easily deal with GROMACS simulation output.
TPR files are preprocessed topology files which are generated from TOP and ITP files (see #212) and are needed to actually run a simulation. Therefore one has typically TPR files easier at hand than TOP files e.g. on hpc systems.
Unfortunately, TPR files are not really meant for use outside GROMACS which may lead to unannounced changes in the format (see e.g. [this issue](https://gitlab.com/gromacs/gromacs/-/issues/3269) from a few years back). The tests (and possibly implementation) should be regularly amended by TPRs from the latest release to see if anything has changed.
However, MDAnalysis parses TPR as well which means there are multiple people looking for breaking changes.

This implementation can read basically every possible topological information that chemfiles understands. GROMACS internally uses various different inter-atomic interaction functions. Here, a set of certain interaction functions is defined to be "bonded" interactions. This set is congruent to the MDA implementation and should result in the same connectivity in the topology.
Chemfiles calculates angles and other "higher order" connectivity elements itself, so there is no set for angles, etc (MDA in contrast adds those explicitly).