### PR TITLE
Make MinGW builder faster on CI

### DIFF
--- a/.github/MinGW-Toolchain.cmake
+++ b/.github/MinGW-Toolchain.cmake
@@ -1,0 +1,17 @@
+# Cmake Toolchain file for native MinGW compilers on Github CI windows-2019 VM
+
+set(CMAKE_SYSTEM_NAME Windows)
+
+set(MINGW_PREFIX "C:/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin")
+
+set(CMAKE_CXX_COMPILER ${MINGW_PREFIX}/x86_64-w64-mingw32-g++.exe CACHE FILEPATH "")
+set(CMAKE_C_COMPILER ${MINGW_PREFIX}/x86_64-w64-mingw32-gcc.exe CACHE FILEPATH "")
+
+set(CMAKE_LINKER ${MINGW_PREFIX}/ld.exe CACHE FILEPATH "")
+set(CMAKE_AR ${MINGW_PREFIX}/gcc-ar.exe CACHE FILEPATH "")
+set(CMAKE_RANLIB ${MINGW_PREFIX}/gcc-ranlib.exe CACHE FILEPATH "")
+
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "-static-libstdc++ -fuse-ld=lld")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "-static-libstdc++ -fuse-ld=lld")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-static-libstdc++ -fuse-ld=lld")

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,7 +171,7 @@ jobs:
               - -DCMAKE_SHARED_LINKER_FLAGS="-static-libstdc++"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Set up MinGW
@@ -181,7 +181,7 @@ jobs:
           platform: x64
       - name: Setup emsdk
         if: ${{ matrix.use-emsdk }}
-        uses: mymindstorm/setup-emsdk@v10
+        uses: mymindstorm/setup-emsdk@v12
         with:
           version: ${{ matrix.emscripten-version }}
           actions-cache-folder: "emsdk"
@@ -219,7 +219,7 @@ jobs:
         if: matrix.collect-coverage
         run: find . -type f -name '*.gcno' -exec gcov -p {} +
       - name: upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: matrix.collect-coverage
         with:
           fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,7 @@ jobs:
             setup-dependencies: |
               sudo apt-get update
               sudo apt-get install -y valgrind
+
           # ==
           # macOS builders
           # ==
@@ -132,6 +133,7 @@ jobs:
             setup-dependencies: |
               export HOMEBREW_NO_AUTO_UPDATE=1
               brew install gcc@9
+
           # ==
           # windows builders
           # ==
@@ -161,24 +163,32 @@ jobs:
               - -G "Visual Studio 16 2019" -A Win32
           - name: windows / MinGW
             os: windows-2019
-            cc: cc
-            cxx: c++
+            cc: C:/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/x86_64-w64-mingw32-gcc.exe
+            cxx: C:/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin/x86_64-w64-mingw32-g++.exe
+            # Linking takes a lot longer with debug information
             build-type: Release
             use-mingw: true
             cmake-extra-args:
               - -G "MinGW Makefiles"
-              - -DCMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
-              - -DCMAKE_SHARED_LINKER_FLAGS="-static-libstdc++"
+              - -DCMAKE_TOOLCHAIN_FILE=.github/MinGW-Toolchain.cmake
+              - -DCHFL_BUILD_DOCTESTS=OFF
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+
       - name: Set up MinGW
         if: ${{ matrix.use-mingw }}
         uses: egor-tensin/setup-mingw@v2
         with:
           platform: x64
+
+      - name: DEBUG
+        if: ${{ matrix.use-mingw }}
+        run: |
+          get-command gcc-ar
+          get-command gcc-ranlib
       - name: Setup emsdk
         if: ${{ matrix.use-emsdk }}
         uses: mymindstorm/setup-emsdk@v12


### PR DESCRIPTION
This tries to make CI a bit faster (MinGW builder takes 25 min just to compile the code, vs 6-8 min on most other builders)