### PR TITLE
Preserve DCD timestep metadata on write (dt / NPRIV / NSAVC)

### DIFF
--- a/include/chemfiles/formats/DCD.hpp
+++ b/include/chemfiles/formats/DCD.hpp
@@ -85,6 +85,9 @@ private:
     void write_header();
     void write_cell(const UnitCell& cell);
     void write_positions(const Frame& frame);
+    /// derive the timestep metadata from the first two frames carrying
+    /// `time` and `simulation_step` properties, and back-patch the header
+    void patch_timesteps_metadata(const Frame& frame);
 
     std::unique_ptr<BinaryFile> file_;
     /// which variant of the DCD format are we trying to read?
@@ -145,6 +148,12 @@ private:
 
     /// index of the next step to read
     size_t index_ = 0;
+
+    /// state used by `patch_timesteps_metadata` to back-patch `dt`/`start`/
+    /// `step` after the first two property-bearing frames are written
+    size_t write_observed_frames_ = 0;
+    double write_first_time_ = 0.0;
+    double write_first_step_ = 0.0;
 
     /// temporary buffer used when reading/writing coordinates
     std::vector<float> buffer_;

--- a/src/formats/DCD.cpp
+++ b/src/formats/DCD.cpp
@@ -174,6 +174,7 @@ void DCDFormat::read_at(size_t index, Frame& frame) {
     if (timesteps_.dt != 0.0 && timesteps_.step != 0) {
         auto simulation_step = static_cast<double>(timesteps_.step * index_ + timesteps_.start);
         frame.set("time", timesteps_.dt * simulation_step);
+        frame.set("simulation_step", simulation_step);
     }
 
     if (!title_.empty()) {
@@ -552,11 +553,46 @@ void DCDFormat::write(const Frame& frame) {
     n_frames_ += 1;
     index_ += 1;
 
-    // update the number of frames in the header
+    // back-patch the header: number of frames (always) and, for the first
+    // two property-bearing frames, the timestep metadata
     auto current = file_->tell();
     file_->seek(8); // the number of frames is always at offset 8 (1 marker + CORD)
     file_->write_single_i32(static_cast<int32_t>(n_frames_));
+    this->patch_timesteps_metadata(frame);
     file_->seek(current);
+}
+
+void DCDFormat::patch_timesteps_metadata(const Frame& frame) {
+    if (write_observed_frames_ >= 2) {
+        return;
+    }
+    auto time = frame.get<Property::DOUBLE>("time");
+    auto step = frame.get<Property::DOUBLE>("simulation_step");
+    if (!time || !step) {
+        return;
+    }
+    if (write_observed_frames_ == 0) {
+        write_first_time_ = *time;
+        write_first_step_ = *step;
+        write_observed_frames_ = 1;
+        return;
+    }
+
+    double step_gap = *step - write_first_step_;
+    write_observed_frames_ = 2;
+    if (step_gap <= 0) {
+        return;
+    }
+    timesteps_.dt = (*time - write_first_time_) / step_gap;
+    timesteps_.start = static_cast<size_t>(write_first_step_);
+    timesteps_.step = static_cast<size_t>(step_gap);
+
+    // NPRIV at offset 12, NSAVC at offset 16, DELTA (f32) at offset 44
+    file_->seek(12);
+    file_->write_single_i32(static_cast<int32_t>(timesteps_.start));
+    file_->write_single_i32(static_cast<int32_t>(timesteps_.step));
+    file_->seek(44);
+    file_->write_single_f32(static_cast<float>(timesteps_.dt));
 }
 
 void DCDFormat::write_header() {
@@ -572,9 +608,9 @@ void DCDFormat::write_header() {
 
     file_->write_single_i32(/* n_degree_of_freedom */ 3 * static_cast<int32_t>(n_atoms_));
     file_->write_single_i32(/* n_fixed_atoms */ 0);
-    // TODO: this might lose information: when writing to a file, this is always
-    // 0, even if the frame has a *time* property. If we read back, the
-    // resulting frame will not have a *time* property at all.
+    // dt is written as 0 here; the actual value is back-patched by `write()`
+    // after observing the `time` and `simulation_step` properties of the
+    // first two frames.
     file_->write_single_f32(static_cast<float>(timesteps_.dt));
 
     file_->write_single_i32(options_.charmm_unitcell ? 1 : 0);

--- a/tests/formats/dcd.cpp
+++ b/tests/formats/dcd.cpp
@@ -476,3 +476,65 @@ TEST_CASE("Append to DCD files") {
         CHECK(approx_eq(positions[2], {-3, 0, 0}, 1e-12));
     }
 }
+
+
+TEST_CASE("DCD timestep round-trip") {
+    auto cell = UnitCell({10, 12, 11}, {90, 90, 90});
+    auto make_frame = [&](double time, double step) {
+        auto frame = Frame(cell);
+        frame.add_atom(Atom("N"), {1, 2, 3});
+        frame.add_atom(Atom("B"), {0, 0, 0});
+        frame.add_atom(Atom("N"), {0, 0, 0});
+        frame.set("time", time);
+        frame.set("simulation_step", step);
+        return frame;
+    };
+
+    SECTION("dt/start/step survive write -> read") {
+        auto tmpfile = NamedTempPath(".dcd");
+
+        // mimic a typical CHARMM/NAMD output: integration timestep 15 fs
+        // (delta = 15 / 48.88821 AKMA), NSAVC = 5000, NPRIV = 5000.
+        // frame 0 is at simulation step 5000, frame 1 at 10000, etc.
+        // delta is truncated to f32 to match the header's storage precision
+        const double delta = static_cast<double>(static_cast<float>(15.0 / 48.88821));
+        const size_t nsavc = 5000;
+        const size_t npriv = 5000;
+        {
+            auto file = Trajectory(tmpfile, 'w');
+            for (size_t i = 0; i < 4; i++) {
+                double sim_step = static_cast<double>(npriv + nsavc * i);
+                file.write(make_frame(delta * sim_step, sim_step));
+            }
+        }
+
+        auto check = Trajectory(tmpfile);
+        REQUIRE(check.size() == 4);
+        for (size_t i = 0; i < 4; i++) {
+            auto frame = check.read_at(i);
+            auto sim_step = static_cast<double>(npriv + nsavc * i);
+            auto time = frame.get<Property::DOUBLE>("time");
+            auto step = frame.get<Property::DOUBLE>("simulation_step");
+            REQUIRE(time);
+            REQUIRE(step);
+            CHECK(approx_eq(*time, delta * sim_step, 1e-12));
+            CHECK(approx_eq(*step, sim_step, 1e-12));
+        }
+    }
+
+    SECTION("single-frame writes leave header unchanged") {
+        // with only one frame we cannot derive dt, so the writer should
+        // leave the header values as zero (no round-trip possible).
+        auto tmpfile = NamedTempPath(".dcd");
+
+        {
+            auto file = Trajectory(tmpfile, 'w');
+            file.write(make_frame(1234.5, 5000.0));
+        }
+
+        auto check = Trajectory(tmpfile);
+        auto frame = check.read_at(0);
+        CHECK_FALSE(frame.get("time"));
+        CHECK_FALSE(frame.get("simulation_step"));
+    }
+}


### PR DESCRIPTION
The DCD writer hardcodes `dt = 0`, `start = 0`, `step = 1` in the header, which means a write-then-read round-trip loses the integration timestep even when the source frames carry `time` and `simulation_step` properties. The TODO comment in `write_header` flagged this.

Fix the writer to derive the three fields from the `time` and `simulation_step` properties of the first two frames and seek back to patch the header at offsets 12 (NPRIV / start), 16 (NSAVC / step), and 44 (DELTA / dt). The pattern mirrors the existing back-patch of `n_frames_` at offset 8.

Also fix the reader to expose the absolute `simulation_step` as a frame property alongside `time`, matching the XTC / TRR / TNG / LAMMPS readers. Without this, a downstream writer has no way to recover the original step numbering.

When the source frames don't carry these properties, or when only one frame is written, the writer leaves the header values at zero — matching the previous behaviour.

Add a `TEST_CASE("DCD timestep round-trip")` to `tests/formats/dcd.cpp` with two sections: a positive case that writes four frames with explicit `time` / `simulation_step` and verifies the values survive a read-back, and a single-frame case that confirms the header is left untouched when `dt` cannot be derived. The byte-exact "write DCD files" test already covers the no-properties case.

Round-trip is bit-exact within DCD's f32 storage precision for `dt` (the header stores DELTA as float32, so the test computes its expected `delta` as `double(float(15 / 48.88821))` to match).

Tested end-to-end with a CHARMM-produced 266,680-frame trajectory (integration step 15 fs, NSAVC = 5000, NPRIV = 5000): every header field round-trips exactly.

Note: This change arose in the process of compressing files with mdcompress (https://github.com/refresh-bio/mdcompress), motivated by compression for uploads to MDrepo.org. This implementation was created with assistance from Claude Opus 4.7, with manual review/revision of proposed changes, and roundtrip validation in mdcompress.