### PR TITLE
A draft for read and write bond type for lammps data

### DIFF
--- a/include/chemfiles/Connectivity.hpp
+++ b/include/chemfiles/Connectivity.hpp
@@ -317,7 +317,7 @@ public:
     const sorted_set<Improper>& impropers() const;
 
     /// Add a bond between the atoms `i` and `j`
-    void add_bond(size_t i, size_t j, Bond::BondOrder bond_order = Bond::UNKNOWN);
+    void add_bond(size_t i, size_t j, Bond::BondOrder bond_order = Bond::UNKNOWN, std::string);
 
     /// Remove any bond between the atoms `i` and `j`
     void remove_bond(size_t i, size_t j);
@@ -330,6 +330,9 @@ public:
 
     /// Get the bond order of the bond between i and j
     Bond::BondOrder bond_order(size_t i, size_t j) const;
+
+    /// Get the bond type of the bond between i and j
+    std::string bond_type(size_t i, size_t j) const;
 private:
     /// Recalculate the angles and the dihedrals from the bond list
     void recalculate() const;
@@ -349,6 +352,7 @@ private:
     mutable bool uptodate_ = false;
     /// Store the bond orders
     std::vector<Bond::BondOrder> bond_orders_;
+    std::vector<std::string> bond_types_;
 };
 
 } // namespace chemfiles

--- a/include/chemfiles/Connectivity.hpp
+++ b/include/chemfiles/Connectivity.hpp
@@ -317,7 +317,7 @@ public:
     const sorted_set<Improper>& impropers() const;
 
     /// Add a bond between the atoms `i` and `j`
-    void add_bond(size_t i, size_t j, Bond::BondOrder bond_order = Bond::UNKNOWN, std::string);
+    void add_bond(size_t i, size_t j, Bond::BondOrder bond_order = Bond::UNKNOWN, std::string = "");
 
     /// Remove any bond between the atoms `i` and `j`
     void remove_bond(size_t i, size_t j);

--- a/include/chemfiles/Frame.hpp
+++ b/include/chemfiles/Frame.hpp
@@ -246,8 +246,8 @@ public:
     /// @param bond_order the bond order of the new bond
     /// @throws OutOfBounds if `atom_i` or `atom_j` are greater than `size()`
     /// @throws Error if `atom_i == atom_j`, as this is an invalid bond
-    void add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order = Bond::UNKNOWN) {
-        topology_.add_bond(atom_i, atom_j, bond_order);
+    void add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order = Bond::UNKNOWN, std::string bond_type = "") {
+        topology_.add_bond(atom_i, atom_j, bond_order, bond_type);
     }
 
     /// Remove a bond in the system, between the atoms at index `atom_i` and

--- a/include/chemfiles/Topology.hpp
+++ b/include/chemfiles/Topology.hpp
@@ -115,7 +115,7 @@ public:
     /// @param bond_order the bond order for the bond added
     /// @throws OutOfBounds if `atom_i` or `atom_j` are greater than `size()`
     /// @throws Error if `atom_i == atom_j`, as this is an invalid bond
-    void add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order = Bond::UNKNOWN);
+    void add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order = Bond::UNKNOWN, std::string = "");
 
     /// Remove a bond in the system, between the atoms at index `atom_i` and
     /// `atom_j`.
@@ -140,6 +140,19 @@ public:
     /// @throws OutOfBounds if `atom_i` or `atom_j` are greater than `size()`
     /// @throws Error if no bond between `atom_i` and `atom_j` exists.
     Bond::BondOrder bond_order(size_t atom_i, size_t atom_j) const;
+
+    /// Get the bond type for the given bond
+    ///
+    /// If the bond does not exist, this will thrown an Error.
+    ///
+    /// @example{topology/bond_order.cpp}
+    ///
+    /// @param atom_i the index of the first atom in the bond
+    /// @param atom_j the index of the second atom in the bond
+    /// @throws OutOfBounds if `atom_i` or `atom_j` are greater than `size()`
+    /// @throws Error if no bond between `atom_i` and `atom_j` exists.
+    std::string bond_type(size_t atom_i, size_t atom_j) const;
+
 
     /// Get the number of atoms in the topology
     ///

--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -59,7 +59,7 @@ public:
 
 // atom types are defined by the type string and the mass of the atom
 using atom_type = std::pair<std::string, double>;
-using bond_type = std::tuple<size_t, size_t>;
+using bond_type = std::tuple<std::string, size_t, size_t>;
 using angle_type = std::tuple<size_t, size_t, size_t>;
 using dihedral_type = std::tuple<size_t, size_t, size_t, size_t>;
 using improper_type = std::tuple<size_t, size_t, size_t, size_t>;
