### PR TITLE
Handle whitespaces in more places in LAMMPS Data format

### DIFF
--- a/include/chemfiles/formats/LAMMPSData.hpp
+++ b/include/chemfiles/formats/LAMMPSData.hpp
@@ -168,7 +168,7 @@ private:
     /// Read the header section
     void read_header(Frame& frame);
     size_t read_header_integer(string_view line, const std::string& context);
-    double read_header_box_bounds(string_view line, const std::string& context);
+    double read_header_box_bounds(string_view line, const std::string& lo, const std::string& hi);
 
     /// Get the section name from the next non-empty line
     void get_next_section();

--- a/include/chemfiles/utils.hpp
+++ b/include/chemfiles/utils.hpp
@@ -88,7 +88,7 @@ inline char to_ascii_uppercase(char c) {
     }
 }
 
-/// Remove whitespaces at the begining and end of `string`
+/// Remove whitespaces at the beginning and end of `string`
 inline string_view trim(string_view string) {
     auto begin = string.begin();
     auto end = string.end();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "2e29a3fe1704bc0f0ea51052a651dc617bc64b74")
+set(TESTS_DATA_GIT "1256f2dbf7370528fb8361b28d78e4534633b1f7")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=7833a7181f2d90db22a07e29968574b0f0c503de
+        EXPECTED_HASH SHA1=5b25c9b2b5e3be9eeacfc435a15ad0598ee4ace5
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/formats/lammps-data.cpp
+++ b/tests/formats/lammps-data.cpp
@@ -110,6 +110,12 @@ TEST_CASE("Read files in LAMMPS data format") {
         CHECK(topology.residue_for_atom(9)->contains(11));
         CHECK(topology.residue_for_atom(9)->id().value() == 3);
     }
+
+    SECTION("File with whitespaces") {
+        // https://github.com/chemfiles/chemfiles/issues/485
+        auto file = Trajectory("data/lammps-data/whitespaces.lmp", 'r', "LAMMPS Data");
+        auto frame = file.read();
+    }
 }
 
 TEST_CASE("Write files in LAMMPS data format") {


### PR DESCRIPTION
Fix #485 

Corresponding test file: https://github.com/chemfiles/tests-data/blob/1256f2dbf7370528fb8361b28d78e4534633b1f7/lammps-data/whitespaces.lmp