### PR TITLE
Change unit cell matrix representation to be row-major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   proposed by [libxtc](https://doi.org/10.1186/s13104-021-05536-5)
 
 ### Changes to the C++ API
-- Per-atom properties are optional, i.e. `Atom::properties` returns an optional property map.
+
+- Per-atom properties are optional, i.e. `Atom::properties` returns an optional
+  property map.
+- Unit cell matrixes are now stored one cell vector per row (previously of cell
+  vector per column).
 
 ## 0.10.0 (14 Feb 2021)
 

--- a/include/chemfiles/UnitCell.hpp
+++ b/include/chemfiles/UnitCell.hpp
@@ -14,7 +14,7 @@
 
 namespace chemfiles {
 
-namespace private_details {
+namespace details {
     /// check if a single value is close enough to zero to be considered equal
     /// to zero, in the context of unit cell matrices
     bool is_roughly_zero(double value);
@@ -26,19 +26,33 @@ namespace private_details {
     /// check if a matrix is diagonal according to `is_roughly_zero`
     bool is_diagonal(const Matrix3D& matrix);
 
-    /// check if a matrix is an upper triangular matrix according to
+    /// check if a matrix is a lower triangular matrix according to
     /// `is_roughly_zero`
-    bool is_upper_triangular(const Matrix3D& matrix);
+    bool is_lower_triangular(const Matrix3D& matrix);
 }
 
 /// An UnitCell represent the box containing the atoms, and its periodicity
 ///
-/// A unit cell is represented by the cell matrix, containing the three cell
-/// vectors:
+/// An unit cell is defined by three vectors (A, B, and C), which can be stored
+/// together to define a matrix represenation of the cell (storing one vector
+/// per row):
+///
 /// ```
-/// | a_x   b_x   c_x |
-/// | a_y   b_y   c_y |
-/// | a_z   b_z   c_z |
+/// | a_x    a_y   a_z |
+/// | b_x    b_y   b_z |
+/// | c_x    c_y   c_z |
+/// ```
+///
+/// Alternatively, the cell can be represented with three lengths (a, b, c); and
+/// three angles (alpha, beta, gamma). The angles are stored in degrees, and the
+/// lengths in Angstroms. In this representation, the overall cell orientation
+/// is lost, and we choose to orient the cell such that the A vector is along
+/// the x axis, and the B vector is in the xy plane:
+///
+/// ```
+/// | a_x    0     0   |
+/// | b_x    b_y   0   |
+/// | c_x    c_y   c_z |
 /// ```
 class CHFL_EXPORT UnitCell final {
 public:
@@ -162,8 +176,8 @@ private:
 
     /// Cell matrix
     Matrix3D matrix_;
-    /// Caching the inverse of the cell matrix
-    Matrix3D matrix_inv_;
+    /// Caching the transpose of the inverse of the cell matrix
+    Matrix3D matrix_inv_transposed_;
     /// Cell type
     CellShape shape_;
 };

--- a/include/chemfiles/capi/types.h
+++ b/include/chemfiles/capi/types.h
@@ -65,18 +65,26 @@ typedef struct CHFL_ATOM CHFL_ATOM;
 ///
 /// A `CHFL_CELL` represent the box containing the atoms, and its periodicity.
 ///
-/// An unit cell is fully represented by three lengths (a, b, c); and three angles
-/// (alpha, beta, gamma). The angles are stored in degrees, and the lengths in
-/// Angstroms.
-///
-/// A cell also has a matricial representation, by projecting the three base
-/// vector into an orthonormal base. We choose to represent such matrix as an
-/// upper triangular matrix:
+/// An unit cell is defined by three vectors (A, B, and C), which can be stored
+/// together to define a matrix represenation of the cell (storing one vector
+/// per row):
 ///
 /// ```
-/// | a_x   b_x   c_x |
-/// |  0    b_y   c_y |
-/// |  0     0    c_z |
+/// | a_x    a_y   a_z |
+/// | b_x    b_y   b_z |
+/// | c_x    c_y   c_z |
+/// ```
+///
+/// Alternatively, the cell can be represented with three lengths (a, b, c); and
+/// three angles (alpha, beta, gamma). The angles are stored in degrees, and the
+/// lengths in Angstroms. In this representation, the overall cell orientation
+/// is lost, and we choose to orient the cell such that the A vector is along
+/// the x axis, and the B vector is in the xy plane:
+///
+/// ```
+/// | a_x    0     0   |
+/// | b_x    b_y   0   |
+/// | c_x    c_y   c_z |
 /// ```
 typedef struct CHFL_CELL CHFL_CELL;
 

--- a/include/chemfiles/types.hpp
+++ b/include/chemfiles/types.hpp
@@ -38,6 +38,9 @@ public:
     /// @example{vector3d/vector3d-3.cpp}
     Vector3D(double x, double y, double z): super({{x, y, z}}) {}
 
+    /// Create a Vector3D from an std::array
+    Vector3D(std::array<double, 3> v): super(v) {}
+
     ~Vector3D() = default;
     Vector3D(const Vector3D&) = default;
     Vector3D& operator=(const Vector3D&) = default;

--- a/src/UnitCell.cpp
+++ b/src/UnitCell.cpp
@@ -31,7 +31,7 @@ static double sind(double theta) {
     return sin(deg2rad(theta));
 }
 
-namespace chemfiles { namespace private_details {
+namespace chemfiles { namespace details {
     bool is_roughly_zero(double value) {
         // We think that 0.00001 is close enough to 0
         return fabs(value) < 1e-5;
@@ -48,13 +48,13 @@ namespace chemfiles { namespace private_details {
                is_roughly_zero(matrix[0][2]) && is_roughly_zero(matrix[1][2]);
     }
 
-    bool is_upper_triangular(const Matrix3D& matrix) {
-        return is_roughly_zero(matrix[1][0]) && is_roughly_zero(matrix[2][0]) &&
-               is_roughly_zero(matrix[2][1]);
+    bool is_lower_triangular(const Matrix3D& matrix) {
+        return is_roughly_zero(matrix[0][1]) && is_roughly_zero(matrix[0][2]) &&
+               is_roughly_zero(matrix[1][2]);
     }
 }}
 
-using namespace chemfiles::private_details;
+using namespace chemfiles::details;
 
 static void check_lengths(const Vector3D& lengths) {
     if (lengths[0] < 0 || lengths[1] < 0 || lengths[2] < 0) {
@@ -91,37 +91,37 @@ static Matrix3D cell_matrix_from_lenths_angles(Vector3D lengths, Vector3D angles
     auto matrix = Matrix3D::zero();
 
     matrix[0][0] = lengths[0];
-    matrix[1][0] = 0;
-    matrix[2][0] = 0;
+    matrix[0][1] = 0;
+    matrix[0][2] = 0;
 
-    matrix[0][1] = cosd(angles[2]) * lengths[1];
+    matrix[1][0] = cosd(angles[2]) * lengths[1];
     matrix[1][1] = sind(angles[2]) * lengths[1];
-    matrix[2][1] = 0;
+    matrix[1][2] = 0;
 
-    matrix[0][2] = cosd(angles[1]);
-    matrix[1][2] = (cosd(angles[0]) - cosd(angles[1]) * cosd(angles[2])) / sind(angles[2]);
-    matrix[2][2] = sqrt(1 - matrix[0][2] * matrix[0][2] - matrix[1][2] * matrix[1][2]);
-    matrix[0][2] *= lengths[2];
-    matrix[1][2] *= lengths[2];
+    matrix[2][0] = cosd(angles[1]);
+    matrix[2][1] = (cosd(angles[0]) - cosd(angles[1]) * cosd(angles[2])) / sind(angles[2]);
+    matrix[2][2] = sqrt(1 - matrix[2][0] * matrix[2][0] - matrix[2][1] * matrix[2][1]);
+    matrix[2][0] *= lengths[2];
+    matrix[2][1] *= lengths[2];
     matrix[2][2] *= lengths[2];
 
-    assert(is_upper_triangular(matrix));
+    assert(is_lower_triangular(matrix));
 
     return matrix;
 }
 
 static Vector3D calc_lengths_from_cell_matrix(const Matrix3D& matrix) {
-    Vector3D v1 = {matrix[0][0], matrix[1][0], matrix[2][0]};
-    Vector3D v2 = {matrix[0][1], matrix[1][1], matrix[2][1]};
-    Vector3D v3 = {matrix[0][2], matrix[1][2], matrix[2][2]};
+    auto v1 = Vector3D(matrix[0]);
+    auto v2 = Vector3D(matrix[1]);
+    auto v3 = Vector3D(matrix[2]);
 
     return {v1.norm(), v2.norm(), v3.norm()};
 }
 
 static Vector3D calc_angles_from_cell_matrix(const Matrix3D& matrix) {
-    Vector3D v1 = {matrix[0][0], matrix[1][0], matrix[2][0]};
-    Vector3D v2 = {matrix[0][1], matrix[1][1], matrix[2][1]};
-    Vector3D v3 = {matrix[0][2], matrix[1][2], matrix[2][2]};
+    auto v1 = Vector3D(matrix[0]);
+    auto v2 = Vector3D(matrix[1]);
+    auto v3 = Vector3D(matrix[2]);
 
     return {
         rad2deg(acos(dot(v2, v3) / (v2.norm() * v3.norm()))),
@@ -153,7 +153,7 @@ UnitCell::UnitCell(Vector3D lengths): UnitCell(lengths, {90, 90, 90}) {}
 UnitCell::UnitCell(Vector3D lengths, Vector3D angles):
     UnitCell(cell_matrix_from_lenths_angles(lengths, angles)) {}
 
-UnitCell::UnitCell(Matrix3D matrix): matrix_(matrix), matrix_inv_(Matrix3D::unit()) {
+UnitCell::UnitCell(Matrix3D matrix): matrix_(matrix), matrix_inv_transposed_(Matrix3D::unit()) {
     auto determinant = matrix_.determinant();
     if (determinant < 0.0) {
         throw error("invalid unit cell matrix with negative determinant");
@@ -178,7 +178,7 @@ UnitCell::UnitCell(Matrix3D matrix): matrix_(matrix), matrix_inv_(Matrix3D::unit
 
     if (!is_roughly_zero(this->volume())) {
         // Do not try to invert a cell with a 0 volume
-        matrix_inv_ = matrix_.invert();
+        matrix_inv_transposed_ = matrix_.invert().transpose();
     }
 }
 
@@ -251,7 +251,7 @@ void UnitCell::set_lengths(Vector3D lengths) {
 
     check_lengths(lengths);
 
-    if (!is_upper_triangular(matrix_)) {
+    if (!is_lower_triangular(matrix_)) {
         warning("UnitCell", "resetting unit cell orientation in set_lengths");
     }
 
@@ -266,7 +266,7 @@ void UnitCell::set_angles(Vector3D angles) {
 
     check_angles(angles);
 
-    if (!is_upper_triangular(matrix_)) {
+    if (!is_lower_triangular(matrix_)) {
         warning("UnitCell", "resetting unit cell orientation in set_angles");
     }
 
@@ -284,11 +284,11 @@ Vector3D UnitCell::wrap_orthorhombic(const Vector3D& vector) const {
 }
 
 Vector3D UnitCell::wrap_triclinic(const Vector3D& vector) const {
-    auto fractional = matrix_inv_ * vector;
+    auto fractional = matrix_inv_transposed_ * vector;
     fractional[0] -= round(fractional[0]);
     fractional[1] -= round(fractional[1]);
     fractional[2] -= round(fractional[2]);
-    return matrix_ * fractional;
+    return matrix_.transpose() * fractional;
 }
 
 Vector3D UnitCell::wrap(const Vector3D& vector) const {

--- a/src/formats/CML.cpp
+++ b/src/formats/CML.cpp
@@ -255,7 +255,7 @@ void CMLFormat::read_atoms(Frame& frame, const pugi::xml_node& atoms) {
 
         Vector3D position;
         if (frame.cell().shape() != UnitCell::INFINITE && (xf != 0.0 || yf != 0.0 || zf != 0.0)) {
-            position = frame.cell().matrix() * Vector3D(xf, yf, zf);
+            position = frame.cell().matrix().transpose() * Vector3D(xf, yf, zf);
         } else if (x3 == 0.0 && y3 == 0.0 && z3 == 0.0) {
             position = Vector3D(x2, y2, 0);
         } else {

--- a/src/formats/CSSR.cpp
+++ b/src/formats/CSSR.cpp
@@ -112,7 +112,7 @@ void CSSRFormat::read_next(Frame& frame) {
 
         auto position = Vector3D(x, y, z);
         if (use_fractional) {
-            position = frame.cell().matrix() * position;
+            position = frame.cell().matrix().transpose() * position;
         }
 
         // Atomic names can be created as <type><id>: O121 H22
@@ -182,7 +182,7 @@ void CSSRFormat::write_next(const Frame& frame) {
     }
 
     const auto& positions = frame.positions();
-    auto cell_inv = frame.cell().matrix().invert();
+    auto cell_inv = frame.cell().matrix().invert().transpose();
     for (size_t i = 0; i<frame.size(); i++) {
         std::string atom_id;
         if (i <= 9999) {

--- a/src/formats/DCD.cpp
+++ b/src/formats/DCD.cpp
@@ -627,9 +627,9 @@ void DCDFormat::write_cell(const UnitCell& cell) {
         }
     }
 
-    if (!chemfiles::private_details::is_upper_triangular(cell.matrix())) {
+    if (!chemfiles::details::is_lower_triangular(cell.matrix())) {
         warning("DCD writer",
-            "the unit cell is not upper-triangular, positions might not align "
+            "the unit cell is not lower-triangular, positions might not align "
             "with the cell in the file"
         );
     }

--- a/src/formats/LAMMPSData.cpp
+++ b/src/formats/LAMMPSData.cpp
@@ -291,9 +291,9 @@ void LAMMPSDataFormat::read_header(Frame& frame) {
                     "invalid header value: expected '<xy> <xz> <yz> xy xz yz', got '{}'", content
                 );
             }
-            matrix[0][1] = parse<double>(splitted[0]);
-            matrix[0][2] = parse<double>(splitted[1]);
-            matrix[1][2] = parse<double>(splitted[2]);
+            matrix[1][0] = parse<double>(splitted[0]);
+            matrix[2][0] = parse<double>(splitted[1]);
+            matrix[2][1] = parse<double>(splitted[2]);
             // Even if all parameters are 0, set shape to TRICLINIC
             shape = UnitCell::TRICLINIC;
         } else {
@@ -752,13 +752,13 @@ void LAMMPSDataFormat::write_header(const DataTypes& types, const Frame& frame) 
     file_.print("{:#.9} {:#.9} ylo yhi\n", 0.0, matrix[1][1]);
     file_.print("{:#.9} {:#.9} zlo zhi\n", 0.0, matrix[2][2]);
     if (frame.cell().shape() == UnitCell::TRICLINIC) {
-        assert(tilt_factor(matrix, 1, 0) == 0);
-        assert(tilt_factor(matrix, 2, 0) == 0);
-        assert(tilt_factor(matrix, 2, 1) == 0);
+        assert(tilt_factor(matrix, 0, 1) == 0);
+        assert(tilt_factor(matrix, 0, 2) == 0);
+        assert(tilt_factor(matrix, 1, 2) == 0);
         file_.print("{:#.9} {:#.9} {:#.9} xy xz yz\n",
-            tilt_factor(matrix, 0, 1),
-            tilt_factor(matrix, 0, 2),
-            tilt_factor(matrix, 1, 2)
+            tilt_factor(matrix, 1, 0),
+            tilt_factor(matrix, 2, 0),
+            tilt_factor(matrix, 2, 1)
         );
     }
 
@@ -1009,7 +1009,7 @@ std::vector<size_t> guess_molecules(const Frame& frame) {
 double tilt_factor(const Matrix3D& matrix, size_t i, size_t j) {
     assert(i != j);
     auto factor = matrix[i][j];
-    auto a = matrix[i][i];
+    auto a = matrix[j][j];
     if (factor >= 0) {
         while (fabs(factor) > a / 2) {
             factor -= a;

--- a/src/formats/TNG.cpp
+++ b/src/formats/TNG.cpp
@@ -230,9 +230,9 @@ void TNGFormat::read_cell(Frame& frame) {
     }
 
     auto matrix = distance_scale_factor_ * Matrix3D(
-        static_cast<double>(buffer[0]), static_cast<double>(buffer[3]), static_cast<double>(buffer[6]),
-        static_cast<double>(buffer[1]), static_cast<double>(buffer[4]), static_cast<double>(buffer[7]),
-        static_cast<double>(buffer[2]), static_cast<double>(buffer[5]), static_cast<double>(buffer[8])
+        static_cast<double>(buffer[0]), static_cast<double>(buffer[1]), static_cast<double>(buffer[2]),
+        static_cast<double>(buffer[3]), static_cast<double>(buffer[4]), static_cast<double>(buffer[5]),
+        static_cast<double>(buffer[6]), static_cast<double>(buffer[7]), static_cast<double>(buffer[8])
     );
 
     frame.set_cell(UnitCell(matrix));

--- a/src/formats/TRR.cpp
+++ b/src/formats/TRR.cpp
@@ -393,13 +393,13 @@ void get_cell(std::vector<float>& box, const Frame& frame) {
     // Factor 10 because the lengths are in nm in the TRR format
     auto matrix = frame.cell().matrix() / 10.0;
     box[0] = static_cast<float>(matrix[0][0]);
-    box[1] = static_cast<float>(matrix[1][0]);
-    box[2] = static_cast<float>(matrix[2][0]);
-    box[3] = static_cast<float>(matrix[0][1]);
+    box[1] = static_cast<float>(matrix[0][1]);
+    box[2] = static_cast<float>(matrix[0][2]);
+    box[3] = static_cast<float>(matrix[1][0]);
     box[4] = static_cast<float>(matrix[1][1]);
-    box[5] = static_cast<float>(matrix[2][1]);
-    box[6] = static_cast<float>(matrix[0][2]);
-    box[7] = static_cast<float>(matrix[1][2]);
+    box[5] = static_cast<float>(matrix[1][2]);
+    box[6] = static_cast<float>(matrix[2][0]);
+    box[7] = static_cast<float>(matrix[2][1]);
     box[8] = static_cast<float>(matrix[2][2]);
 }
 

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -552,9 +552,9 @@ private:
 static UnitCell parse_cell(std::string_view lattice) {
     auto matrix = Matrix3D::zero();
     scan(lattice,
-        matrix[0][0], matrix[1][0], matrix[2][0],
-        matrix[0][1], matrix[1][1], matrix[2][1],
-        matrix[0][2], matrix[1][2], matrix[2][2]
+        matrix[0][0], matrix[0][1], matrix[0][2],
+        matrix[1][0], matrix[1][1], matrix[1][2],
+        matrix[2][0], matrix[2][1], matrix[2][2]
     );
     return UnitCell(matrix);
 }

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -75,9 +75,9 @@ TEST_CASE("Use the UnitCell type") {
             CHECK(approx_eq(cell.volume(), 1119.9375925598192, 1e-12));
 
             matrix = Matrix3D(
-                26.2553,  0.0000, -4.4843,
+                26.2553,  0.0000,  0.0000,
                  0.0000, 11.3176,  0.0000,
-                 0.0000,  0.0000,  11.011
+                -4.4843,  0.0000,  11.011
             );
 
             cell = UnitCell(matrix);

--- a/tests/doc/capi/chfl_cell/matrix.c
+++ b/tests/doc/capi/chfl_cell/matrix.c
@@ -16,7 +16,7 @@ int main(void) {
     assert(matrix[2][2] == 12);
 
     // Out of diagonal terms are zero
-    assert(matrix[2][1] == 0);
+    assert(matrix[1][2] == 0);
 
     chfl_free(cell);
     // [example]

--- a/tests/formats/cml.cpp
+++ b/tests/formats/cml.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Read files in CML format") {
         CHECK(approx_eq(cell.angles(), {90.0, 90.0, 120.0}, 1e-12));
 
         auto positions = frame.positions();
-        auto fract0 = frame.cell().matrix().invert() * positions[0];
+        auto fract0 = frame.cell().matrix().invert().transpose() * positions[0];
         CHECK(approx_eq(fract0, Vector3D(-1.77493, 0.980333, 0.0000), 1e-3));
     }
 


### PR DESCRIPTION
It was previously column-major, which is not the expected representation for a C++ library. This also made it row-major in Fortran and Julia, again not matching the expected representation.



---

Ref https://github.com/chemfiles/Chemfiles.jl/pull/71