### PR TITLE
Support for reading and writing simulation time in Amber Restart and Amber NetCFD trajectories

### DIFF
--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -42,10 +42,12 @@ When writing, the first frame writen to a DCD file sets this header field."""
 type = "number"
 
 LAMMPS = "The time of the frame in time units."
-TNG = "The time of the frame in pico seconds."
-TRR = "The time of the frame in pico seconds."
-XTC = "The time of the frame in pico seconds."
+TNG = "The time of the frame in picoseconds."
+TRR = "The time of the frame in picoseconds."
+XTC = "The time of the frame in picoseconds."
 DCD = "The time of the frame in the file units, only set when reading a file"
+"Amber NetCDF" = "The time of the frame in picoseconds, only set when reading a file"
+"Amber Restart" = "The time of the frame in picoseconds, only set when reading a file"
 
 [lammps_units]
 type = "string"

--- a/doc/src/properties/frame.toml
+++ b/doc/src/properties/frame.toml
@@ -45,9 +45,9 @@ LAMMPS = "The time of the frame in time units."
 TNG = "The time of the frame in picoseconds."
 TRR = "The time of the frame in picoseconds."
 XTC = "The time of the frame in picoseconds."
-DCD = "The time of the frame in the file units, only set when reading a file"
-"Amber NetCDF" = "The time of the frame in picoseconds, only set when reading a file"
-"Amber Restart" = "The time of the frame in picoseconds, only set when reading a file"
+DCD = "The time of the frame in the file units, only set when reading a file."
+"Amber NetCDF" = "The time of the frame in picoseconds."
+"Amber Restart" = "The time of the frame in picoseconds."
 
 [lammps_units]
 type = "string"

--- a/include/chemfiles/formats/AmberNetCDF.hpp
+++ b/include/chemfiles/formats/AmberNetCDF.hpp
@@ -58,6 +58,7 @@ protected:
         variable_scale_t velocities;
         variable_scale_t cell_lengths;
         variable_scale_t cell_angles;
+        variable_scale_t time;
     } variables_;
 
     optional<std::string> file_title_;

--- a/src/formats/AmberNetCDF.cpp
+++ b/src/formats/AmberNetCDF.cpp
@@ -288,7 +288,7 @@ void AmberNetCDFBase::write(const Frame& frame) {
                 throw format_error("invalid type for time variable");
             }
         } else {
-            warning("AMBER NetCDF", "this file does not contain space for time, it will not be saved");
+            warning("AMBER NetCDF", "this file does not have a 'time' attribute, it will not be saved");
         }
     }
 

--- a/tests/formats/amber-netcdf.cpp
+++ b/tests/formats/amber-netcdf.cpp
@@ -89,10 +89,13 @@ TEST_CASE("Write files in NetCDF format") {
         auto cell = frame.cell();
         CHECK(approx_eq(cell.lengths(), {2, 3, 4}, 1e-6));
         CHECK(approx_eq(cell.angles(), {80, 90, 120}, 1e-6));
+
+        CHECK(approx_eq(frame.get("time")->as_double(), 10.0));
     };
 
     auto frame = Frame(UnitCell({2, 3, 4}, {80, 90, 120}));
     frame.set("name", "Test Title 123");
+    frame.set("time", 10.0);
     frame.add_velocities();
     for(size_t i=0; i<4; i++) {
         double d = static_cast<double>(i);

--- a/tests/formats/amber-netcdf.cpp
+++ b/tests/formats/amber-netcdf.cpp
@@ -16,6 +16,8 @@ TEST_CASE("Read files in NetCDF format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.4172191, 8.303366, 11.73717), 1e-4));
         CHECK(approx_eq(positions[296], Vector3D(6.664049, 11.61418, 12.96149), 1e-4));
+        // Check time
+        CHECK(approx_eq(frame.get("time")->as_double(), 2.02));
     }
 
     SECTION("Read more than one frame") {
@@ -29,6 +31,7 @@ TEST_CASE("Read files in NetCDF format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.2990952, 8.31003, 11.72146), 1e-4));
         CHECK(approx_eq(positions[296], Vector3D(6.797599, 11.50882, 12.70423), 1e-4));
+        CHECK(approx_eq(frame.get("time")->as_double(), 2.04));
 
         while (!file.done()) {
             frame = file.read();
@@ -36,6 +39,7 @@ TEST_CASE("Read files in NetCDF format") {
         positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.3185586, 8.776042, 11.8927), 1e-4));
         CHECK(approx_eq(positions[296], Vector3D(7.089802, 10.35007, 12.8159), 1e-4));
+        CHECK(approx_eq(frame.get("time")->as_double(), 3.01));
     }
 
     SECTION("Missing unit cell") {

--- a/tests/formats/amber-restart.cpp
+++ b/tests/formats/amber-restart.cpp
@@ -23,6 +23,10 @@ TEST_CASE("Read files in Amber Restart format") {
         auto positions = frame.positions();
         CHECK(approx_eq(positions[0], Vector3D(0.4172191, 8.303366, 11.73717), 1e-4));
         CHECK(approx_eq(positions[296], Vector3D(6.664049, 11.61418, 12.96149), 1e-4));
+
+        // Check time
+        // time in water.ncrst is in ps, but in water.nc it's in fs
+        CHECK(approx_eq(frame.get("time")->as_double(), 2020.0));
     }
 
     SECTION("Missing unit cell") {

--- a/tests/formats/amber-restart.cpp
+++ b/tests/formats/amber-restart.cpp
@@ -80,10 +80,13 @@ TEST_CASE("Write files in Amber Restart format") {
         auto cell = frame.cell();
         CHECK(approx_eq(cell.lengths(), {2, 3, 4}, 1e-9));
         CHECK(approx_eq(cell.angles(), {80, 90, 120}, 1e-9));
+        
+        CHECK(approx_eq(frame.get("time")->as_double(), 10.0));
     };
 
     auto frame = Frame(UnitCell({2, 3, 4}, {80, 90, 120}));
     frame.set("name", "Test Title 123");
+    frame.set("time", 10.0);
     frame.add_velocities();
     for(size_t i=0; i<4; i++) {
         double d = static_cast<double>(i);


### PR DESCRIPTION
1. I’ve added support for reading simulation time from both Amber Restart and Amber NetCDF trajectories. I also added some checks for this in the existing tests. I also did some manual testing with a handful of other `.nc` files to confirm the reported times are accurate - though it wasn’t particularly exhaustive. Reading NetCDF trajectories without time info still works as expected too.

2. I’ve also added the ability to write simulation time for both Amber Restart and Amber NetCDF trajectories. For trajectories, time writing is only initialized if the first frame written includes time info. If a later frame includes time info but time writing wasn’t initialized, a warning is raised, and the time isn’t written. If time writing *is* initialized and a frame doesn’t have time info, nothing happens. I ran some manual tests to ensure the files generated by chemfiles can be read by VMD, and everything looks good. The files are also parsable by `netCDF4` and the time info is accessible. The writer assumes that frame time is in picoseconds. I’ve also added checks for time handling in the write tests.

3. I've also updated the documentation in `frame.toml`.

4. Finally, I've tested `chemfiles.rs` compiled with this new version of chemfiles and everything seems to be working fine as well there.

This addresses [Issue #500](https://github.com/chemfiles/chemfiles/issues/500).

I don’t have much experience with C++, so a thorough code review might be useful.