### PR TITLE
mmtf optimization issue

### DIFF
--- a/src/formats/MMTF.cpp
+++ b/src/formats/MMTF.cpp
@@ -590,7 +590,7 @@ void MMTFFormat::add_residue_to_structure(const Frame& frame, const Residue& res
     group.atomNameList.reserve(residue.size());
     group.elementList.reserve(residue.size());
 
-    auto positions = frame.positions();
+    const auto& positions = frame.positions();
     for (auto i: residue) {
         const auto& atom = frame[i];
         group.formalChargeList.emplace_back(atom.charge());


### PR DESCRIPTION
Writing a mmtf file of a big molecule is taking a lot of time abnormally.

On line 593 of src/formats/MMTF.cpp there is the line :
`auto positions = frame.positions();`

This affectation make a copy of the whole position vector instead of just got a reference.
Because this affectation is called for every residue, it dramatically slow down the writing process.

Changing it to
`const auto& positions = frame.positions();`

will use a reference assignment and correct the optimization issue.