### PR TITLE
Add TPR files with format version 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Amber NetCDF files are now read/written with a custom netcdf parser (#443)
 - TRR and XTC files are now read/written with a custom XDR files parser (#451)
 - DCD files are now read/written with a custom parser (#453)
+- Support TPR files up to version 2023 without a warning. Files from future
+  versions are tried to be read but emit a warning
 
 ### Changes to the C++ API
 - Per-atom properties are optional, i.e. `Atom::properties` returns an optional property map.

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -69,6 +69,7 @@ class TPRVersion {
         ReaddedConstantAcceleration,
         RemoveTholeRfac,
         RemoveAtomtypes,
+        EnsembleTemperature,
         Count // This number is for the total number of versions
     };
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "26e54a77e8ee73cf015413c1c247908495ad06dc")
+set(TESTS_DATA_GIT "845124105e4acf05a365d2410d45e78f77c60349")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=b1b01f355320cc9f6ba47c417f36f14acd01ac1b
+        EXPECTED_HASH SHA1=581b7e68d530db4f2fe5349d206911fbd349dc4c
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/tpr.cpp
+++ b/tests/formats/tpr.cpp
@@ -147,6 +147,11 @@ static void check_traj(const char* path) {
 }
 
 TEST_CASE("Read files in TPR format") {
+    SECTION("Read TPR Version 2023") {
+        check_traj("data/tpr/gmx_v2023_s.tpr");
+        check_traj("data/tpr/gmx_v2023_d.tpr");
+    }
+
     SECTION("Read TPR Version 2022") {
         check_traj("data/tpr/gmx_v2022_s.tpr");
         check_traj("data/tpr/gmx_v2022_d.tpr");


### PR DESCRIPTION
Removes warning the warning "file version is from the future" when reading TPR files produced by GROMACS version 2023.
Also, added test files.