### PR TITLE
Limit memory used by BinaryFile to 100MiB in mmap mode

### DIFF
--- a/src/files/BinaryFile.cpp
+++ b/src/files/BinaryFile.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <type_traits>
 
+#include "chemfiles/config.h"  // IWYU pragma: keep (CHEMFILES_WINDOWS)
 #include "chemfiles/File.hpp"
 #include "chemfiles/error_fmt.hpp"
 #include "chemfiles/unreachable.hpp"
@@ -46,6 +47,9 @@
 #if CHEMFILES_BINARY_FILE_USE_MMAP
     #include <sys/mman.h>
     #include <unistd.h>
+
+    // Limit the memory usable by mmaped files to 100MiB at the time.
+    #define CHEMFILES_MMAP_SIZE 0x06400000
 #endif
 
 using namespace chemfiles;
@@ -107,39 +111,19 @@ BinaryFile::BinaryFile(std::string path, File::Mode mode):
     page_size_ = static_cast<size_t>(sysconf(_SC_PAGESIZE));
 
     if (mode == File::READ) {
-        mmap_size_ = file_size_;
         total_written_size_ = file_size_;
     } else if (mode == File::WRITE) {
-        // set the map size to a large value (1GiB here) to reduce the number of
-        // time we have to unmap/mmap the file. This drastically improves
-        // performances when writing, at the cost of only being able to use mmap
-        // on 64-bit systems (on 32-bits systems, there is a very low chance to
-        // be able to get 1GiB contiguous allocation even in virtual memory, so
-        // we fallback to the implementation based on cstdio instead).
-        //
-        // This does not mean chemfiles will actually hold that much RAM, only a
-        // virtual allocation of that size.
-        mmap_size_ = 0x40000000;
+        total_written_size_ = 0;
     } else if (mode == File::APPEND) {
-        mmap_size_ = 0x40000000;
-        // make sure the file fits inside mmap_size_
-        while (file_size_ > mmap_size_) {
-            mmap_size_ *= 2;
-        }
-
-        offset_ = file_size_;
+        mmap_offset_ = (file_size_ / CHEMFILES_MMAP_SIZE) * CHEMFILES_MMAP_SIZE;
+        current_ = file_size_ % CHEMFILES_MMAP_SIZE;
         total_written_size_ = file_size_;
     } else {
         unreachable();
     }
 
-    mmap_data_ = static_cast<char*>(mmap(
-        nullptr, mmap_size_, mmap_prot_, MAP_SHARED, file_descriptor_, 0
-    ));
+    this->remap_file();
 
