### PR TITLE
Add check before fmt inclusion to avoid clash

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -135,19 +135,25 @@ if (${CMAKE_VERSION} VERSION_LESS "3.1")
     endfunction()
 endif()
 
-external_library(fmt)
-list(APPEND EXTERNAL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/fmt/include/)
+if(NOT TARGET fmt)
+    external_library(fmt)
+    list(APPEND EXTERNAL_INCLUDES ${CMAKE_CURRENT_BINARY_DIR}/fmt/include/)
 
-# Hide FMT variables from CMake GUI
-mark_as_advanced(FORCE
-    FMT_CUDA_TEST
-    FMT_DOC
-    FMT_FUZZ
-    FMT_INSTALL
-    FMT_PEDANTIC
-    FMT_TEST
-    FMT_WERROR
-)
+    # Hide FMT variables from CMake GUI
+    mark_as_advanced(FORCE
+        FMT_CUDA_TEST
+        FMT_DOC
+        FMT_FUZZ
+        FMT_INSTALL
+        FMT_PEDANTIC
+        FMT_TEST
+        FMT_WERROR
+    )
+else()
+    get_target_property(FMT_INCLUDES fmt INCLUDE_DIRECTORIES)
+    list(APPEND EXTERNAL_INCLUDES "${FMT_INCLUDES}")
+endif()
+
 
 # ==========
 # pugixml: http://github.com/chemfiles/pugixml


### PR DESCRIPTION
Using chemfiles with other submodules can cause clashes like the following:
```
[CMake] CMake Error at <PathToChemfiles>/chemfiles/external/fmt/CMakeLists.txt:204 (add_library):
[CMake]   add_library cannot create target "fmt" because another target with the same
[CMake]   name already exists.  The existing target is a static library created in
[CMake]   source directory
[CMake]   "<PathToExternal>/fmt".  See
[CMake]   documentation for policy CMP0002 for more details.
```
This forces the user's project to rely on chemfiles' version of fmt which is not always possible.
To address this issue and allow more flexibility, I added a check before fmt inclusion avoiding clashes with a fallback to the previously defined target. 