### PR TITLE
Faster XTC decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - DCD files are now read/written with a custom parser (#453)
 - Support TPR files up to version 2023 without a warning. Files from future
   versions are tried to be read but emit a warning
+- Improved reading speed of XTC files by implementing a decoding routine
+  proposed by [libxtc](https://doi.org/10.1186/s13104-021-05536-5)
 
 ### Changes to the C++ API
 - Per-atom properties are optional, i.e. `Atom::properties` returns an optional property map.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "845124105e4acf05a365d2410d45e78f77c60349")
+set(TESTS_DATA_GIT "2e29a3fe1704bc0f0ea51052a651dc617bc64b74")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=581b7e68d530db4f2fe5349d206911fbd349dc4c
+        EXPECTED_HASH SHA1=7833a7181f2d90db22a07e29968574b0f0c503de
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/files/xdr-file.cpp
+++ b/tests/files/xdr-file.cpp
@@ -10,14 +10,14 @@ using namespace chemfiles;
 
 static void write_xdr_file(XDRFile& file) {
     file.write_gmx_string("Hello!"); // needs 2B padding
-    const std::vector<float> arrary = {1.234f, -5.123f, 100.232f};
-    file.write_gmx_compressed_floats(arrary, 1000.0);
+    const std::vector<float> array = {1.234f, -5.123f, 100.232f};
+    file.write_gmx_compressed_floats(array, 1000.0);
 }
 
 TEST_CASE("XDR files") {
     SECTION("read") {
         XDRFile file("data/misc/xdr.bin", File::READ);
-        CHECK(file.file_size() == 112);
+        CHECK(file.file_size() == 164);
 
         // read some big-endian data types
         CHECK(file.read_single_i32() == -123);
@@ -26,17 +26,19 @@ TEST_CASE("XDR files") {
         CHECK(file.read_single_f32() == -4.567f);
 
         std::vector<double> darr;
-        darr.resize(3);
+        darr.resize(6);
         file.read_f64(darr);
-        const std::vector<double> dexpected = {1.234, -6.234, 105.232};
+        const std::vector<double> dexpected = {1.234,    -6.234,    105.232,
+                                               1034.346, -5056.465, 10054.475};
         CHECK(darr == dexpected);
 
         auto array = std::vector<float>();
-        array.resize(3);
+        array.resize(6);
         file.read_f32(array);
-        const std::vector<float> expected = {1.234f, -5.123f, 100.232f};
+        const std::vector<float> expected = {1.234f,    -5.123f,    100.232f,
+                                             1034.346f, -5056.465f, 10054.475f};
         CHECK(array == expected);
-        array = {0.0, 0.0, 0.0};
+        array = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
         // read XDR and GROMACS specific data types
         CHECK(file.read_gmx_string() == "Hello!");


### PR DESCRIPTION
This PR adds faster decoding of integers which are stored as <= 64 bits. For these values, integer arithmetic can be used as proposed [here](https://doi.org/10.1186/s13104-021-05536-5) and implemented by [libxtc](https://gitlab.com/impulse_md/libxtc).

libxtc also has a special implementation for larger ints using 128 bit ints. I found that these lengths are rather unusual in "typical" MD trajectories.
Instead, the old algorithm is used to decode those values here eliminating special compile time checks for the presence of 128 bit types.

Also, a testcase for these large ints is added to test the old code paths.

The changes reduce the time to read the `ubuquitin.xtc` test file by more than 20%.