@@ -81,12 +81,12 @@ public:
     /// the vector backing the `sorted_set<atom_type>` returned by `atoms()`.
     size_t atom_type_id(const Atom& atom) const;
 
-    /// Get the bond type number for the bond type i-j.
+    /// Get the bond type number for the bond type.
     ///
     /// The bond type must be in the topology used to construct this `DataTypes`
     /// instance. The index numbering starts at zero, and can be used to index
     /// the vector backing the `sorted_set<bond_type>` returned by `bonds()`.
-    size_t bond_type_id(size_t type_i, size_t type_j) const;
+    size_t bond_type_id(std::string, size_t, size_t) const;
 
     /// Get the angle type number for the angle type i-j-k.
     ///

--- a/src/Connectivity.cpp
+++ b/src/Connectivity.cpp
@@ -186,7 +186,7 @@ const sorted_set<Improper>& Connectivity::impropers() const {
     return impropers_;
 }
 
-void Connectivity::add_bond(size_t i, size_t j, Bond::BondOrder bond_order) {
+void Connectivity::add_bond(size_t i, size_t j, Bond::BondOrder bond_order, std::string bond_type) {
     uptodate_ = false;
     auto result = bonds_.emplace(i, j);
     if (i > biggest_atom_) {biggest_atom_ = i;}
@@ -195,6 +195,7 @@ void Connectivity::add_bond(size_t i, size_t j, Bond::BondOrder bond_order) {
     if (result.second) {
         auto diff = std::distance(bonds_.cbegin(), result.first);
         bond_orders_.insert(bond_orders_.begin() + diff, bond_order);
+        bond_types_.insert(bond_types_.begin() + diff, bond_type);
     }
 }
 
@@ -251,6 +252,20 @@ Bond::BondOrder Connectivity::bond_order(size_t i, size_t j) const {
 
     throw error(
         "out of bounds atomic index in `Connectivity::bond_order`: "
+        "No bond between {} and {} exists",
+        i, j
+    );
+}
+
+std::string Connectivity::bond_type(size_t i, size_t j) const {
+    auto pos = bonds_.find(Bond(i, j));
+    if (pos != bonds_.end()) {
+        auto diff = std::distance(bonds_.cbegin(), pos);
+        return bond_types_[static_cast<size_t>(diff)];
+    }
+
+    throw error(
+        "out of bounds atomic index in `Connectivity::bond_type`: "
         "No bond between {} and {} exists",
         i, j
     );

--- a/src/Topology.cpp
+++ b/src/Topology.cpp
@@ -36,7 +36,7 @@ void Topology::reserve(size_t size) {
     atoms_.reserve(size);
 }
 
-void Topology::add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order) {
+void Topology::add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order, std::string bond_type) {
     if (atom_i >= size() || atom_j >= size()) {
         throw out_of_bounds(
             "out of bounds atomic index in `Topology::add_bond`: "
@@ -44,7 +44,7 @@ void Topology::add_bond(size_t atom_i, size_t atom_j, Bond::BondOrder bond_order
             size(), atom_i, atom_j
         );
     }
-    connect_.add_bond(atom_i, atom_j, bond_order);
+    connect_.add_bond(atom_i, atom_j, bond_order, bond_type);
 }
 
 void Topology::remove_bond(size_t atom_i, size_t atom_j) {
@@ -68,6 +68,18 @@ Bond::BondOrder Topology::bond_order(size_t atom_i, size_t atom_j) const {
     }
 
     return connect_.bond_order(atom_i, atom_j);
+}
+
+std::string Topology::bond_type(size_t atom_i, size_t atom_j) const {
+    if (atom_i >= size() || atom_j >= size()) {
+        throw out_of_bounds(
+            "out of bounds atomic index in `Topology::bond_type`: "
+            "we have {} atoms, but the bond indexes are {} and {}",
+            size(), atom_i, atom_j
+        );
+    }
+
+    return connect_.bond_type(atom_i, atom_j);
 }
 
 void Topology::remove(size_t i) {


### PR DESCRIPTION
Dear @Luthaf  and other developers,

According to the previous discussion #476 , I write an untested draft that read and write bond type from lammps data file. In this PR, I want to read and write bond/angle/dihedral data from lammps data and trajectory.

Since issue #462 is planning to support symbolic atom type, I choose std::string as the representation for bond type. 

In the following code, I completely complied with the storage method of BondOrder. But here I want to initiate a discussion about whether to use `bond type` or even `bond order` as a member attribute of `Bond`, like `type` in `Atom`. I think the benefits are as follows: The form is tidier, and the bond information can be obtained directly by iterating `topology.bonds`

I hope you can review my code in your free time so that I can complete these features in the future~ 

Thanks a lot! 