### PR TITLE
Support UTF-8 paths on Windows (allow for non-ASCII characters in paths)

### DIFF
--- a/src/files/BinaryFile.cpp
+++ b/src/files/BinaryFile.cpp
@@ -78,10 +78,10 @@ BinaryFile::BinaryFile(std::string path, File::Mode mode):
 #ifdef _WIN32
     // On Windows, allow for UTF-8 paths containing non-ASCII characters
 
-	// convert to a wide string (UTF-8) to take care of special characters
-	const int size_needed = MultiByteToWideChar(CP_UTF8, 0, &this->path()[0], (int)this->path().size(), NULL, 0);
-	std::wstring w_path = std::wstring(size_needed, 0);
-	MultiByteToWideChar(CP_UTF8, 0, &this->path()[0], (int)this->path().size(), &w_path[0], size_needed);
+    // convert to a wide string (UTF-8) to take care of special characters
+    const int size_needed = MultiByteToWideChar(CP_UTF8, 0, &this->path()[0], (int)this->path().size(), NULL, 0);
+    std::wstring w_path = std::wstring(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &this->path()[0], (int)this->path().size(), &w_path[0], size_needed);
 
     auto file_descriptor = _wopen(w_path.c_str(), open_mode, permissions);
 #else

--- a/tests/lints/check-public-headers.py
+++ b/tests/lints/check-public-headers.py
@@ -35,6 +35,8 @@ WHITELIST = [
     "new",
     "cstddef",
     "map",
+    # windows headers used for converting to a wide string
+    "windows.h",
     # external headers
     "chemfiles/external/span.hpp",
     "chemfiles/external/optional.hpp",


### PR DESCRIPTION
These changes make it possible to load files with special UTF-8 characters (e.g., é, à, ö) in their paths on Windows.

The tests pass.