### PR TITLE
Add support for XTC format for gigantic systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - added `chemfiles::guess_format` and `chfl_guess_format` to get the format
   chemfiles would use for a given file based on its filename
 - Added read support for GROMACS TPR format.
+- Added support for XTC trajectories of gigantic systems (> ~300M atoms)
+  as introduced with GROMACS version 2023
 
 ### Changes in supported formats
 

--- a/include/chemfiles/error_fmt.hpp
+++ b/include/chemfiles/error_fmt.hpp
@@ -5,6 +5,7 @@
 #define CHEMFILES_ERROR_FMT_HPP
 
 #include <utility>
+#include <fmt/core.h> // IWYU pragma: export
 #include <fmt/format.h>
 #include "chemfiles/Error.hpp"  // IWYU pragma: export
 

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -41,9 +41,9 @@ class XDRFile final : public BigEndianFile {
     void write_gmx_string(const std::string& value);
 
     /// Read compressed GROMACS floats and returns the precision
-    float read_gmx_compressed_floats(std::vector<float>& data);
+    float read_gmx_compressed_floats(std::vector<float>& data, bool is_long_format);
     /// Write compressed GROMACS floats with a given precision
-    void write_gmx_compressed_floats(const std::vector<float>& data, float precision);
+    void write_gmx_compressed_floats(const std::vector<float>& data, float precision, bool is_long_format);
 
     /// Read the GROMACS simulation box in nano meters
     UnitCell read_gmx_box(bool use_double = false);
@@ -56,6 +56,10 @@ class XDRFile final : public BigEndianFile {
     void read_opaque(std::vector<char>& data);
     /// Write XDR variable-length opaque data
     void write_opaque(const char* data, uint32_t count);
+    /// Read GROMACS long variable-length opaque data
+    void read_gmx_long_opaque(std::vector<char>& data);
+    /// Write GROMACS long variable-length opaque data
+    void write_gmx_long_opaque(const char* data, uint64_t count);
 
     /// Cache allocation for compressed data (XTC)
     std::vector<char> compressed_data_;

--- a/include/chemfiles/files/XDRFile.hpp
+++ b/include/chemfiles/files/XDRFile.hpp
@@ -11,11 +11,11 @@
 #include <vector>
 
 #include "chemfiles/File.hpp"
-#include "chemfiles/UnitCell.hpp"
 
 #include "chemfiles/files/BinaryFile.hpp"
 
 namespace chemfiles {
+class UnitCell;
 
 /// Partial implementation of XDR according to RFC 4506
 /// (see: https://datatracker.ietf.org/doc/html/rfc4506)
@@ -43,7 +43,8 @@ class XDRFile final : public BigEndianFile {
     /// Read compressed GROMACS floats and returns the precision
     float read_gmx_compressed_floats(std::vector<float>& data, bool is_long_format);
     /// Write compressed GROMACS floats with a given precision
-    void write_gmx_compressed_floats(const std::vector<float>& data, float precision, bool is_long_format);
+    void write_gmx_compressed_floats(const std::vector<float>& data, float precision,
+                                     bool is_long_format);
 
     /// Read the GROMACS simulation box in nano meters
     UnitCell read_gmx_box(bool use_double = false);

--- a/include/chemfiles/formats/XTC.hpp
+++ b/include/chemfiles/formats/XTC.hpp
@@ -31,9 +31,11 @@ class XTCFormat final : public Format {
 
   private:
     struct FrameHeader {
-        size_t natoms; /* The total number of atoms */
-        size_t step;   /* Current step number       */
-        float time;    /* Current time              */
+        int32_t magic; // Magic number indicating the file format
+        size_t natoms; // The total number of atoms
+        size_t step;   // Current step number
+        float time;    // Current time
+        bool is_long_format() const;
     };
 
     /// Read header of the Frame at the current position
@@ -43,6 +45,9 @@ class XTCFormat final : public Format {
     /// Determine the number of frames
     /// and the corresponding offset within the file
     void determine_frame_offsets();
+    /// Get the total number of bytes of the next frame
+    /// The returned value is aligned to 4 bytes
+    uint64_t read_framebytes(bool is_long_format);
 
     /// Associated XDR file
     XDRFile file_;

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -11,9 +11,6 @@
 #include <iterator>
 #include <string_view>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 #include "chemfiles/File.hpp"
 #include "chemfiles/files/GzFile.hpp"
 #include "chemfiles/files/XzFile.hpp"

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -228,8 +228,8 @@ static void encodebits(std::vector<char>& buf, DecodeState& state, uint32_t num_
  * to remove those checks...
  */
 
-static void encodeints(std::vector<char>& buf, DecodeState& state, const uint32_t num_of_ints,
-                       const uint32_t num_of_bits, const uint32_t sizes[], const uint32_t nums[]) {
+static void encodeints(std::vector<char>& buf, DecodeState& state, const uint32_t num_of_bits,
+                       const uint32_t sizes[], const uint32_t nums[]) {
     uint32_t tmp = nums[0];
     uint32_t num_of_bytes = 0;
     uint8_t bytes[32];
@@ -238,7 +238,7 @@ static void encodeints(std::vector<char>& buf, DecodeState& state, const uint32_
         tmp >>= CHAR_BIT;
     } while (tmp != 0);
 
-    for (size_t i = 1; i < num_of_ints; i++) {
+    for (size_t i = 1; i < 3; i++) {
         if (nums[i] >= sizes[i]) {
             throw file_error("major breakdown in encodeints - num {} doesn't match size {}",
                              nums[i], sizes[i]);
@@ -724,7 +724,7 @@ void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float 
             encodebits(compressed_data_, state, bitsizeint[1], tmpcoord[1]);
             encodebits(compressed_data_, state, bitsizeint[2], tmpcoord[2]);
         } else {
-            encodeints(compressed_data_, state, 3, bitsize, sizeint, tmpcoord);
+            encodeints(compressed_data_, state, bitsize, sizeint, tmpcoord);
         }
         prevcoord[0] = thiscoord[0];
         prevcoord[1] = thiscoord[1];
@@ -776,7 +776,7 @@ void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float 
             encodebits(compressed_data_, state, 1, 0);
         }
         for (int k = 0; k < run; k += 3) {
-            encodeints(compressed_data_, state, 3, smallidx, sizesmall, &tmpcoord[k]);
+            encodeints(compressed_data_, state, smallidx, sizesmall, &tmpcoord[k]);
         }
         if (is_smaller != 0) {
             if (is_smaller < 0) {

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/core.h"
+
 #include "chemfiles/files/BinaryFile.hpp"
 #include "chemfiles/files/XDRFile.hpp"
 
@@ -80,7 +82,8 @@ UnitCell XDRFile::read_gmx_box(bool use_double) {
         // Double
         std::vector<double> box(3 * 3);
         read_f64(box);
-        auto matrix = Matrix3D(box[0], box[1], box[2], box[3], box[4], box[5], box[6], box[7], box[8]);
+        auto matrix =
+            Matrix3D(box[0], box[1], box[2], box[3], box[4], box[5], box[6], box[7], box[8]);
         // Factor 10 because the lengths are in nm in the TPR/TRR/XTC format
         return UnitCell(10.0 * matrix);
     } else {
@@ -316,13 +319,8 @@ template <> class FastTypes<uint64_t> {
 };
 
 template <typename T>
-static void unpack_from_int(
-    const std::vector<char>& buf,
-    DecodeState& state,
-    uint32_t num_of_bits,
-    const uint32_t sizes[3],
-    span<int32_t> nums
-) {
+static void unpack_from_int(const std::vector<char>& buf, DecodeState& state, uint32_t num_of_bits,
+                            const uint32_t sizes[3], span<int32_t> nums) {
     T v = 0;
     size_t num_of_bytes = 0;
     while (num_of_bits >= 8) {
@@ -402,12 +400,8 @@ static void decodeints(const std::vector<char>& buf, DecodeState& state, uint32_
     nums[0] = bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
 }
 
-static uint32_t calc_sizeint(
-    const int minint[3],
-    const int maxint[3],
-    uint32_t sizeint[3],
-    uint32_t bitsizeint[3]
-) {
+static uint32_t calc_sizeint(const int minint[3], const int maxint[3], uint32_t sizeint[3],
+                             uint32_t bitsizeint[3]) {
     sizeint[0] = static_cast<uint32_t>(maxint[0] - minint[0]) + 1;
     sizeint[1] = static_cast<uint32_t>(maxint[1] - minint[1]) + 1;
     sizeint[2] = static_cast<uint32_t>(maxint[2] - minint[2]) + 1;
@@ -471,8 +465,7 @@ float XDRFile::read_gmx_compressed_floats(std::vector<float>& data, bool is_long
 
     if (is_long_format) {
         read_gmx_long_opaque(compressed_data_);
-    }
-    else {
+    } else {
         read_opaque(compressed_data_);
     }
     intbuf_.resize(data.size());
@@ -577,7 +570,8 @@ float XDRFile::read_gmx_compressed_floats(std::vector<float>& data, bool is_long
     return precision;
 }
 
-void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float precision, bool is_long_format) {
+void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float precision,
+                                          bool is_long_format) {
     if (precision <= 0) {
         warning("XTC compression", "invalid precision {} <= 0, use 1000 as fallback", precision);
         precision = 1000;
@@ -777,8 +771,7 @@ void XDRFile::write_gmx_compressed_floats(const std::vector<float>& data, float 
            "internal Error: overflow during decompression");
     if (is_long_format) {
         write_gmx_long_opaque(compressed_data_.data(), static_cast<uint64_t>(state.count));
-    }
-    else {
+    } else {
         write_opaque(compressed_data_.data(), static_cast<uint32_t>(state.count));
     }
 }

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -292,7 +292,7 @@ static T decodebits(const std::vector<char>& buf, DecodeState& state, uint32_t n
             lastbyte = (lastbyte << 8) | static_cast<uint8_t>(buf[cnt++]);
         }
         lastbits -= num_of_bits;
-        num |= (lastbyte >> lastbits) & mask;
+        num |= (lastbyte >> lastbits) & (static_cast<uint32_t>(1 << num_of_bits) - 1);
     }
     num &= mask;
     state.count = cnt;

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -13,8 +13,6 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
-
 #include "chemfiles/files/BinaryFile.hpp"
 #include "chemfiles/files/XDRFile.hpp"
 

--- a/src/files/XDRFile.cpp
+++ b/src/files/XDRFile.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -46,6 +47,10 @@ void XDRFile::write_opaque(const char* data, uint32_t count) {
 
 void XDRFile::read_gmx_long_opaque(std::vector<char>& data) {
     const uint64_t count = read_single_u64();
+    if (count > std::numeric_limits<size_t>::max()) {
+        // count would overflow the address space
+        throw file_error("compressed data is too large to be allocated");
+    }
     const uint64_t num_filler = (4 - (count % 4)) % 4;
     data.resize(static_cast<size_t>(count + num_filler));
     read_char(data.data(), count + num_filler);

--- a/src/formats/TPR.cpp
+++ b/src/formats/TPR.cpp
@@ -12,8 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
-
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/external/optional.hpp"
 #include "chemfiles/external/span.hpp"

--- a/src/formats/TRR.cpp
+++ b/src/formats/TRR.cpp
@@ -11,8 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
-
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/external/optional.hpp"
 #include "chemfiles/external/span.hpp"

--- a/src/formats/XTC.cpp
+++ b/src/formats/XTC.cpp
@@ -10,8 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "fmt/core.h"
-
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/external/optional.hpp"
 #include "chemfiles/external/span.hpp"

--- a/src/formats/XYZ.cpp
+++ b/src/formats/XYZ.cpp
@@ -15,9 +15,6 @@
 #include <string_view>
 #include <unordered_map>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 #include "chemfiles/types.hpp"
 #include "chemfiles/parse.hpp"
 #include "chemfiles/utils.hpp"

--- a/src/selections/expr.cpp
+++ b/src/selections/expr.cpp
@@ -14,9 +14,6 @@
 #include <algorithm>
 #include <functional>
 
-#include <fmt/core.h>
-#include <fmt/format.h>
-
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/unreachable.hpp"
 #include "chemfiles/external/optional.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "afa8b4f588c20e7f40deae5141532eae5975cc18")
+set(TESTS_DATA_GIT "bfd2887f0a459fd1b7c1412be9096e42adc70545")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=b92411102ee5730ea20f689c33c86d494132b3ed
+        EXPECTED_HASH SHA1=83a5b64251cd2f8177a2cba00feaec91ff224b24
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Update this value if you need to update the data file set
-set(TESTS_DATA_GIT "bfd2887f0a459fd1b7c1412be9096e42adc70545")
+set(TESTS_DATA_GIT "1747c383dd1bc911e8ca23f63ecec191bd699571")
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
     message(STATUS "Downloading test data files")
@@ -7,7 +7,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/data/${TESTS_DATA_GIT}")
         "https://github.com/chemfiles/tests-data/archive/${TESTS_DATA_GIT}.tar.gz"
         "${CMAKE_CURRENT_BINARY_DIR}/${TESTS_DATA_GIT}.tar.gz"
         SHOW_PROGRESS
-        EXPECTED_HASH SHA1=83a5b64251cd2f8177a2cba00feaec91ff224b24
+        EXPECTED_HASH SHA1=196a4e2453714ff4ea0a42c3a66dcdb2c73757f9
     )
 
     message(STATUS "Unpacking test data files")

--- a/tests/files/xdr-file.cpp
+++ b/tests/files/xdr-file.cpp
@@ -5,65 +5,70 @@
 #include "chemfiles.hpp"
 #include "chemfiles/files/XDRFile.hpp"
 #include "helpers.hpp"
+#include <cstdint>
 #include <vector>
 using namespace chemfiles;
 
-static void write_xdr_file(XDRFile& file) {
+static void write_xdr_file(XDRFile& file, bool is_long_format) {
     file.write_gmx_string("Hello!"); // needs 2B padding
     const std::vector<float> array = {1.234f, -5.123f, 100.232f};
-    file.write_gmx_compressed_floats(array, 1000.0, false);
+    file.write_gmx_compressed_floats(array, 1000.0, is_long_format);
+}
+
+// clang-format off
+const auto expected_short = std::vector<uint8_t> {
+    0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x06,
+    'H', 'e', 'l', 'l', 'o', '!', 0x00, 0x00,
+    0x44, 0x7a, 0x00, 0x00, 0x00, 0x00, 0x04, 0xd2, 0xff, 0xff, 0xeb, 0xfd,
+    0x00, 0x01, 0x87, 0x88, 0x00, 0x00, 0x04, 0xd2, 0xff, 0xff, 0xeb, 0xfd,
+    0x00, 0x01, 0x87, 0x88, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x01,
+    0x42, 0x00, 0x00, 0x00,
+};
+// clang-format on
+
+static void check_xdr_file(const char* path, bool is_long_format) {
+    XDRFile file(path, File::READ);
+    const uint64_t expected_file_size = 164 + (is_long_format ? 4 : 0);
+    CHECK(file.file_size() == expected_file_size);
+
+    // read some big-endian data types
+    CHECK(file.read_single_i32() == -123);
+    CHECK(file.read_single_u32() == 123);
+    CHECK(file.read_single_f64() == 5.678);
+    CHECK(file.read_single_f32() == -4.567f);
+
+    std::vector<double> darr;
+    darr.resize(6);
+    file.read_f64(darr);
+    const std::vector<double> dexpected = {1.234, -6.234, 105.232, 1034.346, -5056.465, 10054.475};
+    CHECK(darr == dexpected);
+
+    auto array = std::vector<float>();
+    array.resize(6);
+    file.read_f32(array);
+    const std::vector<float> expected = {1.234f,    -5.123f,    100.232f,
+                                         1034.346f, -5056.465f, 10054.475f};
+    CHECK(array == expected);
+    array = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
+    // read XDR and GROMACS specific data types
+    CHECK(file.read_gmx_string() == "Hello!");
+    CHECK(file.read_gmx_compressed_floats(array, is_long_format) == 1000.0f);
+    for (size_t i = 0; i < 3; ++i) {
+        CHECK(approx_eq(array[i], expected[i], 1e-4f));
+    }
+
+    // Go back to the beginning to check reading of sizes as i32
+    file.seek(0);
+    CHECK_THROWS_WITH(file.read_single_size_as_i32(),
+                      "invalid value in XDR file: expected a positive integer, got -123");
+    CHECK(file.read_single_size_as_i32() == 123);
 }
 
 TEST_CASE("XDR files") {
-    SECTION("read") {
-        XDRFile file("data/misc/xdr.bin", File::READ);
-        CHECK(file.file_size() == 164);
+    SECTION("read") { check_xdr_file("data/misc/xdr.bin", false); }
 
-        // read some big-endian data types
-        CHECK(file.read_single_i32() == -123);
-        CHECK(file.read_single_u32() == 123);
-        CHECK(file.read_single_f64() == 5.678);
-        CHECK(file.read_single_f32() == -4.567f);
-
-        std::vector<double> darr;
-        darr.resize(6);
-        file.read_f64(darr);
-        const std::vector<double> dexpected = {1.234,    -6.234,    105.232,
-                                               1034.346, -5056.465, 10054.475};
-        CHECK(darr == dexpected);
-
-        auto array = std::vector<float>();
-        array.resize(6);
-        file.read_f32(array);
-        const std::vector<float> expected = {1.234f,    -5.123f,    100.232f,
-                                             1034.346f, -5056.465f, 10054.475f};
-        CHECK(array == expected);
-        array = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-
-        // read XDR and GROMACS specific data types
-        CHECK(file.read_gmx_string() == "Hello!");
-        CHECK(file.read_gmx_compressed_floats(array, false) == 1000.0f);
-        for (size_t i = 0; i < 3; ++i) {
-            CHECK(approx_eq(array[i], expected[i], 1e-4f));
-        }
-
-        // Go back to the beginning to check reading of sizes as i32
-        file.seek(0);
-        CHECK_THROWS_WITH(file.read_single_size_as_i32(),
-                          "invalid value in XDR file: expected a positive integer, got -123");
-        CHECK(file.read_single_size_as_i32() == 123);
-    }
-
-    // clang-format off
-    auto expected = std::vector<uint8_t> {
-        0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x06,
-        'H', 'e', 'l', 'l', 'o', '!', 0x00, 0x00,
-        0x44, 0x7a, 0x00, 0x00, 0x00, 0x00, 0x04, 0xd2, 0xff, 0xff, 0xeb, 0xfd,
-        0x00, 0x01, 0x87, 0x88, 0x00, 0x00, 0x04, 0xd2, 0xff, 0xff, 0xeb, 0xfd,
-        0x00, 0x01, 0x87, 0x88, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x01,
-        0x42, 0x00, 0x00, 0x00,
-    };
-    // clang-format on
+    const auto expected = expected_short;
     auto expected_2 = expected;
     expected_2.insert(expected_2.end(), expected.begin(), expected.end());
 
@@ -71,7 +76,7 @@ TEST_CASE("XDR files") {
         auto filename = NamedTempPath(".bin");
         {
             XDRFile file(filename, File::WRITE);
-            write_xdr_file(file);
+            write_xdr_file(file, false);
             CHECK(file.file_size() == expected.size());
         }
 
@@ -83,7 +88,7 @@ TEST_CASE("XDR files") {
         auto filename = NamedTempPath(".bin");
         {
             XDRFile file(filename, File::WRITE);
-            write_xdr_file(file);
+            write_xdr_file(file, false);
             CHECK(file.file_size() == expected.size());
         }
 
@@ -92,7 +97,7 @@ TEST_CASE("XDR files") {
 
         {
             XDRFile file(filename, File::Mode::APPEND);
-            write_xdr_file(file);
+            write_xdr_file(file, false);
             CHECK(file.file_size() == expected_2.size());
         }
 
@@ -104,7 +109,63 @@ TEST_CASE("XDR files") {
         auto filename = NamedTempPath(".bin");
         {
             XDRFile file(filename, File::WRITE);
-            write_xdr_file(file);
+            write_xdr_file(file, false);
+            CHECK(file.file_size() == expected.size());
+        }
+
+        auto content = read_binary_file(filename);
+        CHECK(content == expected);
+    }
+}
+
+TEST_CASE("XDR files long compressed format") {
+    SECTION("read") { check_xdr_file("data/misc/xdr_long.bin", true); }
+
+    auto expected = expected_short;
+    // make the size field long by padding the u32 by four 0x00 bytes at position 48
+    expected.insert(std::next(expected.begin(), 48), 4, 0x00);
+
+    auto expected_2 = expected;
+    expected_2.insert(expected_2.end(), expected.begin(), expected.end());
+
+    SECTION("write") {
+        auto filename = NamedTempPath(".bin");
+        {
+            XDRFile file(filename, File::WRITE);
+            write_xdr_file(file, true);
+            CHECK(file.file_size() == expected.size());
+        }
+
+        auto content = read_binary_file(filename);
+        CHECK(content == expected);
+    }
+
+    SECTION("write and append") {
+        auto filename = NamedTempPath(".bin");
+        {
+            XDRFile file(filename, File::WRITE);
+            write_xdr_file(file, true);
+            CHECK(file.file_size() == expected.size());
+        }
+
+        auto content = read_binary_file(filename);
+        CHECK(content == expected);
+
+        {
+            XDRFile file(filename, File::Mode::APPEND);
+            write_xdr_file(file, true);
+            CHECK(file.file_size() == expected_2.size());
+        }
+
+        content = read_binary_file(filename);
+        CHECK(content == expected_2);
+    }
+
+    SECTION("append") {
+        auto filename = NamedTempPath(".bin");
+        {
+            XDRFile file(filename, File::WRITE);
+            write_xdr_file(file, true);
             CHECK(file.file_size() == expected.size());
         }
 

--- a/tests/files/xdr-file.cpp
+++ b/tests/files/xdr-file.cpp
@@ -11,7 +11,7 @@ using namespace chemfiles;
 static void write_xdr_file(XDRFile& file) {
     file.write_gmx_string("Hello!"); // needs 2B padding
     const std::vector<float> array = {1.234f, -5.123f, 100.232f};
-    file.write_gmx_compressed_floats(array, 1000.0);
+    file.write_gmx_compressed_floats(array, 1000.0, false);
 }
 
 TEST_CASE("XDR files") {
@@ -42,7 +42,7 @@ TEST_CASE("XDR files") {
 
         // read XDR and GROMACS specific data types
         CHECK(file.read_gmx_string() == "Hello!");
-        CHECK(file.read_gmx_compressed_floats(array) == 1000.0f);
+        CHECK(file.read_gmx_compressed_floats(array, false) == 1000.0f);
         for (size_t i = 0; i < 3; ++i) {
             CHECK(approx_eq(array[i], expected[i], 1e-4f));
         }

--- a/tests/formats/xtc.cpp
+++ b/tests/formats/xtc.cpp
@@ -6,77 +6,85 @@
 #include "helpers.hpp"
 using namespace chemfiles;
 
+static void check_traj_ubiquitin(const char* path) {
+    auto file = Trajectory(path);
+    CHECK(file.size() == 251);
+    auto frame = file.read_at(0);
+
+    CHECK(frame.index() == 0);
+    CHECK(frame.get("simulation_step")->as_double() == 0);
+    CHECK(approx_eq(frame.get("time")->as_double(), 0));
+    CHECK(frame.get("xtc_precision")->as_double() == 1000);
+    CHECK(frame.size() == 20455);
+
+    auto positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(24.8300, 24.6600, 18.8100), 1e-4));
+    CHECK(approx_eq(positions[11], Vector3D(23.7700, 24.5600, 21.4700), 1e-4));
+
+    auto cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
+
+    frame = file.read_at(1); // Skip a frame
+    CHECK(frame.index() == 1);
+    CHECK(frame.get("simulation_step")->as_double() == 100);
+
+    frame = file.read();
+
+    CHECK(frame.index() == 2);
+    CHECK(frame.get("simulation_step")->as_double() == 200);
+    CHECK(approx_eq(frame.get("time")->as_double(), 0.4, 1e-4));
+    CHECK(frame.get("xtc_precision")->as_double() == 1000);
+    CHECK(frame.size() == 20455);
+
+    positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(24.7100, 24.5700, 18.4500), 1e-4));
+    CHECK(approx_eq(positions[11], Vector3D(23.6700, 24.4800, 21.5200), 1e-4));
+
+    cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
+
+    frame = file.read_at(230); // skip forward
+
+    CHECK(frame.index() == 230);
+    CHECK(frame.get("simulation_step")->as_double() == 23000);
+    CHECK(approx_eq(frame.get("time")->as_double(), 46.0));
+    CHECK(frame.get("xtc_precision")->as_double() == 1000);
+    CHECK(frame.size() == 20455);
+
+    positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(24.6300, 24.6700, 18.5000), 1e-4));
+    CHECK(approx_eq(positions[11], Vector3D(23.6800, 24.0700, 21.3100), 1e-4));
+
+    cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
+
+    frame = file.read_at(50); // skip behind previous step
+
+    CHECK(frame.index() == 50);
+    CHECK(frame.get("simulation_step")->as_double() == 5000);
+    CHECK(approx_eq(frame.get("time")->as_double(), 10.0));
+    CHECK(frame.get("xtc_precision")->as_double() == 1000);
+    CHECK(frame.size() == 20455);
+
+    positions = frame.positions();
+    CHECK(approx_eq(positions[0], Vector3D(24.5100, 24.5300, 18.7800), 1e-4));
+    CHECK(approx_eq(positions[11], Vector3D(23.5300, 24.0900, 21.3100), 1e-4));
+
+    cell = frame.cell();
+    CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
+    CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
+}
+
 TEST_CASE("Read files in XTC format") {
     SECTION("Read trajectory") {
-        auto file = Trajectory("data/xtc/ubiquitin.xtc");
-        CHECK(file.size() == 251);
-        auto frame = file.read_at(0);
+        check_traj_ubiquitin("data/xtc/ubiquitin.xtc");
+    }
 
-        CHECK(frame.index() == 0);
-        CHECK(frame.get("simulation_step")->as_double() == 0);
-        CHECK(approx_eq(frame.get("time")->as_double(), 0));
-        CHECK(frame.get("xtc_precision")->as_double() == 1000);
-        CHECK(frame.size() == 20455);
-
-        auto positions = frame.positions();
-        CHECK(approx_eq(positions[0], Vector3D(24.8300, 24.6600, 18.8100), 1e-4));
-        CHECK(approx_eq(positions[11], Vector3D(23.7700, 24.5600, 21.4700), 1e-4));
-
-        auto cell = frame.cell();
-        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
-        CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
-
-        frame = file.read_at(1); // Skip a frame
-        CHECK(frame.index() == 1);
-        CHECK(frame.get("simulation_step")->as_double() == 100);
-
-        frame = file.read();
-
-        CHECK(frame.index() == 2);
-        CHECK(frame.get("simulation_step")->as_double() == 200);
-        CHECK(approx_eq(frame.get("time")->as_double(), 0.4, 1e-4));
-        CHECK(frame.get("xtc_precision")->as_double() == 1000);
-        CHECK(frame.size() == 20455);
-
-        positions = frame.positions();
-        CHECK(approx_eq(positions[0], Vector3D(24.7100, 24.5700, 18.4500), 1e-4));
-        CHECK(approx_eq(positions[11], Vector3D(23.6700, 24.4800, 21.5200), 1e-4));
-
-        cell = frame.cell();
-        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
-        CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
-
-        frame = file.read_at(230); // skip forward
-
-        CHECK(frame.index() == 230);
-        CHECK(frame.get("simulation_step")->as_double() == 23000);
-        CHECK(approx_eq(frame.get("time")->as_double(), 46.0));
-        CHECK(frame.get("xtc_precision")->as_double() == 1000);
-        CHECK(frame.size() == 20455);
-
-        positions = frame.positions();
-        CHECK(approx_eq(positions[0], Vector3D(24.6300, 24.6700, 18.5000), 1e-4));
-        CHECK(approx_eq(positions[11], Vector3D(23.6800, 24.0700, 21.3100), 1e-4));
-
-        cell = frame.cell();
-        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
-        CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
-
-        frame = file.read_at(50); // skip behind previous step
-
-        CHECK(frame.index() == 50);
-        CHECK(frame.get("simulation_step")->as_double() == 5000);
-        CHECK(approx_eq(frame.get("time")->as_double(), 10.0));
-        CHECK(frame.get("xtc_precision")->as_double() == 1000);
-        CHECK(frame.size() == 20455);
-
-        positions = frame.positions();
-        CHECK(approx_eq(positions[0], Vector3D(24.5100, 24.5300, 18.7800), 1e-4));
-        CHECK(approx_eq(positions[11], Vector3D(23.5300, 24.0900, 21.3100), 1e-4));
-
-        cell = frame.cell();
-        CHECK(cell.shape() == UnitCell::ORTHORHOMBIC);
-        CHECK(approx_eq(cell.lengths(), {55.6800, 58.8700, 62.5700}, 1e-4));
+    SECTION("Read trajectory with gigantic system") {
+        check_traj_ubiquitin("data/xtc/ubiquitin_faux2023magic.xtc");
     }
 
     SECTION("Read different cell shapes") {


### PR DESCRIPTION
Fixes #479.

I faked a test XTC file for reading, but properly testing writing is really hard because single frames can become rather large.
Instead of testing writing of the new XTC format directly, the underlying compression functions are tested in the XDR file tests.