-    if (mmap_data_ == MAP_FAILED) {
-        throw file_error("mmap failed for '{}': {}", this->path(), std::strerror(errno));
-    }
 #else
     const char* fdopen_mode;
     if (mode == Mode::READ) {
@@ -176,10 +160,10 @@ BinaryFile& BinaryFile::operator=(BinaryFile&& other) noexcept {
     std::swap(this->total_written_size_, other.total_written_size_);
     std::swap(this->mmap_data_, other.mmap_data_);
     std::swap(this->file_size_, other.file_size_);
-    std::swap(this->mmap_size_, other.mmap_size_);
-    std::swap(this->mmap_prot_, other.mmap_prot_);
     std::swap(this->page_size_, other.page_size_);
-    std::swap(this->offset_, other.offset_);
+    std::swap(this->mmap_offset_, other.mmap_offset_);
+    std::swap(this->mmap_prot_, other.mmap_prot_);
+    std::swap(this->current_, other.current_);
 #else
     std::swap(this->file_, other.file_);
 #endif
@@ -187,10 +171,44 @@ BinaryFile& BinaryFile::operator=(BinaryFile&& other) noexcept {
     return *this;
 }
 
+void BinaryFile::remap_file() {
+#if CHEMFILES_BINARY_FILE_USE_MMAP
+    if (mmap_data_ != nullptr) {
+        auto status = msync(mmap_data_, CHEMFILES_MMAP_SIZE, MS_SYNC);
+        if (status != 0) {
+            throw file_error(
+                "failed to sync file ({}), some data might be lost",
+                std::strerror(errno)
+            );
+        }
+
+        status = munmap(mmap_data_, CHEMFILES_MMAP_SIZE);
+        if (status != 0) {
+            throw file_error("failed to unmap file: {}", std::strerror(errno));
+        }
+    }
+
+    mmap_data_ = static_cast<char*>(mmap(
+        nullptr, CHEMFILES_MMAP_SIZE, mmap_prot_, MAP_SHARED, file_descriptor_, static_cast<off_t>(mmap_offset_)
+    ));
+
+    if (mmap_data_ == MAP_FAILED) {
+        throw file_error("mmap failed for '{}': {}", this->path(), std::strerror(errno));
+    }
+
+    auto status = madvise(mmap_data_, CHEMFILES_MMAP_SIZE, MADV_SEQUENTIAL);
+    if (status != 0) {
+        throw file_error("madvise failed for '{}': {}", this->path(), std::strerror(errno));
+    }
+#endif
+}
+
+
+
 void BinaryFile::close_file() noexcept {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
     if (mmap_data_ != nullptr) {
-        auto status = msync(mmap_data_, mmap_size_, MS_SYNC);
+        auto status = msync(mmap_data_, CHEMFILES_MMAP_SIZE, MS_SYNC);
         if (status != 0) {
             warning(
                 "binary file writer",
@@ -199,7 +217,7 @@ void BinaryFile::close_file() noexcept {
             );
         }
 
-        status = munmap(mmap_data_, mmap_size_);
+        status = munmap(mmap_data_, CHEMFILES_MMAP_SIZE);
         if (status != 0) {
             warning(
                 "binary file writer",
@@ -234,10 +252,9 @@ void BinaryFile::close_file() noexcept {
     total_written_size_ = 0;
     mmap_data_ = nullptr;
     file_size_ = 0;
-    mmap_size_ = 0;
+    mmap_offset_ = 0;
     mmap_prot_ = 0;
-    page_size_ = 0;
-    offset_ = 0;
+    current_ = 0;
 #else
     if (file_ == nullptr) {
         return;
@@ -258,22 +275,34 @@ void BinaryFile::close_file() noexcept {
 
 void BinaryFile::read_char(char* data, size_t count) {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
-    if (offset_ + count > file_size_) {
+    if (mmap_offset_ + current_ + count > file_size_) {
         throw file_error(
             "failed to read {} bytes from the file at '{}': mmap out of bounds",
             count, this->path()
         );
     }
-    std::memcpy(data, mmap_data_ + offset_, count);
-    offset_ += count;
+
+    if (current_ + count > CHEMFILES_MMAP_SIZE) {
+        // read remaining data
+        auto read = CHEMFILES_MMAP_SIZE - current_;
+        std::memcpy(data, mmap_data_ + current_, read);
+
+        mmap_offset_ += CHEMFILES_MMAP_SIZE;
+        current_ = 0;
+        this->remap_file();
+        this->read_char(data + read, count - read);
+    } else {
+        std::memcpy(data, mmap_data_ + current_, count);
+        current_ += count;
+    }
+
 #else
     auto read = std::fread(data, 1, count, file_);
     const char* error_info = "unknown cause";
     if (read != count) {
-        if (feof(file_)) {
+        if (feof(file_) != 0) {
             error_info = "reached end of file";
-        }
-        else if (ferror(file_)) {
+        } else if (ferror(file_) != 0) {
             error_info = std::strerror(errno);
         }
         throw file_error(
@@ -287,54 +316,37 @@ void BinaryFile::read_char(char* data, size_t count) {
 
 void BinaryFile::write_char(const char* data, size_t count) {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
-    if (offset_ + count > file_size_) {
-        while (offset_ + count > file_size_) {
-            // increase the file size by multiples of the page size to have to
-            // call ftruncate less often
-            file_size_ += 4 * page_size_;
-        }
-        // resize the file, but keep the same mmap allocation unless
-        // file_size_ > mmap_size_
+    auto file_size_changed = false;
+    while (mmap_offset_ + current_ + count > file_size_) {
+        file_size_ += 4 * page_size_;
+        file_size_changed = true;
+    }
+
+    if (file_size_changed) {
+        // resize the underlying file
         auto status = ftruncate(file_descriptor_, static_cast<off_t>(file_size_));
         if (status != 0) {
             throw file_error("failed to resize file: {}", std::strerror(errno));
         }
+    }
 
-        if (file_size_ > mmap_size_) {
-            // unmap & remap file with bigger mapping
-            status = msync(mmap_data_, mmap_size_, MS_SYNC);
-            if (status != 0) {
-                throw file_error(
-                    "failed to sync file ({}), some data might be lost",
-                    std::strerror(errno)
-                );
-            }
+    if (current_ + count > CHEMFILES_MMAP_SIZE) {
+        // copy data in the remaining space
+        auto written = CHEMFILES_MMAP_SIZE - current_;
+        std::memcpy(mmap_data_ + current_, data, written);
 
-            status = munmap(mmap_data_, mmap_size_);
-            if (status != 0) {
-                throw file_error("failed to unmap file: {}", std::strerror(errno));
-            }
-
-            while (file_size_ > mmap_size_) {
-                mmap_size_ *= 2;
-            }
-
-            mmap_data_ = static_cast<char*>(mmap(
-                nullptr, mmap_size_, mmap_prot_, MAP_SHARED, file_descriptor_, 0
-            ));
-
-            if (mmap_data_ == MAP_FAILED) {
-                throw file_error("mmap failed for '{}': {}", this->path(), std::strerror(errno));
-            }
+        mmap_offset_ += CHEMFILES_MMAP_SIZE;
+        current_ = 0;
+        this->remap_file();
+        this->write_char(data + written, count - written);
+    } else {
+        if (mmap_offset_ + current_ + count > total_written_size_) {
+            total_written_size_ = mmap_offset_ + current_ + count;
         }
-    }
 
-    if (offset_ + count > total_written_size_) {
-        total_written_size_ = offset_ + count;
+        std::memcpy(mmap_data_ + current_, data, count);
+        current_ += count;
     }
-
-    std::memcpy(mmap_data_ + offset_, data, count);
-    offset_ += count;
 #else
     auto written = std::fwrite(data, 1, count, file_);
     if (written != count) {
@@ -349,7 +361,7 @@ void BinaryFile::write_char(const char* data, size_t count) {
 
 uint64_t BinaryFile::tell() const {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
-    return offset_;
+    return mmap_offset_ + current_;
 #else
     auto position = ftell64(file_);
     if (position < 0) {
@@ -362,7 +374,13 @@ uint64_t BinaryFile::tell() const {
 
 void BinaryFile::seek(uint64_t position) {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
-    offset_ = position;
+    if (position < mmap_offset_ || position > mmap_offset_ + CHEMFILES_MMAP_SIZE) {
+        // find a new offset so positions is in the mapped region
+        mmap_offset_ = (position / CHEMFILES_MMAP_SIZE) * CHEMFILES_MMAP_SIZE;
+        this->remap_file();
+    }
+
+    current_ = position - mmap_offset_;
 #else
     auto status = fseek64(file_, static_cast<off64_t>(position), SEEK_SET);
 
@@ -375,7 +393,7 @@ void BinaryFile::seek(uint64_t position) {
 
 void BinaryFile::skip(uint64_t count) {
 #if CHEMFILES_BINARY_FILE_USE_MMAP
-    offset_ += count;
+    this->seek(mmap_offset_ + current_ + count);
 #else
     auto status = fseek64(file_, static_cast<off64_t>(count), SEEK_CUR);
     if (status != 0) {


### PR DESCRIPTION
We now load/unload 100MiB chunks, making sure loading large files don't fill up memory and leave some for processing of the data.

xref https://github.com/chemfiles/Chemfiles.jl/issues/83